### PR TITLE
Adds subprocess fallback for POSIX users

### DIFF
--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -27,11 +27,18 @@
 import sys
 import os
 import tempfile
+import logging
+
 
 # POSIX users (Linux, BSD, etc.) are strongly encouraged to
 # install and use the much more recent subprocess32
 if os.name == 'posix' and sys.version_info[0] < 3:
-  import subprocess32 as subprocess
+  try:
+    import subprocess32 as subprocess
+  except Exception, e:
+    logging.warning("POSIX users (Linux, BSD, etc.) are strongly encouraged to"
+        + " install and use the much more recent subprocess32")
+    import subprocess
 else:
   import subprocess
 

--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -37,7 +37,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
     import subprocess32 as subprocess
   except Exception, e:
     logging.warning("POSIX users (Linux, BSD, etc.) are strongly encouraged to"
-        + " install and use the much more recent subprocess32")
+        " install and use the much more recent subprocess32")
     import subprocess
 else:
   import subprocess


### PR DESCRIPTION
Since we only encourage POSIX systems to use subprocess32 we add a fallback to subprocess if the import fails and output a warning.
