### PR TITLE
Libify runlib and verifylib - fixes #5

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -95,7 +95,7 @@ def main():
 
 
   write_code_cmd = "python -m toto.toto-run "\
-                   "--name write-code --products foo.py "\
+                   "--step-name write-code --products foo.py "\
                    "--key alice -- vi foo.py"
   log.doing("(Alice) - %s" % write_code_cmd)
 
@@ -103,7 +103,7 @@ def main():
   subprocess.call(write_code_cmd.split())
 
   package_cmd = "python -m toto.toto-run "\
-                "--name package --material foo.py --products foo.tar.gz "\
+                "--step-name package --material foo.py --products foo.tar.gz "\
                 "--key bob --record-byproducts -- tar zcvf foo.tar.gz foo.py"
   log.doing("(Bob) - %s" % package_cmd)
   subprocess.call(package_cmd.split())
@@ -119,7 +119,7 @@ def main():
 
   verify_cmd = "python -m toto.toto-verify "\
                "--layout root.layout "\
-               "--layout-key alice"
+               "--layout-key alice.pub"
   log.doing("(User) - %s" % verify_cmd)
   subprocess.call(verify_cmd.split())
 
@@ -132,7 +132,7 @@ def main():
   """
 
   write_code_cmd = "python -m toto.toto-run "\
-                   "--name write-code --products foo.py "\
+                   "--step-name write-code --products foo.py "\
                    "--key alice -- vi foo.py"
   log.doing("(Alice) - %s" % write_code_cmd)
   wait_for_y("Wanna drop to vi and write peachy code?")
@@ -147,7 +147,7 @@ def main():
 
 
   package_cmd = "python -m toto.toto-run "\
-                "--name package --material foo.py --products foo.tar.gz "\
+                "--step-name package --material foo.py --products foo.tar.gz "\
                 "--key bob --record-byproducts -- tar zcvf foo.tar.gz foo.py"
   log.doing("(Bob) - %s" % package_cmd)
   subprocess.call(package_cmd.split())
@@ -162,7 +162,7 @@ def main():
 
   verify_cmd = "python -m toto.toto-verify "\
                "--layout root.layout "\
-               "--layout-key alice"
+               "--layout-key alice.pub"
   log.doing("(User) - %s" % verify_cmd)
   subprocess.call(verify_cmd.split())
 

--- a/toto/models/common.py
+++ b/toto/models/common.py
@@ -66,19 +66,20 @@ class Signable(Metablock):
     signature = ssl_crypto__keys.create_signature(key, self.payload)
     self.signatures.append(signature)
 
-  def verify_signature(self, key):
-    """Verifies if the object contains a signature matching the keyid of the
-    passed key, and if the signature is valid."""
+  def verify_signatures(self, keys_dict):
+    """Verifies all signatures of the object using the passed key_dict."""
 
-    # XXX LP: Todo: Verify key format
+    if not self.signatures or len(self.signatures) <= 0:
+      raise Exception("No signatures found")
 
     for signature in self.signatures:
-      if key["keyid"] == signature["keyid"]:
-        return ssl_crypto__keys.verify_signature(key, signature,
-            self.payload)
-    else:
-      # XXX LP: Replace exception with KeyNotFound exception (or return false?)
-      raise Exception("Signature with keyid not found")
+      keyid = signature["keyid"]
+      try:
+        key = keys_dict[keyid]
+      except:
+        raise Exception("Signature key not found, key id is %s" % keyid)
+      if not ssl_crypto__keys.verify_signature(key, signature, self.payload):
+        raise Exception("Invalid signature")
 
 
 @attr.s(repr=False, cmp=False)

--- a/toto/models/layout.py
+++ b/toto/models/layout.py
@@ -35,7 +35,7 @@ import attr
 # import validators
 from . import common as models__common
 from . import matchrule as models__matchrule
-
+from . import link as models__link
 @attr.s(repr=False)
 class Layout(models__common.Signable):
   """
@@ -104,6 +104,31 @@ class Layout(models__common.Signable):
         keys=data.get("keys"), expires=data.get("expires"),
         signatures=data.get("signatures"))
 
+  def import_step_metadata_from_files_as_dict(self):
+    """
+    <Purpose>
+      Iteratively loads link metadata files for each Step of the Layout
+      from disk and returns a dict with Link names as keys and Link objects
+      as values.
+
+    <Arguments>
+      None
+
+    <Exceptions>
+      TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+    <Side Effects>
+      Calls functions to read files from disk
+
+    <Returns>
+      A dictionary with Link names as keys and Link objects as values.
+
+    """
+    step_link_dict = {}
+    for step in self.steps:
+      link = models__link.Link.read_from_file(step.name + '.link')
+      step_link_dict[step.name] = link
+    return step_link_dict
 
 @attr.s(repr=False)
 class Step(models__common.Metablock):

--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -27,8 +27,6 @@
 import sys
 import os
 import tempfile
-import logging
-
 
 # POSIX users (Linux, BSD, etc.) are strongly encouraged to
 # install and use the much more recent subprocess32
@@ -42,53 +40,63 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
   import subprocess
 
