### PR TITLE
Adds basic exceptions module

### DIFF
--- a/toto/exceptions.py
+++ b/toto/exceptions.py
@@ -1,0 +1,7 @@
+from toto.ssl_commons.exceptions import Error
+
+
+class RuleVerficationFailed(Error):
+  """Indicates that a match rule verification failed. """
+  pass
+


### PR DESCRIPTION
Adds basic in-toto exceptions module, which inherits from `ssl_commons.exceptions`.
For the time being it implements one Exception class `RuleVerificationFailed` used for matchrule verification.

This module will be updated with https://github.com/in-toto/in-toto/issues/6.