### PR TITLE
ENH:toto-run:handle multiple products and materials

### DIFF
--- a/toto/toto-run.py
+++ b/toto/toto-run.py
@@ -93,8 +93,8 @@ def main():
   parser = argparse.ArgumentParser(
       description="Executes link command and records metadata",
       usage="toto-verify.py --step-name <unique step name>\n" +
-            "                     [--materials <filepath>[,<filepath> ...]]\n" +
-            "                     [--products <filepath>[,<filepath> ...]]\n" +
+            "                     [--materials <filepath>[ <filepath> ...]]\n" +
+            "                     [--products <filepath>[ <filepath> ...]]\n" +
             "                      --key <functionary private key path>\n" +
             "                     [--record-byproducts]\n" +
             "                      -- <cmd> [args]")
@@ -108,9 +108,9 @@ def main():
 
   # XXX LP: We should allow path wildcards here and sanitze them
   toto_args.add_argument("-m", "--materials", type=str, required=False,
-      help="Files to record before link command execution")
+      nargs='+', help="Files to record before link command execution")
   toto_args.add_argument("-p", "--products", type=str, required=False,
-      help="Files to record after link command execution")
+      nargs='+', help="Files to record after link command execution")
 
   # XXX LP: Specifiy a format or choice of formats to use
   toto_args.add_argument("-k", "--key", type=str, required=True,
@@ -132,9 +132,9 @@ def main():
   product_list = []
 
   if args.materials:
-    material_list = args.materials.split(",")
+    material_list = args.materials
   if args.products:
-    product_list = args.products.split(",")
+    product_list = args.products
 
   in_toto_run(args.step_name, args.key, material_list, product_list,
       args.link_cmd, args.record_byproducts)

--- a/toto/toto-run.py
+++ b/toto/toto-run.py
@@ -92,7 +92,7 @@ def in_toto_run(step_name, key_path, material_list, product_list,
 def main():
   parser = argparse.ArgumentParser(
       description="Executes link command and records metadata",
-      usage="toto-verify.py --step-name <unique step name>\n" +
+      usage="toto-run.py --step-name <unique step name>\n" +
             "                     [--materials <filepath>[ <filepath> ...]]\n" +
             "                     [--products <filepath>[ <filepath> ...]]\n" +
             "                      --key <functionary private key path>\n" +

--- a/toto/toto-run.py
+++ b/toto/toto-run.py
@@ -106,7 +106,6 @@ def main():
   toto_args.add_argument("-n", "--step-name", type=str, required=True,
       help="Unique name for link metadata")
 
-  # XXX LP: We should allow path wildcards here and sanitze them
   toto_args.add_argument("-m", "--materials", type=str, required=False,
       nargs='+', help="Files to record before link command execution")
   toto_args.add_argument("-p", "--products", type=str, required=False,
@@ -128,15 +127,7 @@ def main():
 
   args = parser.parse_args()
 
-  material_list = []
-  product_list = []
-
-  if args.materials:
-    material_list = args.materials
-  if args.products:
-    product_list = args.products
-
-  in_toto_run(args.step_name, args.key, material_list, product_list,
+  in_toto_run(args.step_name, args.key, args.materials, args.products,
       args.link_cmd, args.record_byproducts)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the argparse calls so that the --materials and --products
flags can recieve multiple paths as arguments without the need of quotes
or commas.