-# XXX LP: I think we'll get rid of toto formats because we want to use
-# model validators instead for toto schemas, we'll still use
-# toto.ssl_crypto.formats though
-
-# import toto.formats
-
 import toto.models.link
 import toto.log as log
 
 import toto.ssl_crypto.hash
 import toto.ssl_crypto.formats
 
+def _hash_artifact(filepath, hash_algorithms=['sha256']):
+  """Internal helper that takes a filename and hashes the respective file's
+  contents using the passed hash_algorithms and returns a hashdict conformant
+  with ssl_crypto.formats.HASHDICT_SCHEMA. """
+  toto.ssl_crypto.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
+  hash_dict = {}
+
+  for algorithm in hash_algorithms:
+    digest_object = toto.ssl_crypto.hash.digest_filename(filepath, algorithm)
+    hash_dict.update({algorithm: digest_object.hexdigest()})
+
+  toto.ssl_crypto.formats.HASHDICT_SCHEMA.check_match(hash_dict)
+
+  return hash_dict
+
+
+def _normalize_path(path):
+  """Internal helper that strips "./" on the left side of the path. """
+  if path.startswith("./"):
+      return path[2:]
+  return path
+
 
 def record_artifacts_as_dict(artifacts):
-  """Takes a list of directories and/or filenames as input and creates a dict
-  with filepaths as keys and their files' hashes as values.
+  """
+  <Purpose>
+    Hashes each file in the passed path list. If the path list contains
+    paths to directories the directory tree(s) are traversed.
 
-  The dirs/files a link command is executed on are called materials.
-  The dirs/files that result form a link command execution are called
-  products."""
+    The files a link command is executed on are called materials.
+    The files that result form a link command execution are called
+    products.
 
+  <Arguments>
+    artifacts:
+            A list of file or directory paths used as materials or products for
+            the link command.
+
+  <Exceptions>
+    TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+  <Side Effects>
+    Calls functions to generate cryptographic hashes.
+
+  <Returns>
+    A dictionary with file paths as keys and the files' hashes as values.
+  """
   artifacts_dict = {}
 
   if not artifacts:
     return artifacts_dict
-
-  def _hash_artifact(filepath, hash_algorithms=['sha256']):
-    """Takes a filename and hashes the respective file's contents
-    using the passed hash_algorithms. Returns a HASHDICT"""
-
-    toto.ssl_crypto.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
-    hash_dict = {}
-
-    for algorithm in hash_algorithms:
-      digest_object = toto.ssl_crypto.hash.digest_filename(filepath, algorithm)
-      hash_dict.update({algorithm: digest_object.hexdigest()})
-
-    toto.ssl_crypto.formats.HASHDICT_SCHEMA.check_match(hash_dict)
-
-    return hash_dict
-
-  def _normalize_path(path):
-    """Strips "./" on the left side of the path"""
-
-    if path.startswith("./"):
-        return path[2:]
-    return path  # or whatever
 
   for artifact in artifacts:
     if os.path.isfile(artifact):
@@ -103,11 +111,35 @@ def record_artifacts_as_dict(artifacts):
 
 
 def execute_link(link_cmd_args, record_byproducts):
-  """Takes a command and its options and arguments of the software supply
-  chain as input, runs the command in a subprocess, records stdout,
-  stderr and return value of the command and returns them. Stdout and stderr
-  are called by-products."""
+  """
+  <Purpose>
+    Executes the passed command plus arguments in a subprocess and returns
+    the return value of the executed command. If the specified standard output
+    and standard error of the command are recorded and also returned to the
+    caller.
 
+  <Arguments>
+    link_cmd_args:
+            A list where the first element is a command and the remaining
+            elements are arguments passed to that command.
+    record_byproducts:
+            A bool that specifies whether to redirect standard output and
+            and standard error to a temporary file which is returned to the
+            caller (True) or not (False).
+
+  <Exceptions>
+    TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+  <Side Effects>
+    Executes passed command in a subprocess and redirects stdout and stderr
+    if specified.
+
+  <Returns>
+    - A dictionary containg standard output and standard error of the
+      executed command, called by-products.
+      Note: If record_byproducts is False, the dict values are empty strings.
+    - The return value of the executed command.
+  """
   # XXX: The first approach only redirects the stdout/stderr to a tempfile
   # but we actually want to duplicate it, ideas
   #  - Using a pipe won't work because processes like vi will complain
@@ -139,51 +171,96 @@ def execute_link(link_cmd_args, record_byproducts):
 
   return {"stdout": stdout_str, "stderr": stderr_str}, return_value
 
