### PR TITLE
Matchrules: path expansion + verification changes + unittests

### DIFF
--- a/demo/owner_alice/create_layout.py
+++ b/demo/owner_alice/create_layout.py
@@ -36,10 +36,22 @@ def main():
     "inspect": [{
         "name": "untar",
         "material_matchrules": [
-            ["MATCH", "PRODUCT", "foo.tar.gz", "FROM", "package"]
+            ["MATCH", "PRODUCT", "foo.tar.gz", "FROM", "package"],
+            # FIXME: Without the "allow everything else" rule here
+            # inspection would fail because of the metadata and other files
+            # (.DS_STORE, layout key, ...) in the directory where the Inspection
+            # is executed, which get recorded as materials.
+            # The behavior is actually wanted in order to prevent sneaking
+            # files. But we do have to think of a way to ignore
+            # irrelevant files.
+            ["CREATE", "*"],
         ],
         "product_matchrules": [
-            ["MATCH", "PRODUCT", "foo.py", "FROM", "write-code"],
+            ["MATCH", "PRODUCT", "foo.py", "AS", "foo.py",
+                "FROM", "write-code"],
+            # FIXME: See material_matchrules above
+            ["CREATE", "*"],
+
         ],
         "run": "tar xfz foo.tar.gz",
       }],

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -111,7 +111,7 @@ def main():
   parser = argparse.ArgumentParser()
   parser.add_argument("-n", "--no-prompt", help="No prompt.",
       action="store_true")
