### PR TITLE
MAINT:verifylib, toto-verify: libify in_toto_verify

### DIFF
--- a/toto/toto-verify.py
+++ b/toto/toto-verify.py
@@ -29,79 +29,6 @@ import argparse
 import toto.util
 import toto.verifylib
 import toto.log as log
-from toto.models.layout import Layout
-
-def _die(msg, exitcode=1):
-  log.failing(msg)
-  sys.exit(exitcode)
-
-def in_toto_verify(layout_path, layout_key_paths):
-  """Loads layout file and layout keys from disk and performs all in-toto
-  verifications."""
-
-  try:
-    log.doing("load layout...")
-    layout = Layout.read_from_file(layout_path)
-  except Exception, e:
-    _die("in load layout - %s" % e)
-
-  try:
-    log.doing("verify layout expiration")
-    toto.verifylib.verify_layout_expiration(layout)
-  except Exception, e:
-    _die("in verify layout expiration - %s" % e)
-
-  try:
-    log.doing("load layout keys...")
-    layout_key_dict = toto.util.import_rsa_public_keys_from_files_as_dict(
-        layout_key_paths)
-  except Exception, e:
-    _die("in load layout keys - %s" % e)
-
-  try:
-    log.doing("verify layout signatures...")
-    toto.verifylib.verify_layout_signatures(layout, layout_key_dict)
-  except Exception, e:
-    _die("in verify layout signatures - %s" % e)
-
-  try:
-    log.doing("load link metadata for steps...")
-    step_link_dict = layout.import_step_metadata_from_files_as_dict()
-  except Exception, e:
-    _die("in load link metadata - %s" % e)
-
-  try:
-    log.doing("verify all step command alignments...")
-    toto.verifylib.verify_all_steps_command_alignment(layout, step_link_dict)
-  except Exception, e:
-    _die("command alignments - %s" % e)
-
-  try:
-    log.doing("verify signatures for all links...")
-    toto.verifylib.verify_all_steps_signatures(layout, step_link_dict)
-  except Exception, e:
-    _die("in verify link signatures - %s" % e)
-
-  try:
-    log.doing("run all inspections...")
-    inspection_link_dict = toto.verifylib.run_all_inspections(layout)
-  except Exception, e:
-    _die("in run inspections - %s" % e)
-
-  try:
-    log.doing("verify all step matchrules...")
-    toto.verifylib.verify_all_item_rules(layout.steps, step_link_dict)
-  except Exception, e:
-    _die("in verify all step matchrules - %s" % e)
-
-  try:
-    log.doing("verify all inspection matchrules...")
-    toto.verifylib.verify_all_item_rules(layout.inspect, inspection_link_dict,
-        step_link_dict)
-  except Exception, e:
-    _die("in verify all inspection matchrules - %s" % e)
-
-  log.passing("all verification")
 
 def main():
   parser = argparse.ArgumentParser(
@@ -120,7 +47,7 @@ def main():
   args = parser.parse_args()
 
   layout_key_paths = args.layout_keys.split(',')
-  in_toto_verify(args.layout, layout_key_paths)
+  toto.verifylib.in_toto_verify(args.layout, layout_key_paths)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Integrators of Toto may want to directly access a "seamless"
verification routine to avoid any misunderstandings on errors upon
implementation. Move "holistic" in_toto_verify function to verifylib so
integrators can use it.