### PR TITLE
Update matchrules

### DIFF
--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -343,6 +343,14 @@ class TestVerifyMatchRule(unittest.TestCase):
     with self.assertRaises(RuleVerficationFailed):
       verify_match_rule(rule, queue, artifacts, self.links)
 
+  def test_fail_cannot_find_target_item(self):
+    """["MATCH", "MATERIAL", "foo", "FROM", "link-missing"],
+    no target link "link-missing" in passed target links, fails. """
+
+    rule = ["MATCH", "MATERIAL", "foo", "FROM", "link-missing"]
+    with self.assertRaises(RuleVerficationFailed):
+      verify_match_rule(rule, [], {}, self.links)
+
 
 
 
@@ -389,13 +397,19 @@ class TestVerifyNotmatchRule(unittest.TestCase):
 
 
   def test_pass_not_match_as_name(self):
-    rule = ["NOTMATCH", "PRODUCT", "bar", "AS", "bar" "FROM", "link-1"]
+    """["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"],
+    source foo has different hash then target as foo, passes. """
+
+    rule = ["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"]
     artifacts = {"bar": {"sha256": self.sha256_foo}}
     queue = artifacts.keys()
     verify_notmatch_rule(rule, queue, artifacts, self.links)
 
 
   def test_pass_not_match_as_star(self):
+    """["NOTMATCH", "PRODUCT", "*", "AS", "*" "FROM", "link-1"],
+    source bar has different hash then target bar and barfoo, passes. """
+
     rule = ["NOTMATCH", "PRODUCT", "*", "AS", "*" "FROM", "link-1"]
     artifacts = {"bar": {"sha256": self.sha256_foo}}
     queue = artifacts.keys()
@@ -403,6 +417,9 @@ class TestVerifyNotmatchRule(unittest.TestCase):
 
 
   def test_fail_match(self):
+    """["NOTMATCH", "PRODUCT", "bar", "FROM", "link-1"],
+    source and target bar have same hash, fails. """
+
     rule = ["NOTMATCH", "PRODUCT", "bar", "FROM", "link-1"]
     artifacts = {"bar": {"sha256": self.sha256_bar}}
     queue = artifacts.keys()
@@ -411,6 +428,9 @@ class TestVerifyNotmatchRule(unittest.TestCase):
 
 
   def test_fail_match_as_name(self):
+    """["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"],
+    source bar and target as bar have same hash, fails. """
+
     rule = ["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"]
     artifacts = {"bar": {"sha256": self.sha256_bar}}
     queue = artifacts.keys()
@@ -419,12 +439,14 @@ class TestVerifyNotmatchRule(unittest.TestCase):
 
 
   def test_fail_match_as_star(self):
-    rule = ["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"]
+    """["NOTMATCH", "PRODUCT", "bar", "AS", "bar", "FROM", "link-1"],
+    source bar and target a target artifact (*) have same hash, fails. """
+
+    rule = ["NOTMATCH", "PRODUCT", "bar", "AS", "*", "FROM", "link-1"]
     artifacts = {"bar": {"sha256": self.sha256_bar}}
     queue = artifacts.keys()
     with self.assertRaises(RuleVerficationFailed):
       verify_notmatch_rule(rule, queue, artifacts, self.links)
-
 
 
 

--- a/toto/util.py
+++ b/toto/util.py
@@ -146,6 +146,11 @@ def flatten_and_invert_artifact_dict(artifact_dict, hash_algorithm="sha256"):
     >>> flat_artifacts == {"34324abc34df" : "foo"}
     True
 
+  <Discussion>
+    What should we do if we face a key collision, i.e. if their are two files
+    with the same hash? Should we give a warning, should we raise an exception?
+    This is prone to happen. Think of empty files.
+
   <Arguments>
     artifact_dict:
       The artifact_dict to flatten and invert.

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -262,12 +262,13 @@ def verify_match_rule(rule, artifact_queue, artifacts, links):
     general understanding of glob patterns (especially "*").
 
     Further verifies that each matched target artifact has a corresponding
-    source artifact with a matching hash in the passed artifact dictionary and
-    that this artifact in also the artifact queue.
+    source artifact with a matching hash in the passed artifact dictionary
+    which is matched by the source path pattern - 2nd element of rule - and can
+    be found in the artifact queue.
 
-    This guarantees that the target artifact was reported by the target Step
-    and the step that is being verified reported to use an artifact with the
-    same hash, as required by the matchrule.
+    This guarantees that the target artifact was reported by the target Link
+    and the Step or Inspection that is being verified reported to use an
+    artifact with the same hash, as required by the matchrule.
 
   <Note>
     In case the explicit ("AS", "<target path pattern>") part of the rule is
