### PR TITLE
Adds default expiration and verification (fix #7)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -36,7 +36,7 @@ def main():
   # Create Layout
   layout = m.Layout.read({
     "_type": "layout",
-    "expires": "EXPIRES",
+    "expires": "",
     "keys": {
         alice_public["keyid"]: alice_public,
         bob_public["keyid"]: bob_public

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 sphinx
 simple-settings
+python-dateutil
+iso8601

--- a/toto/models/layout.py
+++ b/toto/models/layout.py
@@ -31,6 +31,8 @@
 
 import json
 import attr
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 # import validators
 from . import common as models__common
@@ -100,8 +102,13 @@ class Layout(models__common.Signable):
     for inspect_data in data.get("inspect"):
       tmp_inspect.append(Inspection.read(inspect_data))
 
+    expires = data.get("expires")
+    if not expires:
+      # Set a month from now with Zulu offset as expiration date default
+      expires = (datetime.today() + relativedelta(months=1)).isoformat() + 'Z'
+
     return Layout(steps=tmp_steps, inspect=tmp_inspect,
-        keys=data.get("keys"), expires=data.get("expires"),
+        keys=data.get("keys"), expires=expires,
         signatures=data.get("signatures"))
 
   def import_step_metadata_from_files_as_dict(self):

--- a/toto/toto-verify.py
+++ b/toto/toto-verify.py
@@ -26,7 +26,6 @@
 """
 import sys
 import argparse
-
 import toto.util
 import toto.verifylib
 import toto.log as log
@@ -45,6 +44,12 @@ def in_toto_verify(layout_path, layout_key_paths):
     layout = Layout.read_from_file(layout_path)
   except Exception, e:
     _die("in load layout - %s" % e)
+
+  try:
+    log.doing("verify layout expiration")
+    toto.verifylib.verify_layout_expiration(layout)
+  except Exception, e:
+    _die("in verify layout expiration - %s" % e)
 
   try:
     log.doing("load layout keys...")

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -27,6 +27,9 @@
 """
 
 import sys
+import datetime
+import iso8601
+from dateutil import tz
 
 import toto.util
 import toto.runlib
@@ -69,6 +72,30 @@ def run_all_inspections(layout):
         inspection.run.split())
     inspection_links_dict[inspection.name] = link
   return inspection_links_dict
+
+def verify_layout_expiration(layout):
+  """
+  <Purpose>
+    Raises an exception if the passed layout has expired, i.e. if its
+    "expire" property is lesser "now".
+    Time zone aware datetime objects in UTC+00:00 (Zulu Time) are used.
+
+  <Arguments>
+    layout:
+            The Layout object to be verified.
+
+  <Exceptions>
+    TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+  <Side Effects>
+    None
+
+  """
+  expire_datetime = iso8601.parse_date(layout.expires)
+  if expire_datetime < datetime.datetime.now(tz.tzutc()):
+    # raise LayoutExpiredError
+    raise Exception("Layout expired")
+
 
 def verify_layout_signatures(layout, keys_dict):
   """


### PR DESCRIPTION
Fixes https://github.com/in-toto/in-toto/issues/7
- If no expiration date is specified a default expiration
  -- one month from now in UTC+00:00 (Zulu time) --
  is set in the Layout's read method
- Adds layout expiration verification method in verifylib
- Calls layout expiration verification in in-toto-verify
- Removes "EXPIRES" string from demo layout (creates a default now)
- Adds new third party requirements: python-dateutil, iso8601
