### PR TITLE
Adds PKI functions to toto.utils

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -25,10 +25,10 @@ def main():
   """
   # Create keys
   print "Generate keypair for Alice..."
-  toto.util.prompt_generate_and_write_rsa_keypair("alice")
+  toto.util.generate_and_write_rsa_keypair("alice")
 
   print "Generate keypair for Bob..."
-  toto.util.prompt_generate_and_write_rsa_keypair("bob")
+  toto.util.generate_and_write_rsa_keypair("bob")
 
   alice_public = toto.util.import_rsa_key_from_file("alice.pub")
   bob_public = toto.util.import_rsa_key_from_file("bob.pub")
@@ -74,7 +74,7 @@ def main():
 
   # Sign and dump layout
   print "Load alice private key to sign layout..."
-  alice_private = toto.util.prompt_import_rsa_key_from_file("alice")
+  alice_private = toto.util.import_rsa_key_from_file("alice")
   layout.sign(alice_private)
   layout.dump()
 

--- a/demo.py
+++ b/demo.py
@@ -23,24 +23,29 @@ def main():
   # Define the supply chain
   #############################################################################
   """
+  # Create keys
+  print "Generate keypair for Alice..."
+  toto.util.prompt_generate_and_write_rsa_keypair("alice")
 
-  # Get keys
-  alice_key = toto.util.create_and_persist_or_load_key("alice")
-  bob_key = toto.util.create_and_persist_or_load_key("bob")
+  print "Generate keypair for Bob..."
+  toto.util.prompt_generate_and_write_rsa_keypair("bob")
+
+  alice_public = toto.util.import_rsa_key_from_file("alice.pub")
+  bob_public = toto.util.import_rsa_key_from_file("bob.pub")
 
   # Create Layout