@@ -277,11 +278,17 @@ def verify_match_rule(rule, artifact_queue, artifacts, links):
   <Arguments>
     rule:
             The rule to be verified. Format is one of:
-            ["MATCH", "MATERIAL", "<path pattern>", "FROM", "<step name>"]
-            ["MATCH", "PRODUCT", "<path pattern>", "FROM", "<step name>"]
-            ["MATCH", "MATERIAL", "<path pattern>", "AS",
+
+            ["MATCH", "MATERIAL", "<source and target path pattern>",
+                "FROM", "<step name>"]
+
+            ["MATCH", "PRODUCT", "<source and target pattern>",
+                "FROM", "<step name>"]
+
+            ["MATCH", "MATERIAL", "<source path pattern>", "AS",
                 "<target path pattern>", "FROM", "<step name>"]
-            ["MATCH", "PRODUCT", "<path pattern>", "AS",
+
+            ["MATCH", "PRODUCT", "<source path pattern>", "AS",
                 "<target path pattern>", "FROM", "<step name>"]
 
     artifact_queue:
@@ -296,13 +303,14 @@ def verify_match_rule(rule, artifact_queue, artifacts, links):
             {
               <path> : HASHDICTS
             }
-             with artifact paths as keys
+            with artifact paths as keys
             and HASHDICTS as values.
 
     links:
             A dictionary of Link objects with Link names as keys.
             The Link objects relate to Steps.
-            The contained materials and products are used as verification target.
+            The contained materials and products are used as verification
+            target.
 
   <Exceptions>
     raises an Exception if the rule does not conform with the rule format.

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -254,6 +254,7 @@ def verify_all_steps_command_alignment(layout, links_dict):
     verify_command_alignment(command, expected_command)
 
 
+
 def verify_match_rule(rule, artifact_queue, artifacts, links):
   """
   <Purpose>
@@ -460,22 +461,23 @@ def verify_notmatch_rule(rule, artifact_queue, artifacts, links):
 
   # FIXME: sha256 should not be hardcoded but be a setting instead
   hash_algorithm = "sha256"
-
-  matched_source_hashes = Set()
+  matched_source_hashes = set()
   for path in matched_source_artifacts:
     matched_source_hashes.add(artifacts[path][hash_algorithm])
 
-  matched_target_hashes = Set()
+  matched_target_hashes = set()
   for path in matched_target_artifacts:
     matched_target_hashes.add(target_artifacts[path][hash_algorithm])
 
-  if (matched_source_hashes & matched_target_hashes):
+
+  if matched_source_hashes & matched_target_hashes:
     raise RuleVerficationFailed("Rule {0} failed, artifacts {1} "
-              "must not match {2}s {3}  not changed."
+              "must not match {2}s {3}."
               .format(rule, matched_source_artifacts, target_type,
               matched_target_artifacts))
 
-  return artifact_queue
+
+  return list(set(artifact_queue) - set(matched_source_artifacts))
 
 
 def verify_create_rule(rule, artifact_queue):
@@ -626,7 +628,7 @@ def verify_item_rules(item_name, rules, artifacts, links):
       artifact_queue = verify_match_rule(rule, artifact_queue, artifacts, links)
 
     elif rule[0].lower() == "notmatch":
-      artifact_queue = verify_match_rule(rule, artifact_queue, artifacts, links)
+      artifact_queue = verify_notmatch_rule(rule, artifact_queue, artifacts, links)
 
     elif rule[0].lower() == "create":
       artifact_queue = verify_create_rule(rule, artifact_queue)

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -373,7 +373,7 @@ def verify_match_rule(rule, artifact_queue, artifacts, links):
             "could not be found (was matched before)".format(rule, source_path))
 
       # and it must match with path pattern.
-      elif not fnmatch.filter([source_path], path_pattern):
+      elif not fnmatch.fnmatch(source_path, path_pattern):
         raise RuleVerficationFailed("Rule {0} failed, target hash of '{1}' "
           "matches hash of '{2}' in source artifacts but should match '{3}')"
           .format(rule, target_path, source_path, path_pattern))


### PR DESCRIPTION
Adds modify rule verification back to verifylib. The rule is now called NOTMATCH and has one of the following formats.
```python
["NOTMATCH", "MATERIAL", "<source and target path pattern>", "FROM", "<step name>"]
["NOTMATCH", "PRODUCT", "<source and target path pattern>", "FROM", "<step name>"]
["NOTMATCH", "MATERIAL", "<source path pattern>", "AS", "<target path pattern>", "FROM", "<step name>"]
["NOTMATCH", "PRODUCT", "<source path pattern>", "AS", "<target path pattern>", "FROM", "<step name>"]
```
The verification itself has changed as well. Now it verifies that no file in the artifact queue matched by source path pattern has a related file in the target artifacts matched by the target artifact pattern with the same hash.