### PR TITLE
FIX:.gitmodules: use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "toto/ssl_crypto"]
 	path = toto/ssl_crypto
-	url = git@github.com:/santiagotorres/ssl_crypto
+	url = https://github.com/santiagotorres/ssl_crypto


### PR DESCRIPTION
This will make the demo code work even if users do not have a github
account. It also gets rid of the 301 that may be confusing some people