-  parser.add_argument("-c", "--clear", help="Clear created files.",
+  parser.add_argument("-c", "--clean", help="Remove files created during demo.",
       action="store_true")
   args = parser.parse_args()
 

--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -38,7 +38,7 @@ def supply_chain():
   prompt_key("Package (Carl)")
   os.chdir("../functionary_carl")
   package_cmd = ("python -m toto.toto-run" +
-                 " --step-name package --material foo.py" +
+                 " --step-name package --materials foo.py" +
                  " --products foo.tar.gz" +
                  " --key carl --record-byproducts" +
                  " -- tar zcvf foo.tar.gz foo.py")
@@ -79,7 +79,7 @@ def supply_chain():
   prompt_key("Package (Carl)")
   os.chdir("../functionary_carl")
   package_cmd = ("python -m toto.toto-run" +
-                 " --step-name package --material foo.py" +
+                 " --step-name package --materials foo.py" +
                  " --products foo.tar.gz" +
                  " --key carl --record-byproducts" +
                  " -- tar zcvf foo.tar.gz foo.py")
@@ -101,6 +101,7 @@ def supply_chain():
   verify_cmd = ("python -m toto.toto-verify" +
                 " --layout root.layout" +
                 " --layout-key alice.pub")
+
   print verify_cmd
   retval = subprocess.call(verify_cmd.split())
   print "Return value: " + str(retval)
@@ -108,12 +109,37 @@ def supply_chain():
 
 def main():
   parser = argparse.ArgumentParser()
-  parser.add_argument("-n", "--no-prompt", help="No prompt",
+  parser.add_argument("-n", "--no-prompt", help="No prompt.",
+      action="store_true")
+  parser.add_argument("-c", "--clear", help="Clear created files.",
       action="store_true")
   args = parser.parse_args()
+
+  if args.clear:
+    files_to_delete = [
+      "owner_alice/root.layout",
+      "functionary_bob/write-code.link",
+      "functionary_bob/foo.py",
+      "functionary_carl/package.link",
+      "functionary_carl/foo.tar.gz",
+      "functionary_carl/foo.py",
+      "final_product/alice.pub",
+      "final_product/foo.py",
+      "final_product/foo.tar.gz",
+      "final_product/package.link",
+      "final_product/write-code.link",
+      "final_product/root.layout"
+    ]
+
+    for path in files_to_delete:
+      if os.path.isfile(path):
+        os.remove(path)
+
+    sys.exit(0)
   if args.no_prompt:
     global NO_PROMPT
     NO_PROMPT = True
+
 
   supply_chain()
 

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_verifylib.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Nov 07, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test verifylib functions.
+
+"""
+
+import unittest
+from toto.models.link import Link
+from toto.verifylib import verify_delete_rule, verify_create_rule, \
+    verify_match_rule
+from toto.exceptions import RuleVerficationFailed
+
+class TestVerifyDeleteRule(unittest.TestCase):
+  """Test verifylib.verify_delete_rule function. """
+
+  def setUp(self):
+    """ Setup artifact queues. """
+    self.artifact_queue = ["foo"]
+    self.artifact_queue_empty = []
+
+
+  def test_fail_delete_file(self):
+    """["DELETE", "foo"], matches foo (not deleted), fails. """
+
+    rule = ["DELETE", "foo"]
+    with self.assertRaises(RuleVerficationFailed):
+      verify_delete_rule(rule, self.artifact_queue)
+
+
+  def test_fail_delete_star(self):
+    """["DELETE", "*"], matches * in non-empty queue (not deleted), fails. """
+
+    rule = ["DELETE", "*"]
+    with self.assertRaises(RuleVerficationFailed):
+        verify_delete_rule(rule, self.artifact_queue)
+
+
+  def test_pass_delete_file(self):
+    """["DELETE", "bar"] does not match bar (deleted), passes. """
+
+    rule = ["DELETE", "bar"]
+    self.assertIsNone(
+        verify_delete_rule(rule, self.artifact_queue))
+
+
+  def test_pass_delete_star(self):
+    """["DELETE", "*"], does not match * in empty queue (deleted), passes. """
+
+    rule = ["DELETE", "*"]
+    self.assertIsNone(
+        verify_delete_rule(rule, self.artifact_queue_empty))
+
+
+  def test_pass_ignore_case_keyword(self):
+    """["delete", "bar"], ["DELETE", "bar"], ignores keyword case, passes. """
+
+    rule1 = ["delete", "bar"]
+    rule2 = ["DELETE", "bar"]
+    self.assertIsNone(
+        verify_delete_rule(rule1, self.artifact_queue))
+    self.assertIsNone(
+        verify_delete_rule(rule2, self.artifact_queue))
+
+
+
+
+
+class TestVerifyCreateRule(unittest.TestCase):
+  """Test verifylib.verify_create_rule function. """
+
+  def setUp(self):
+    """ Setup artifact queues. """
+    self.artifact_queue = ["foo"]
+    self.artifact_queue_foostar = ["foo", "bar", "foobar"]
+    self.artifact_queue_empty = []
+
+  def test_fail_create_file(self):
+    """["CREATE", "bar"], does not mach bar (not created), fails. """
+
+    rule = ["CREATE", "bar"]
+    with self.assertRaises(RuleVerficationFailed):
+      verify_create_rule(rule, self.artifact_queue)
+
+
+  def test_fail_create_star(self):
+    """["CREATE", "*"], does not match * (nothing created), fails. """
+
+    rule = ["CREATE", "*"]
+    with self.assertRaises(RuleVerficationFailed):
+        verify_create_rule(rule, self.artifact_queue_empty)
+
+
+  def test_pass_create_file(self):
+    """["CREATE", "foo"], matches foo (created), passes. """
+
+    rule = ["CREATE", "foo"]
+    self.assertListEqual(
+      verify_create_rule(rule, self.artifact_queue), [])
+
+
+  def test_pass_create_star(self):
+    """["CREATE", "*"], matches * in non-empty queue (created), passes. """
+
+    rule = ["CREATE", "*"]
+    self.assertListEqual(
+        verify_create_rule(rule, self.artifact_queue), [])
+
+
+  def test_remove_foostar_from_artifact_queue(self):
+    """["CREATE", "foo*"], matches foo* (created), passes. """
+
+    rule = ["CREATE", "foo*"]
+    self.assertListEqual(
+        verify_create_rule(rule, self.artifact_queue_foostar), ["bar"])
+
+
+  def test_pass_ignore_case_keyword(self):
+    """["create", "bar"], ["CREATE", "bar"], ignores keyword case, passes. """
+
+    rule1 = ["create", "foo"]
+    rule2 = ["CREATE", "foo"]
+    self.assertListEqual(
+        verify_create_rule(rule1, self.artifact_queue), [])
+    self.assertListEqual(
+        verify_create_rule(rule2, self.artifact_queue), [])
+
+
+
+
+
+class TestVerifyMatchRule(unittest.TestCase):
+  """Test verifylib.verify_match_rule function. """
+
+  def setUp(self):
+    """Setup artifact queues, artifacts dictionary and Link dictionary. """
+
+    # Dummy artifact hashes
+    self.sha256_foo = \
+        "d65165279105ca6773180500688df4bdc69a2c7b771752f0a46ef120b7fd8ec3"
+    self.sha256_foobar = \
+        "155c693a6b7481f48626ebfc545f05236df679f0099225d6d0bc472e6dd21155"
+    self.sha256_bar = \
+        "cfdaaf1ab2e4661952a9dec5e8fa3c360c1b06b1a073e8493a7c46d2af8c504b"
+    self.sha256_barfoo = \
+        "2036784917e49b7685c7c17e03ddcae4a063979aa296ee5090b5bb8f8aeafc5d"
+
+    # Link dictionary containing dummy artifacts related to Steps the rule is
+    # matched with (match target).
+    materials = {
+      "foo": {"sha256": self.sha256_foo},
+      "foobar": {"sha256": self.sha256_foobar}
+    }
+    products = {
+      "bar": {"sha256": self.sha256_bar},
+      "barfoo": {"sha256": self.sha256_barfoo}
+      }
+
+    # Note: For simplicity the Links don't have all usually required fields set
+    self.links = {
+        "link-1" : Link(name="link-1", materials=materials, products=products),
+    }
+
+
+  def test_pass_match_material(self):
+    """["MATCH", "MATERIAL", "foo", "FROM", "link-1"],
+    source artifact foo and target material foo hashes match, passes. """
+
+    rule = ["MATCH", "MATERIAL", "foo", "FROM", "link-1"]
+    artifacts = {
+      "foo": {"sha256": self.sha256_foo}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_product(self):
+    """["MATCH", "PRODUCT", "bar", "FROM", "link-1"],
+    source artifact bar and target product bar hashes match, passes. """
+
+    rule = ["MATCH", "PRODUCT", "bar", "FROM", "link-1"]
+    artifacts = {
+      "bar": {"sha256": self.sha256_bar}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_material_as_name(self):
+    """["MATCH", "MATERIAL", "dist/foo", "AS", "foo", "FROM", "link-1"],
+    source artifact dist/foo and target material foo hashes match, passes. """
+
+    rule = ["MATCH", "MATERIAL", "dist/foo", "AS", "foo", "FROM", "link-1"]
+    artifacts = {
+      "dist/foo": {"sha256": self.sha256_foo}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_product_as_name(self):
+    """["MATCH", "PRODUCT", "dist/bar", "AS", "bar", "FROM", "link-1"],
+    source artifact dist/bar and target product bar hahes match, passes. """
+
+    rule = ["MATCH", "PRODUCT", "dist/bar", "AS", "bar", "FROM", "link-1"]
+    artifacts = {
+      "dist/bar": {"sha256": self.sha256_bar}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_material_star(self):
+    """["MATCH", "MATERIAL", "foo*", "FROM", "link-1"],
+    source artifacts foo* match target materials foo* hashes, passes. """
+
+    rule = ["MATCH", "MATERIAL", "foo*", "FROM", "link-1"]
+    artifacts = {
+      "foo": {"sha256": self.sha256_foo},
+      "foobar": {"sha256": self.sha256_foobar}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_product_star(self):
+    """["MATCH", "PRODUCT", "bar*", "FROM", "link-1"],
+    source artifacts bar* match target products bar* hashes, passes. """
+
+    rule = ["MATCH", "PRODUCT", "bar*", "FROM", "link-1"]
+    artifacts = {
+      "bar": {"sha256": self.sha256_bar},
+      "barfoo": {"sha256": self.sha256_barfoo}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_material_as_star(self):
+    """["MATCH", "MATERIAL", "dist/*", "AS", "foo*", "FROM", "link-1"],
+    source artifacts dist/* match target materials foo* hashes, passes. """
+
+    rule = ["MATCH", "MATERIAL", "dist/*", "AS", "foo*", "FROM", "link-1"]
+    artifacts = {
+      "dist/foo": {"sha256": self.sha256_foo},
+      "dist/foobar": {"sha256": self.sha256_foobar}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_pass_match_product_as_star(self):
+    """["MATCH", "PRODUCT", "dist/*", "AS", "bar*", "FROM", "link-1"],
+    source artifacts dist/* match target products bar* hashes, passes. """
+
+    rule = ["MATCH", "PRODUCT", "dist/*", "AS", "bar*", "FROM", "link-1"]
+    artifacts = {
+      "dist/bar": {"sha256": self.sha256_bar},
+      "dist/barfoo": {"sha256": self.sha256_barfoo}
+    }
+    queue = artifacts.keys()
+    self.assertListEqual(
+        verify_match_rule(rule, queue, artifacts, self.links), [])
+
+
+  def test_fail_pattern_matched_nothing_in_target_materials(self):
+    """["MATCH", "MATERIAL", "bar", "FROM", "link-1"],
+    pattern bar does not match any materials in target, fails. """
+
+    rule = ["MATCH", "MATERIAL", "bar", "FROM", "link-1"]
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, [], [], self.links)
+
+
+  def test_fail_pattern_matched_nothing_in_target_products(self):
+    """["MATCH", "PRODUCT", "foo", "FROM", "link-1"],
+    pattern foo does not match any products in target, fails. """
+
+    rule = ["MATCH", "PRODUCT", "foo", "FROM", "link-1"]
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, [], [], self.links)
+
+
+  def test_fail_target_hash_not_found_in_source_artifacts(self):
+    """["MATCH", "MATERIAL", "foo", "FROM", "link-1"],
+    no source artifact matches target material's hash, fails. """
+
+    rule = ["MATCH", "MATERIAL", "foo", "FROM", "link-1"]
+    artifacts = {
+      "bar": {"sha256": self.sha256_bar},
+    }
+    queue = artifacts.keys()
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, queue, artifacts, self.links)
+
+
+  def test_fail_hash_not_found_in_artifacts_queue(self):
+    """["MATCH", "MATERIAL", "foo", "FROM", "link-1"],
+    no source artifact still in queue matches target material's hash, fails. """
+
+    rule = ["MATCH", "MATERIAL", "foo", "FROM", "link-1"]
+    artifacts = {
+      "foo": {"sha256": self.sha256_foo},
+    }
+    queue = []
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, queue, artifacts, self.links)
+
+
+  def test_fail_hash_matched_but_wrong_name(self):
+    """["MATCH", "MATERIAL", "foo", "FROM", "link-1"],
+    no source artifact matches target material's hash and path pattern, fails. """
+
+    rule = ["MATCH", "MATERIAL", "dist/foo", "AS", "foo", "FROM", "link-1"]
+    artifacts = {
+      "foo": {"sha256": self.sha256_foo},
+    }
+    queue = artifacts.keys()
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, queue, artifacts, self.links)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/toto/toto-verify.py
+++ b/toto/toto-verify.py
@@ -90,8 +90,7 @@ def in_toto_verify(layout_path, layout_key_paths):
 
   try:
     log.doing("verify all step matchrules...")
-    toto.verifylib.verify_all_item_rules(layout.steps, step_link_dict,
-        step_link_dict)
+    toto.verifylib.verify_all_item_rules(layout.steps, step_link_dict)
   except Exception, e:
     _die("in verify all step matchrules - %s" % e)
 

--- a/toto/util.py
+++ b/toto/util.py
@@ -129,3 +129,45 @@ def prompt_generate_and_write_rsa_keypair(filepath):
   password = prompt_password()
   generate_and_write_rsa_keypair(filepath, password)
 
+
+def flatten_and_invert_artifact_dict(artifact_dict, hash_algorithm="sha256"):
+  """
+  <Purpose>
+    Flattens an and inverts artifact_dict in the format of:
+    { <path> : HASHDICT_SCHEMA }.
+
+    >>> artifacts = {
+    >>> "foo": {
+    >>>   "sha512" : "23432df87ab",
+    >>>   "sha256" : "34324abc34df",
+    >>>   }
+    >>> }
+    >>> flat_artifacts = flatten_and_invert_artifact_dict(artifacts)
+    >>> flat_artifacts == {"34324abc34df" : "foo"}
+    True
+
+  <Arguments>
+    artifact_dict:
+      The artifact_dict to flatten and invert.
+
+    hash_algorithm: (optional)
+      Use the hash generated with the specified hash_algorithm.
+
+  <Exceptions>
+    ssl_commons.FormatError, if the arguments are improperly formatted
+
+  <Side Effects>
+    None.
+
+  <Returns>
+    A dictionary with artifact hashes as keys and artifact paths as values.
+  """
+  toto.ssl_crypto.formats.HASHALGORITHMS_SCHEMA.check_match([hash_algorithm])
+
+  inverted_dict = {}
+  for file_path, hash_dict in artifact_dict.iteritems():
+    toto.ssl_crypto.formats.HASHDICT_SCHEMA.check_match(hash_dict)
+    file_hash = hash_dict[hash_algorithm]
+    inverted_dict[file_hash] = file_path
+
+  return inverted_dict

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -409,7 +409,6 @@ def verify_create_rule(rule, artifact_queue):
   # FIXME: Validate rule format
   path_pattern = rule[1]
   matched_artifacts = fnmatch.filter(artifact_queue, path_pattern)
-
   if not matched_artifacts:
     raise RuleVerficationFailed("Rule {0} failed, no artifacts were created"
         .format(rule))
@@ -568,10 +567,10 @@ def verify_item_rules(item_name, rules, artifacts, links):
   #FIXME: Validate rule format
   for rule in rules:
     if rule[0].lower() == "match":
-      queue = verify_match_rule(rule, artifact_queue, artifacts, links)
+      artifact_queue = verify_match_rule(rule, artifact_queue, artifacts, links)
 
     elif rule[0].lower() == "create":
-      queue = verify_create_rule(rule, artifact_queue)
+      artifact_queue = verify_create_rule(rule, artifact_queue)
 
     elif rule[0].lower() == "delete":
       verify_delete_rule(rule, artifact_queue)
@@ -589,7 +588,7 @@ def verify_item_rules(item_name, rules, artifacts, links):
 
   if artifact_queue:
     raise RuleVerficationFailed("Artifacts {0} were not matched by any rule of "
-        "item {1}".format(artifact_queue, item_name))
+        "item '{1}'".format(artifact_queue, item_name))
 
 
 def verify_all_item_rules(items, links, target_links=None):

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -29,6 +29,7 @@
 import sys
 import datetime
 import iso8601
+import fnmatch
 from dateutil import tz
 
 import toto.util
@@ -253,41 +254,52 @@ def verify_all_steps_command_alignment(layout, links_dict):
     verify_command_alignment(command, expected_command)
 
 
-def verify_match_rule(rule, source_type, source_link, target_links):
+def verify_match_rule(rule, artifact_queue, artifacts, links):
   """
   <Purpose>
-    Verifies that the source artifact (depending on the list the rule was
-    extracted from a material or product) hash matches the target artifact
-    (depending on the 2nd element of the rule a material or product).
+    Verifies that target path pattern - 3rd or 5th element of rule - matches
+    at least one file in target artifacts. This might conflict with
+    general understanding of glob patterns (especially "*").
 
-    Also verifies:
-    That the target_link as identified by ("FROM" <step>) exists in
-    the passed target_links dictionary.
-    That the source artifact was recorded in the source and target link.
+    Further verifies that each matched target artifact has a corresponding
+    source artifact with a matching hash in the passed artifact dictionary and
+    that this artifact in also the artifact queue.
 
-    In case the ("AS", "<target_path>") part of the rule is omitted the
-    specified path (3rd element of the rule) is used for target and source.
+    This guarantees that the target artifact was reported by the target Step
+    and the step that is being verified reported to use an artifact with the
+    same hash, as required by the matchrule.
+
+  <Note>
+    In case the explicit ("AS", "<target path pattern>") part of the rule is
+    omitted the 3rd element of the rule (path pattern) is used to match
+    target and source artifacts implicitly.
 
   <Arguments>
     rule:
-          The rule to be verified. Format is one of:
-            ["MATCH", "MATERIAL", "<path>", "FROM", "<step>"]
-            ["MATCH", "PRODUCT", "<path>", "FROM", "<step>"]
-            ["MATCH", "MATERIAL", "<source_path>", "AS",
-                "<target_path>", "FROM", "<step>"]
-            ["MATCH", "PRODUCT", "<source_path>", "AS",
-                "<target_path>", "FROM", "<step>"]
+            The rule to be verified. Format is one of:
+            ["MATCH", "MATERIAL", "<path pattern>", "FROM", "<step name>"]
+            ["MATCH", "PRODUCT", "<path pattern>", "FROM", "<step name>"]
+            ["MATCH", "MATERIAL", "<path pattern>", "AS",
+                "<target path pattern>", "FROM", "<step name>"]
+            ["MATCH", "PRODUCT", "<path pattern>", "AS",
+                "<target path pattern>", "FROM", "<step name>"]
 
-    source_type:
-            A string to identify if the rule is a material matchrule or
-            product matchrule. One of "material" or "product".
+    artifact_queue:
+            A list of artifact paths that haven't been matched by a previous
+            rule yet.
 
-    source_link:
-            The Link object for an Item (Step or Inspection) that contains the
-            rules to be verified.
-            The contained materials and products are used as verification source.
+    artifacts:
+            A dictionary of artifacts, depending on the list the rule was
+            extracted from, materials or products of the step or inspection the
+            rule was extracted from.
+            The format is:
+            {
+              <path> : HASHDICTS
+            }
+             with artifact paths as keys
+            and HASHDICTS as values.
 
-    target_links:
+    links:
             A dictionary of Link objects with Link names as keys.
             The Link objects relate to Steps.
             The contained materials and products are used as verification target.
@@ -303,261 +315,305 @@ def verify_match_rule(rule, source_type, source_link, target_links):
     match.
 
   <Side Effects>
-    None.
+    Uses fnmatch.filter which translates a glob pattern to re.
+
+  <Returns>
+    The artifact queue minus the files that were matched by the rule.
 
   """
   # FIXME: Validate rule format
-
-  source_type = source_type.lower()
-  source_path = rule[2]
-  target_path = rule[4] if len(rule) == 7 else source_path
+  path_pattern = rule[2]
+  target_path_pattern = rule[4] if len(rule) == 7 else path_pattern
   target_type = rule[1].lower()
   target_name = rule[-1]
 
-  # Extract source artifacts from source link
-  if source_type == "material":
-    source_artifacts = source_link.materials
-  elif source_type == "product":
-    source_artifacts = source_link.products
-  else:
-    raise Exception("Wrong source type '%s'. Has to be 'material' or 'product'"
-        % source_type)
-
-  # Extract target artifacts from target links
+  # Extract target artifacts from links
   if target_type == "material":
-    target_artifacts = target_links[target_name].materials
+    target_artifacts = links[target_name].materials
   elif target_type == "product":
-    target_artifacts = target_links[target_name].products
+    target_artifacts = links[target_name].products
   else:
-    # Note: We should never reach this because rule format was validate before
+    # FIXME: We should never reach this because rule format was validate before
     raise Exception("Wrong target type '%s'. Has to be 'material' or 'product'"
         % source_type)
 
-  # Verify that the source artifact was recorded as material or product
-  # in the step this rule was defined for.
-  if (source_path not in source_artifacts.keys()):
-    raise RuleVerficationFailed("'%s' of link '%s' not in source %ss"
-        % (source_path, source_link.name, source_type))
+  matched_target_artifacts = fnmatch.filter(target_artifacts.keys(),
+      target_path_pattern)
 
-  # Verify that the Link metadata object which contains the material or product
-  # to match with exists.
-  if (target_name not in target_links.keys()):
-    raise RuleVerficationFailed("'%s' not in target links"
-        % target_name)
+  if not matched_target_artifacts:
+    raise RuleVerficationFailed("Rule {0} failed, path pattern '{1}' did not "
+      "match any {2}s in target link '{3}'"
+      .format(rule, target_path_pattern, target_type, target_name))
 
-  # Verify that the target Link metadata object contains the material or product
-  # to match with.
-  if (target_path not in target_artifacts.keys()):
-    raise RuleVerficationFailed("'%s' not in target %ss"
-        % (target_path, target_type))
+  inverted_artifacts = toto.util.flatten_and_invert_artifact_dict(artifacts)
 
-  # Verify that the recorded source artifact hash and the recorded target
-  # artifact hash are equal.
-  if (ComparableHashDict(source_artifacts[source_path]) != \
-      ComparableHashDict(target_artifacts[target_path])):
-    raise RuleVerficationFailed("hash of source '%s' does not match hash"
-        " of target '%s'" % (source_path, target_path))
+  # FIXME: sha256 should not be hardcoded but be a setting instead
+  hash_algorithm = "sha256"
+
+  for target_path in matched_target_artifacts:
+    match_hash = target_artifacts[target_path][hash_algorithm]
+    # Look if there is a source artifact that matches the hash
+    try:
+      source_path = inverted_artifacts[match_hash]
+    except KeyError as e:
+      raise RuleVerficationFailed("Rule {0} failed, target hash of '{1}' "
+          "could not be found in source artifacts".format(rule, target_path))
+    else:
+      # The matched source artifact's path must be in the artifact queue
+      if source_path not in artifact_queue:
+        raise RuleVerficationFailed("Rule {0} failed, target hash of '{1}' "
+            "could not be found (was matched before)".format(rule, source_path))
+
+      # and it must match with path pattern.
+      elif not fnmatch.filter([source_path], path_pattern):
+        raise RuleVerficationFailed("Rule {0} failed, target hash of '{1}' "
+          "matches hash of '{2}' in source artifacts but should match '{3}')"
+          .format(rule, target_path, source_path, path_pattern))
+
+      else:
+        artifact_queue.remove(source_path)
+
+  return artifact_queue
 
 
-def verify_create_rule(rule, link):
+def verify_create_rule(rule, artifact_queue):
   """
   <Purpose>
-    Verifies that the path (2nd element in rule list) is not found in the
-    material list but is found in the product list of the passed Link object,
-    i.e. the file was created in the step the rule was defined for.
+    Verifies that path pattern - 2nd element of rule - matches at least one
+    file in the artifact queue. This might conflict with common understanding of
+    glob patterns (especially "*").
+
+    The CREATE rule DOES NOT verify if the artifact has appeared in previous or
+    will appear in later steps of the software supply chain.
 
   <Arguments>
     rule:
-            The rule to be verified. Format is: ["CREATE", "<path>"]
+            The rule to be verified. Format is ["CREATE", "<path pattern>"]
 
-    link:
-            The Link object for the Item (Step or Inspection) that contains
-            the rule.
+    artifact_queue:
+            A list of artifact paths that were not matched by a previous rule.
 
   <Exceptions>
     raises an Exception if the rule does not conform with the rule format.
-    raises an if a matchrule does not verify.
     TBA (see https://github.com/in-toto/in-toto/issues/6)
 
-    RuleVerficationFailed if path is found in materials (was already there
-    before creation) or is not found in products (was not created).
+    RuleVerficationFailed if nothing is matched in the artifact queue.
 
   <Side Effects>
-    None.
+    Uses fnmatch.filter which translates a glob pattern to re.
+
+  <Returns>
+    The artifact queue minus the files that were matched by the rule.
 
   """
   # FIXME: Validate rule format
-  path = rule[1]
-  if (path in link.materials.keys()):
-    raise RuleVerficationFailed("'%s' "
-        "found in materials of link '%s'" % (path, link.name))
+  path_pattern = rule[1]
+  matched_artifacts = fnmatch.filter(artifact_queue, path_pattern)
 
-  if (path not in link.products.keys()):
-    raise RuleVerficationFailed("'%s' not found in products of link '%s' "
-        "- should have been created" % (path, link.name))
+  if not matched_artifacts:
+    raise RuleVerficationFailed("Rule {0} failed, no artifacts were created"
+        .format(rule))
+
+  return list(set(artifact_queue) - set(matched_artifacts))
 
 
-def verify_delete_rule(rule, link):
+def verify_delete_rule(rule, artifact_queue):
   """
   <Purpose>
-    Verifies that the path (2nd element in rule list) is found in the material
-    and not in the product list of the passed Link object, i.e. the file was
-    deleted in the step the rule was defined for.
+    Verifies that the path pattern - 2nd element of rule - does not match any
+    files in the artifact queue.
+
+    The DELETE rule DOES NOT verify if the artifact has appeared in previous or
+    will appear in later steps of the software supply chain.
 
   <Arguments>
     rule:
-            The rule to be verified. Format is: ["DELETE", "<path>"]
+            The rule to be verified. Format is ["DELETE", "<path pattern>"]
 
-    link:
-            The Link object for the Item (Step or Inspection) that contains
-            the rule.
-
-  <Exceptions>
-    raises an Exception if the rule does not conform with the rule format.
-    raises an if a matchrule does not verify.
-    TBA (see https://github.com/in-toto/in-toto/issues/6)
-
-    RuleVerficationFailed if path is not found in materials (was not there)
-    or is found in products (was not deleted).
-
-  <Side Effects>
-    None.
-
-  """
-  # FIXME: Validate rule format
-
-  path = rule[1]
-  if (path not in link.materials.keys()):
-    raise RuleVerficationFailed("'%s' "
-        "not found in materials of link '%s'" % (path, link.name))
-
-  if (path in link.products.keys()):
-    raise RuleVerficationFailed("'%s' found in products of link '%s' "
-        "- should have been deleted" % (path, link.name))
-
-
-def verify_modify_rule(rule, link):
-  """
-  <Purpose>
-    Verifies that the path (2nd element in rule list) is found in the materials
-    and products list of the passed Link object and that the hashes of the
-    according material and product are not equal, i.e. the file was modified in
-    the step the rule was defined for.
-
-  <Arguments>
-    rule:
-            The rule to be verified. Format is: ["MODIFY", "<path>"]
-
-    link:
-            The Link object for the Item (Step or Inspection) that contains
-            the rule.
+    artifact_queue:
+            A list of artifact paths that were not matched by a previous rule.
 
   <Exceptions>
     raises an Exception if the rule does not conform with the rule format.
-    raises an if a matchrule does not verify.
     TBA (see https://github.com/in-toto/in-toto/issues/6)
 
-    RuleVerficationFailed if path is not found in the materials or products
-    or if the hashes are equal (were not modified).
+    RuleVerficationFailed if path pattern matches files in artifact queue.
 
   <Side Effects>
+    Uses fnmatch.filter which translates a glob pattern to re.
+
+  <Returns>
     None.
+    In contrast to other rule types, the DELETE rule does not
+    remove matched files from the artifact queue, because it MUST not match
+    files in order to pass.
 
   """
   # FIXME: Validate rule format
-
-  path = rule[1]
-
-  if (path not in link.materials.keys()):
-    raise RuleVerficationFailed("'%s' "
-        "not found in materials of link '%s'" % (path, link.name))
-
-  if (path not in item_link.products.keys()):
-    raise RuleVerficationFailed("'%s' "
-        "not found in products of link '%s'" % (path, link.name))
-
-  if (ComparableHashDict(link.materials[path]) == \
-      ComparableHashDict(link.products[path])):
-    raise RuleVerficationFailed("hashes of product and material '%s' of link "
-        "'%s' match - should have been modified" % (path, link.name))
+  path_pattern = rule[1]
+  matched_artifacts = fnmatch.filter(artifact_queue, path_pattern)
+  if matched_artifacts:
+    raise RuleVerficationFailed("Rule {0} failed, artifacts {1} "
+        "were not deleted".format(rule, matched_artifacts))
 
 
-def _verify_rules(rules, source_type, source_link, target_links):
+# def verify_modify_rule(rule, link):
+#   """
+#   <Purpose>
+#     Verifies that the path (2nd element in rule list) is found in the materials
+#     and products list of the passed Link object and that the hashes of the
+#     according material and product are not equal, i.e. the file was modified in
+#     the step the rule was defined for.
+
+#   <Arguments>
+#     rule:
+#             The rule to be verified. Format is: ["MODIFY", "<path>"]
+
+#     link:
+#             The Link object for the Item (Step or Inspection) that contains
+#             the rule.
+
+#   <Exceptions>
+#     raises an Exception if the rule does not conform with the rule format.
+#     raises an if a matchrule does not verify.
+#     TBA (see https://github.com/in-toto/in-toto/issues/6)
+
+#     RuleVerficationFailed if path is not found in the materials or products
+#     or if the hashes are equal (were not modified).
+
+#   <Side Effects>
+#     None.
+
+#   """
+#   # FIXME: Validate rule format
+
+#   path = rule[1]
+
+#   if (path not in link.materials.keys()):
+#     raise RuleVerficationFailed("'%s' "
+#         "not found in materials of link '%s'" % (path, link.name))
+
+#   if (path not in item_link.products.keys()):
+#     raise RuleVerficationFailed("'%s' "
+#         "not found in products of link '%s'" % (path, link.name))
+
+#   if (ComparableHashDict(link.materials[path]) == \
+#       ComparableHashDict(link.products[path])):
+#     raise RuleVerficationFailed("hashes of product and material '%s' of link "
+#         "'%s' match - should have been modified" % (path, link.name))
+
+
+def verify_item_rules(item_name, rules, artifacts, links):
   """
   <Purpose>
-    Helper method to iteratively verify all rules of a type.
+    Iteratively apply passed material or product matchrules to guarantee that
+    all artifacts required by a rule are matched and that only artifacts
+    required by a rule are matched.
+
+  <Algorithm>
+      1. Create an artifact queue (a list of all file names found in artifacts)
+      2. For each rule
+        a. Artifacts matched by a rule are removed from the artifact queue
+           (see note below)
+        b. If a rule cannot match the artifacts as specified by the rule
+              raise an Exception
+        c. If the artifacts queue is not empty after verification of a rule
+              continue with the next rule and the updated artifacts queue
+           If the artifacts queue is empty
+              abort verification
+      3. After processing all rules the artifact queue must be empty, if not
+              raise an Exception
+
+  <Note>
+    Each rule will be applied on the artifacts currently in the queue, that is
+    if artifacts were already matched by a previous rule in the list they
+    cannot be matched again.
+
+    This can lead to ambiguity in case of conflicting rules, e.g. given a step
+    with a reported artifact "foo" and a rule list
+    [["CREATE", "foo"], ["DELETE", "foo"]].
+    In this case the verification would pass, because
+    verify_create_rule would remove the artifact from the artifact queue, which
+    would make "foo" appear as deleted for verify_delete_rule.
 
   <Arguments>
+    item_name:
+            The name of the item (Step or Inspection) being verified,
+            used for user feedback.
+
     rules:
-            A list containing rules defined in the material_matchrules or
-            product_matchrules field of a Step or Inspection object.
+            The list of rules (material or product matchrules) for the item
+            being verified.
 
-    source_type:
-            A string to identify if the rule is a material matchrule or
-            product matchrule. One of "material" or "product".
+    artifacts:
+            The artifact dictionary (materials or products) as reported by the
+            Link of the item being verified.
 
-    source_link:
-            The Link object for an Item (Step or Inspection) that contains the
-            rules to be verified.
-            The contained materials and products are used as verification source.
-
-    target_links:
+    links:
             A dictionary of Link objects with Link names as keys.
             The Link objects relate to Steps.
             The contained materials and products are used as verification target.
 
+
   <Exceptions>
     raises an Exception if a rule does not conform with the rule format.
-    raises an Exception if a matchrule does not verify.
     TBA (see https://github.com/in-toto/in-toto/issues/6)
 
   <Side Effects>
     None.
 
   """
+  # A list of file paths, recorded as artifacts for this item
+  artifact_queue = artifacts.keys()
+  #FIXME: Validate rule format
   for rule in rules:
-    #FIXME: Validate rule format
     if rule[0].lower() == "match":
-      verify_match_rule(rule, source_type, source_link, target_links)
+      queue = verify_match_rule(rule, artifact_queue, artifacts, links)
 
     elif rule[0].lower() == "create":
-      verify_create_rule(rule, source_link)
+      queue = verify_create_rule(rule, artifact_queue)
 
     elif rule[0].lower() == "delete":
-      verify_delete_rule(rule, source_link)
+      verify_delete_rule(rule, artifact_queue)
 
+    # FIXME: MODIFY rule needs revision
     elif rule[0].lower() == "modify":
-      verify_modify_rule(rule, source_link)
+      raise Exception("modify rule is currently not implemented.")
 
     else:
-      # Note: We should never get here since the rule format was verified before
+      # FIXME: We should never get here since the rule format was verified before
       raise Exception("Invalid Matchrule", rule)
 
+    if not artifact_queue:
+      break
+
+  if artifact_queue:
+    raise RuleVerficationFailed("Artifacts {0} were not matched by any rule of "
+        "item {1}".format(artifact_queue, item_name))
 
 
-def verify_all_item_rules(items, source_links, target_links):
+def verify_all_item_rules(items, links, target_links=None):
   """
   <Purpose>
     Iteratively verifies material matchrules and product matchrules of
     passed items (Steps or Inspections).
-    In case of MATCH matchrules an artifact from a source link is matched
-    against an artifact from a target link.
-    In case of CREATE, DELETE and MODIFY matchrules a source link material
-    is matched with a target material.
 
   <Arguments>
     items:
-            A list containing Step and/or Inspection objects
+            A list containing Step or Inspection objects whose material
+            and product matchrules will be verified.
 
-    source_links:
-            A dictionary of Link objects with Link names as keys.
-            The Link objects can relate to Steps or Inspections.
-            The contained materials and products are used as verification source.
+    links:
+            A dictionary of Link objects with Link names as keys. For each
+            passed item (Step or Inspection) to be verified, the related Link
+            object is taken from this list.
 
-    target_links:
-            A dictionary of Link objects with Link names as keys.
-            The Link objects relate to Steps.
-            The contained materials and products are used as verification target.
+    target_links: (optional)
+            A dictionary of Link objects with Link names as keys. Each Link
+            object relates to one Step of the supply chain. The artifacts of
+            these links are used as match targets for the the artifacts of the
+            items to be verified.
+            If omitted, the passed links are also used as target_links.
 
   <Exceptions>
     raises an Exception if a matchrule does not verify.
@@ -567,13 +623,15 @@ def verify_all_item_rules(items, source_links, target_links):
     None.
 
   """
-  for item in items:
-    source_link = source_links[item.name]
-    _verify_rules(item.material_matchrules, "material",
-        source_link, target_links)
+  if not target_links:
+    target_links = links
 
-    _verify_rules(item.product_matchrules, "product",
-        source_link, target_links)
+  for item in items:
+    link = links[item.name]
+    verify_item_rules(item.name, item.material_matchrules,
+        link.materials, target_links)
+    verify_item_rules(item.name, item.product_matchrules,
+        link.products, target_links)
 
 
 

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -456,52 +456,6 @@ def verify_delete_rule(rule, artifact_queue):
         "were not deleted".format(rule, matched_artifacts))
 
 
-# def verify_modify_rule(rule, link):
-#   """
-#   <Purpose>
-#     Verifies that the path (2nd element in rule list) is found in the materials
-#     and products list of the passed Link object and that the hashes of the
-#     according material and product are not equal, i.e. the file was modified in
-#     the step the rule was defined for.
-
-#   <Arguments>
-#     rule:
-#             The rule to be verified. Format is: ["MODIFY", "<path>"]
-
-#     link:
-#             The Link object for the Item (Step or Inspection) that contains
-#             the rule.
-
-#   <Exceptions>
-#     raises an Exception if the rule does not conform with the rule format.
-#     raises an if a matchrule does not verify.
-#     TBA (see https://github.com/in-toto/in-toto/issues/6)
-
-#     RuleVerficationFailed if path is not found in the materials or products
-#     or if the hashes are equal (were not modified).
-
-#   <Side Effects>
-#     None.
-
-#   """
-#   # FIXME: Validate rule format
-
-#   path = rule[1]
-
-#   if (path not in link.materials.keys()):
-#     raise RuleVerficationFailed("'%s' "
-#         "not found in materials of link '%s'" % (path, link.name))
-
-#   if (path not in item_link.products.keys()):
-#     raise RuleVerficationFailed("'%s' "
-#         "not found in products of link '%s'" % (path, link.name))
-
-#   if (ComparableHashDict(link.materials[path]) == \
-#       ComparableHashDict(link.products[path])):
-#     raise RuleVerficationFailed("hashes of product and material '%s' of link "
-#         "'%s' match - should have been modified" % (path, link.name))
-
-
 def verify_item_rules(item_name, rules, artifacts, links):
   """
   <Purpose>


### PR DESCRIPTION
 - Enables the usage of shell-style path expansion in matchrules. See Python's [`fnmatch`](https://docs.python.org/2/library/fnmatch.html) module for allowed patterns.
- Matchrules are now verified in two directions:
  - Every recorded artifact (product or material) related to an item (Step or Inspection)  must be explicitly matched by a rule - **authorize artifacts**
  - Every artifact required by a matchrule must have been recored - **enforce artifacts**
- Adds unit tests for all matchrule functions.
- Makes third argument `verify_all_item_rules` optional (see commit message of https://github.com/in-toto/in-toto/commit/213a4c5187179b31d5fb6960673f2fb425001d11).
- Slightly modifies demo script to align with matchrule verification changes. 
- Raises  `Exception("...not implemented")` when verifying a "MODIFY" rule (specs need revision here).