-def create_link_metadata(name, materials, products, byproducts,
-    command, return_value):
-  """Takes the state of the materials (before link command execution), the state
-  of the products (after link command execution) and the by-products of the link
-  command execution and creates and returns a Link metadata object """
+def create_link_metadata(link_name, materials_dict, products_dict,
+    link_cmd_args, byproducts, return_value):
+  """
+  <Purpose>
+    Takes the state of the materials (before link command execution), the state
+    of the products (after link command execution) and the by-products and
+    return value of the link command execution and creates and returns a
+    Link metadata object.
 
+  <Arguments>
+    link_name:
+            A unique name to relate link metadata with a step defined in the
+            layout.
+    materials_dict:
+            A dictionary with file paths as keys and the files' hashes as
+            values.
+    products_dict:
+            A dictionary with file paths as keys and the files' hashes as
+            values.
+    link_cmd_args:
+            A list where the first element is a command and the remaining
+            elements are arguments passed to that command.
+    byproducts:
+            A dictionary in the format containing standard output and standard
+            error of the executed link command, i.e.:
+            {"stdout": "<standard output", "stderr": "<standard error>"}
+    return_value:
+            The return value of the executed command.
+
+  <Exceptions>
+    TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+  <Side Effects>
+    Creates a Link object from a Python dictionary.
+
+  <Returns>
+    - A Link metadata object
+  """
   link_dict = {
-    "name" : name,
-    "materials" : materials,
-    "products" : products,
+    "name" : link_name,
+    "materials" : materials_dict,
+    "products" : products_dict,
+    "command" : link_cmd_args,
     "byproducts" : byproducts,
-    "command" : command,
     "return_value" : return_value
   }
-
   return  toto.models.link.Link.read(link_dict)
 
 
-def run_link(name, materials, products, toto_cmd_args, record_byproducts=False):
-  """Performs all actions associated with toto run-link.
-  XXX LP: This should probably be atomic, i.e. all or nothing"""
-
-  # log.doing("record materials for '%s'" % name)
-  materials_dict = record_artifacts_as_dict(materials)
-
-  # log.doing("run command '%s' for '%s'" % (toto_cmd_args, name))
-  byproducts, return_value = execute_link(toto_cmd_args, record_byproducts)
-
-  # log.doing("record products for '%s'" % name)
-  products_dict = record_artifacts_as_dict(products)
-
-  # log.doing("create metadata for '%s'" % name)
-  link = create_link_metadata(name, materials_dict, products_dict, byproducts,
-    toto_cmd_args, return_value)
-
-  return link
-
-def toto_run(name, materials, products, key, toto_cmd_args,
+def run_link(link_name, materials_list, products_list, link_cmd_args,
     record_byproducts=False):
-  """Calls run link signs the resulting link metadata and stores it to a file """
+  """
+  <Purpose>
+    Wrapper to record materials, execute a link, record products and create
+    and return a Link metadata object.
 
-  link = toto.runlib.run_link(name, materials, products, toto_cmd_args,
-        record_byproducts)
+  <Arguments>
+    link_name:
+            A unique name to relate link metadata with a step defined in the
+            layout.
+    materials_list:
+            A list of file or directory paths used as materials for
+            the link command.
+    products_list:
+            A list of file or directory paths used as materials for
+            the link command.
+    link_cmd_args:
+            A list where the first element is a command and the remaining
+            elements are arguments passed to that command.
+    record_byproducts:
+            A bool that specifies whether to redirect standard output and
+            and standard error to a temporary file which is returned to the
+            caller (True) or not (False).
 
-  # log.doing("sign metadata '%s' with key '%s'" % (name, key))
-  link.sign(key)
-  # log.doing("store metadata '%s' to disk" % name)
-  link.dump()
+  <Exceptions>
+    TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+  <Side Effects>
+    - Calls function to record materials.
+    - Calls function to execute link command.
+    - Calls function to record products.
+    - Calls function to create Link object.
+
+  <Returns>
+    A Link metadata object
+  """
+  materials_dict = record_artifacts_as_dict(materials_list)
+  byproducts, return_value = execute_link(link_cmd_args, record_byproducts)
+  products_dict = record_artifacts_as_dict(products_list)
+  return create_link_metadata(link_name, materials_dict, products_dict,
+      link_cmd_args, byproducts, return_value)
+
+

--- a/toto/util.py
+++ b/toto/util.py
@@ -97,6 +97,15 @@ def import_rsa_key_from_file(filepath, password=None):
 
   return rsa_key
 
+def import_rsa_public_keys_from_files_as_dict(filepaths):
+  """Takes a list of filepaths to RSA public keys and returns them as a
+  dictionary conformant with ssl_crypto.formats.KEYDICT_SCHEMA."""
+  key_dict = {}
+  for filepath in filepaths:
+    key = import_rsa_key_from_file(filepath)
+    keyid = key['keyid']
+    key_dict[keyid] = key
+  return key_dict
 
 def prompt_password(prompt="Enter password: "):
   """Prompts for password input and returns the password. """


### PR DESCRIPTION
- Changes runlib and verifylib to provide logically separated units of functionality that are called from the command line interfaces toto-run and toto-verify respectively.
- The libraries, in case something goes wrong, solely raise exceptions, whereas the user interfaces catch those exceptions and give proper user feedback (stdout/stderr and return values).
- Enhances the docstrings above all in the interface functions

Other changes
- Adds utility function to load publickeys from files into a keydict
- Adds Layout method to load link metadata files into a linkdict 
- Changes verify_signature function to only pass if all signatures verify
- Changes toto-run.py --name option to --step-name