-  layout = m.Layout.read({ 
+  layout = m.Layout.read({
     "_type": "layout",
     "expires": "EXPIRES",
     "keys": {
-        alice_key["keyid"]: alice_key,
-        bob_key["keyid"]: bob_key
+        alice_public["keyid"]: alice_public,
+        bob_public["keyid"]: bob_public
     },
     "steps": [{
         "name": "write-code",
         "material_matchrules": [],
         "product_matchrules": [["CREATE", "foo.py"]],
-        "pubkeys": [alice_key["keyid"]],
+        "pubkeys": [alice_public["keyid"]],
         "expected_command": "vi",
       },
       {
@@ -51,7 +56,7 @@ def main():
         "product_matchrules": [
             ["CREATE", "foo.tar.gz"],
         ],
-        "pubkeys": [bob_key["keyid"]],
+        "pubkeys": [bob_public["keyid"]],
         "expected_command": "tar zcvf foo.tar.gz foo.py",
       }],
     "inspect": [{
@@ -68,7 +73,9 @@ def main():
   })
 
   # Sign and dump layout
-  layout.sign(alice_key)
+  print "Load alice private key to sign layout..."
+  alice_private = toto.util.prompt_import_rsa_key_from_file("alice")
+  layout.sign(alice_private)
   layout.dump()
 
 

--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -175,11 +175,7 @@ def toto_run(name, materials, products, key, toto_cmd_args,
   link = toto.runlib.run_link(name, materials, products, toto_cmd_args,
         record_byproducts)
 
-  # TODO: Change key load
-  # log.doing("load key '%s'" % key)
-  key_dict = toto.util.create_and_persist_or_load_key(key)
-
   # log.doing("sign metadata '%s' with key '%s'" % (name, key))
-  link.sign(key_dict)
+  link.sign(key)
   # log.doing("store metadata '%s' to disk" % name)
   link.dump()

--- a/toto/toto-run.py
+++ b/toto/toto-run.py
@@ -85,7 +85,7 @@ def main():
   name = args.name
   materials = args.materials
   products = args.products
-  key = args.key
+  key_name = args.key
   link_cmd = args.link_cmd
   record_byproducts = args.record_byproducts
 
@@ -93,6 +93,8 @@ def main():
     materials = materials.split(",")
   if products:
     products = products.split(",")
+
+  key = toto.util.prompt_import_rsa_key_from_file(key_name)
 
   toto.runlib.toto_run(name, materials, products, key, link_cmd,
       record_byproducts)

--- a/toto/toto-verify.py
+++ b/toto/toto-verify.py
@@ -48,7 +48,9 @@ def main():  # Create new parser with custom usage message
 
   args = parser.parse_args()
 
-  retval = toto.verifylib.toto_verify(args.layout, args.layout_key)
+  layout_key = toto.util.prompt_import_rsa_key_from_file(args.layout_key)
+
+  retval = toto.verifylib.toto_verify(args.layout, layout_key)
   sys.exit(retval)
 
 if __name__ == '__main__':

--- a/toto/util.py
+++ b/toto/util.py
@@ -6,23 +6,27 @@ import getpass
 
 import toto.ssl_crypto.keys
 import toto.ssl_crypto.formats
+import toto.ssl_commons.exceptions
 import toto.log as log
 
 
-def generate_and_write_rsa_keypair(filepath, password):
+def generate_and_write_rsa_keypair(filepath, password=None):
   """
   <Purpose>
-    Generate an RSA key file, create an encrypted PEM string (using 'password'
-    as the pass phrase), and store it in 'filepath'.  The public key portion of
-    the generated RSA key is stored in <'filepath'>.pub
+    Generate an RSA key keypair and store public and private portion each
+    to a file in PEM format.
+    If a password is specified the private key is encrypted using that password
+    as pass phrase.
+    The private key is stored to <'filepath'> and the public key to
+    <'filepath'>.pub
 
   <Arguments>
     filepath:
       The public and private key files are saved to <filepath>.pub, <filepath>
       respectively
 
-    password:
-      The password used to encrypt 'filepath'
+    password: (optional)
+      If specified the password is used to encrypt the private key
 
   <Exceptions>
     ssl_commons.FormatError, if the arguments are improperly formatted
@@ -33,15 +37,18 @@ def generate_and_write_rsa_keypair(filepath, password):
   <Returns>
     None.
   """
-
   toto.ssl_crypto.formats.PATH_SCHEMA.check_match(filepath)
-  toto.ssl_crypto.formats.PASSWORD_SCHEMA.check_match(password)
 
   rsa_key = toto.ssl_crypto.keys.generate_rsa_key()
 
   public = rsa_key['keyval']['public']
   private = rsa_key['keyval']['private']
-  private_pem = toto.ssl_crypto.keys.create_rsa_encrypted_pem(private, password)
+
+  if password:
+    private_pem = toto.ssl_crypto.keys.create_rsa_encrypted_pem(private,
+        password)
+  else:
+    private_pem = private
 
   with open(filepath + '.pub', 'w') as fo_public:
     fo_public.write(public.encode('utf-8'))
@@ -53,16 +60,17 @@ def generate_and_write_rsa_keypair(filepath, password):
 def import_rsa_key_from_file(filepath, password=None):
   """
   <Purpose>
-    Import the RSA key stored in PEM format to 'filepath'. This could be
+    Import the RSA key stored in PEM format to 'filepath'. This can be
     a public key or a private key.
-    If a password is specified, the key will be decrypted
+    If it is a private key and the password is specified, it will be used
+    to decrypt the private key.
 
   <Arguments>
     filepath:
       <filepath> file, an RSA PEM file
 
-    password (optional):
-      if a password is specified, the imported key will be decrypted
+    password: (optional)
+      If a password is specified, the imported private key will be decrypted
 
   <Exceptions>
     ssl_commons.FormatError, if the arguments are improperly formatted
@@ -73,30 +81,36 @@ def import_rsa_key_from_file(filepath, password=None):
   <Returns>
     An RSA key object conformant to 'tuf.formats.RSAKEY_SCHEMA'
   """
-
   toto.ssl_crypto.formats.PATH_SCHEMA.check_match(filepath)
 
   with open(filepath, 'rb') as fo_pem:
     rsa_pem = fo_pem.read().decode('utf-8')
 
-  if password:
-    toto.ssl_crypto.formats.PASSWORD_SCHEMA.check_match(password)
-    rsa_key = toto.ssl_crypto.keys.import_rsakey_from_encrypted_pem(rsa_pem,
-        password)
-  else:
+  if toto.ssl_crypto.keys.is_pem_private(rsa_pem):
+    rsa_key = toto.ssl_crypto.keys.import_rsakey_from_pem(rsa_pem, password)
+
+  elif toto.ssl_crypto.keys.is_pem_public(rsa_pem):
     rsa_key = toto.ssl_crypto.keys.format_rsakey_from_pem(rsa_pem)
+  else:
+    raise toto.ssl_commons.exceptions.FormatError('The key has to be either'
+            'a private or public RSA key in PEM format')
 
   return rsa_key
 
 
 def prompt_password(prompt="Enter password: "):
-  """Prompts for password input and returns the password"""
+  """Prompts for password input and returns the password. """
   return getpass.getpass(prompt, sys.stderr)
 
 
 def prompt_import_rsa_key_from_file(filepath):
-  """Prompts for password and calls import_rsa_key_from_file"""
-  password = prompt_password()
+  """Trys to load the key without password. If a CryptoError occurs, prompts
+  the user for a password and trys to load the the key again. """
+  password = None
+  try:
+    import_rsa_key_from_file(filepath)
+  except toto.ssl_commons.exceptions.CryptoError, e:
+    password = prompt_password()
   return import_rsa_key_from_file(filepath, password)
 
 

--- a/toto/util.py
+++ b/toto/util.py
@@ -1,31 +1,108 @@
-"""
-    TODO: markup
-"""
 import os
 import sys
 import pickle
 import json
+import getpass
 
 import toto.ssl_crypto.keys
+import toto.ssl_crypto.formats
 import toto.log as log
 
-def create_and_persist_or_load_key(filename):
-  """Throw-away function that loads a key file or creates and
-  stores it if it does not expist.
 
-  Todo:
-      THROW AWAY!!!
+def generate_and_write_rsa_keypair(filepath, password):
+  """
+  <Purpose>
+    Generate an RSA key file, create an encrypted PEM string (using 'password'
+    as the pass phrase), and store it in 'filepath'.  The public key portion of
+    the generated RSA key is stored in <'filepath'>.pub
+
+  <Arguments>
+    filepath:
+      The public and private key files are saved to <filepath>.pub, <filepath>
+      respectively
+
+    password:
+      The password used to encrypt 'filepath'
+
+  <Exceptions>
+    ssl_commons.FormatError, if the arguments are improperly formatted
+
+  <Side Effects>
+    Writes key files to '<filepath>' and '<filepath>.pub'
+
+  <Returns>
+    None.
   """
 
-  if not os.path.isfile(filename):
-    log.warning("key '%s' was not found!" % filename)
-    log.doing("create new key '%s'" % filename)
-    key_dict = toto.ssl_crypto.keys.generate_rsa_key()
-    with open(filename, "w+") as fp:
-      key_data = toto.ssl_crypto.keys.format_keyval_to_metadata(
-          key_dict["keytype"], key_dict["keyval"], private=True)
-      fp.write(json.dumps(key_data))
-      return key_dict
+  toto.ssl_crypto.formats.PATH_SCHEMA.check_match(filepath)
+  toto.ssl_crypto.formats.PASSWORD_SCHEMA.check_match(password)
+
+  rsa_key = toto.ssl_crypto.keys.generate_rsa_key()
+
+  public = rsa_key['keyval']['public']
+  private = rsa_key['keyval']['private']
+  private_pem = toto.ssl_crypto.keys.create_rsa_encrypted_pem(private, password)
+
+  with open(filepath + '.pub', 'w') as fo_public, \
+      open(filepath, 'w') as fo_private:
+
+    fo_public.write(public.encode('utf-8'))
+    fo_private.write(private_pem.encode('utf-8'))
+
+
+def import_rsa_key_from_file(filepath, password=None):
+  """
+  <Purpose>
+    Import the RSA key stored in PEM format to 'filepath'. This could be
+    a public key or a private key.
+    If a password is specified, the key will be decrypted
+
+  <Arguments>
+    filepath:
+      <filepath> file, an RSA PEM file
+
+    password (optional):
+      if a password is specified, the imported key will be decrypted
+
+  <Exceptions>
+    ssl_commons.FormatError, if the arguments are improperly formatted
+
+  <Side Effects>
+    'filepath' is read and its contents extracted
+
+  <Returns>
+    An RSA key object conformant to 'tuf.formats.RSAKEY_SCHEMA'
+  """
+
+  toto.ssl_crypto.formats.PATH_SCHEMA.check_match(filepath)
+
+  with open(filepath, 'rb') as fo_pem:
+    rsa_pem = fo_pem.read().decode('utf-8')
+
+  if password:
+    toto.ssl_crypto.formats.PASSWORD_SCHEMA.check_match(password)
+    rsa_key = toto.ssl_crypto.keys.import_rsakey_from_encrypted_pem(rsa_pem,
+        password)
   else:
-    with open(filename, "r") as fp:
-      return toto.ssl_crypto.keys.format_metadata_to_key(json.load(fp))
+    rsa_key = toto.ssl_crypto.keys.format_rsakey_from_pem(rsa_pem)
+
+  return rsa_key
+
+
+def prompt_password(prompt="Enter password: "):
+  """Prompts for password input and returns the password"""
+  return getpass.getpass(prompt, sys.stderr)
+
+
+def prompt_import_rsa_key_from_file(filepath):
+  """Prompts for password and calls import_rsa_key_from_file"""
+  password = prompt_password()
+  return import_rsa_key_from_file(filepath, password)
+
+
+def prompt_generate_and_write_rsa_keypair(filepath):
+  """Prompts for password and generates and calls
+  generate_and_write_rsa_keypair"""
+  password = prompt_password()
+  generate_and_write_rsa_keypair(filepath, password)
+

--- a/toto/util.py
+++ b/toto/util.py
@@ -43,10 +43,10 @@ def generate_and_write_rsa_keypair(filepath, password):
   private = rsa_key['keyval']['private']
   private_pem = toto.ssl_crypto.keys.create_rsa_encrypted_pem(private, password)
 
-  with open(filepath + '.pub', 'w') as fo_public, \
-      open(filepath, 'w') as fo_private:
-
+  with open(filepath + '.pub', 'w') as fo_public:
     fo_public.write(public.encode('utf-8'))
+
+  with open(filepath, 'w') as fo_private:
     fo_private.write(private_pem.encode('utf-8'))
 
 

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -57,6 +57,7 @@ def toto_verify(layout_path, layout_key):
     log.doing("'%s' - load key '%s'" % (layout_path, layout_key))
     # FIXME: Change key load
     layout_key_dict = toto.util.create_and_persist_or_load_key(layout_key)
+
   except Exception, e:
     log.error("in load key - %s" % e)
 
@@ -67,7 +68,7 @@ def toto_verify(layout_path, layout_key):
         % (layout_path, layout_key))
 
     msg = "'%s' - verify signature" % layout_path
-    if layout.verify_signature(layout_key_dict):
+    if layout.verify_signature(layout_key):
       log.passing(msg)
     else:
       log.failing(msg)


### PR DESCRIPTION
Fixes most of https://github.com/in-toto/in-toto/issues/12
- Adds proper functions to create, encrypt, store to and read from file, and decrypt keys. Keys use RSA and PEM format 
- Adds util wrappers for above functions that additionally prompt the user for a password to decrypt the keys
- Adapts toto-run/toto-verify and demo to use these functions

*Additional notes:*
- above functions are similar to the key functions in [TUF's repository tool](https://github.com/theupdateframework/tuf/tree/develop/tuf#keys). Since TUF wants to keep them in the `repository_tool` module and we don't want to import that (it is TUF specific) we have to replicate the functionality here
- *don't allow private keys in layout (https://github.com/in-toto/in-toto/issues/12)*  will be fixed with https://github.com/in-toto/in-toto/issues/13
- better user feedback will be given with https://github.com/in-toto/in-toto/issues/6
