### PR TITLE
Adds in_toto_record {start, stop} command + minor changes/fixes

### DIFF
--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_in_toto_record.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Nov 28, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test in_toto_record command line tool.
+
+"""
+
+import os
+import sys
+import unittest
+import logging
+import argparse
+from mock import patch
+
+from toto.util import generate_and_write_rsa_keypair
+from toto.models.link import Link
+from toto.in_toto_record import main as in_toto_record_main
+from toto.in_toto_record import in_toto_record_start, in_toto_record_stop
+
+# Suppress all the user feedback that we print using a base logger
+logging.getLogger().setLevel(logging.CRITICAL)
+
+def _try_remove_files(file_list):
+  if not isinstance(file_list, list):
+    return
+  else:
+    for path in file_list:
+      try:
+        os.remove(path)
+      except Exception, e:
+        pass
+
+
+class TestInTotoRecordMain(unittest.TestCase):
+  """Test in_toto_record's main() - requires sys.argv patching. """
+
+  @classmethod
+  def setUpClass(self):
+    """Generate key pair, dummy artifact and base arguments. """
+    generate_and_write_rsa_keypair("test-key")
+    self.args = [
+        "in_toto_record.py",
+        "--step-name",
+        "test-step",
+        "--key",
+        "test-key"
+    ]
+    self.test_artifact = "test-artifact"
+    open(self.test_artifact, "a").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Remove key pair, dummy artifact and link metadata. """
+    files_to_remove = [
+      "test-key", "test-key.pub", "test-step.link", self.test_artifact
+    ]
+    _try_remove_files(files_to_remove)
+
+
+  def test_command_start_stop_required_args(self):
+    """Test CLI command record start/stop with required arguments. """
+    with patch.object(sys, 'argv',  self.args + ["start"]):
+      in_toto_record_main()
+
+    with patch.object(sys, 'argv', self.args + ["stop"]):
+      in_toto_record_main()
+
+  def test_command_start_stop_optional_args(self):
+    """Test CLI command record start/stop with optional arguments. """
+    with patch.object(sys, 'argv', self.args + ["start", "--materials",
+        self.test_artifact]):
+      in_toto_record_main()
+
+    with patch.object(sys, 'argv', self.args + ["stop", "--products",
+        self.test_artifact]):
+      in_toto_record_main()
+
+
+
+
+
+class TestInTotoRecordStart(unittest.TestCase):
+  """"Test in_toto_record_start(step_name, key_path, material_list). """
+
+  @classmethod
+  def setUpClass(self):
+    """Generate key pair, dummy artifact and base arguments. """
+    self.step_name = "test-step"
+    self.key_path = "test-key"
+    generate_and_write_rsa_keypair(self.key_path)
+    self.test_material= "test-material"
+    open(self.test_material, "a").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Remove key pair, dummy artifact and link metadata. """
+    files_to_remove = [
+        self.key_path, self.key_path + ".pub", self.test_material,
+        "." + self.step_name + ".link-unfinished"
+      ]
+    _try_remove_files(files_to_remove)
+
+  def test_create_link_unfinished_file(self):
+    """Test record start creates a link metadata file. """
+    in_toto_record_start(self.step_name, self.key_path, [self.test_material])
+    open("." + self.step_name + ".link-unfinished", "r")
+
+  def test_record_test_material(self):
+    """Test record start records expected material. """
+    link = in_toto_record_start(
+        self.step_name, self.key_path, [self.test_material])
+    self.assertEquals(link.materials.keys(), [self.test_material])
+
+
+
+
+
+class TestInTotoRecordStop(unittest.TestCase):
+  """"Test in_toto_record_start(step_name, key_path, material_list). """
+
+  @classmethod
+  def setUpClass(self):
+    """Generate key pair, dummy artifact and base arguments. """
+    self.step_name = "test-step"
+    self.key_path = "test-key"
+    self.key_path2 = "test-key2"
+    generate_and_write_rsa_keypair(self.key_path)
+    generate_and_write_rsa_keypair(self.key_path)
+
+    self.test_product = "test-product"
+    open(self.test_product, "a").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Remove key pair, dummy artifact and link metadata. """
+    files_to_remove = [
+      self.key_path, self.key_path + ".pub", self.key_path2,
+      self.key_path2 + ".pub", self.test_product, self.step_name + ".link",
+      "." + self.step_name + ".link-unfinished"
+    ]
+    _try_remove_files(files_to_remove)
+
+  def test_record_test_product(self):
+    """Test record stop records expected product. """
+    in_toto_record_start(self.step_name, self.key_path, [])
+    link = in_toto_record_stop(
+        self.step_name, self.key_path, [self.test_product])
+    self.assertEquals(link.products.keys(), [self.test_product])
+
+  def test_replace_unfinished_file(self):
+    """Test record stop removes unfinished file. """
+    in_toto_record_start(self.step_name, self.key_path, [])
+    in_toto_record_stop(self.step_name, self.key_path, [])
+    with self.assertRaises(IOError):
+      open("." + self.step_name + ".link-unfinished", "r")
+    open(self.step_name + ".link", "r")
+
+  def test_missing_unfinished_file(self):
+    """Test record stop exits on missing unfinished file. """
+    with self.assertRaises(SystemExit):
+      in_toto_record_stop(self.step_name, self.key_path, [])
+
+  def test_wrong_signature_in_unfinished_file(self):
+    """Test record stop exits on wrong signature. """
+    in_toto_record_start(self.step_name, self.key_path, [])
+    with self.assertRaises(SystemExit):
+      in_toto_record_stop(self.step_name, self.key_path2, [])
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -27,7 +27,8 @@ import shutil
 import tempfile
 from mock import patch
 
-from toto.util import generate_and_write_rsa_keypair
+from toto.util import generate_and_write_rsa_keypair, \
+    prompt_import_rsa_key_from_file
 from toto.models.link import Link
 from toto.in_toto_record import main as in_toto_record_main
 from toto.in_toto_record import in_toto_record_start, in_toto_record_stop
@@ -37,8 +38,10 @@ WORKING_DIR = os.getcwd()
 # Suppress all the user feedback that we print using a base logger
 logging.getLogger().setLevel(logging.CRITICAL)
 
-class TestInTotoRecordMain(unittest.TestCase):
-  """Test in_toto_record's main() - requires sys.argv patching. """
+class TestInTotoRecordTool(unittest.TestCase):
+  """Test in_toto_record's main() - requires sys.argv patching; and
+  in_toto_record_start/in_toto_record_stop - calls runlib and error logs/exits
+  on Exception. """
 
   @classmethod
   def setUpClass(self):
@@ -47,139 +50,95 @@ class TestInTotoRecordMain(unittest.TestCase):
     self.test_dir = tempfile.mkdtemp()
     os.chdir(self.test_dir)
 
-    self.test_key = "test_key"
-    generate_and_write_rsa_keypair(self.test_key)
+    self.key_path = "test_key"
+    generate_and_write_rsa_keypair(self.key_path)
+    self.key = prompt_import_rsa_key_from_file(self.key_path)
 
     self.test_artifact = "test_artifact"
     open(self.test_artifact, "w").close()
 
-    self.args = [
-        "in_toto_record.py",
-        "--step-name",
-        "test-step",
-        "--key",
-        self.test_key
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(WORKING_DIR)
+    shutil.rmtree(self.test_dir)
+
+  def test_main_required_args(self):
+    """Test CLI command record start/stop with required arguments. """
+    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
+        self.key_path]
+    with patch.object(sys, 'argv', args + ["start"]):
+      in_toto_record_main()
+    with patch.object(sys, 'argv', args + ["stop"]):
+      in_toto_record_main()
+
+  def test_main_optional_args(self):
+    """Test CLI command record start/stop with optional arguments. """
+    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
+        self.key_path]
+    with patch.object(sys, 'argv', args + ["start", "--materials",
+        self.test_artifact]):
+      in_toto_record_main()
+    with patch.object(sys, 'argv', args + ["stop", "--products",
+        self.test_artifact]):
+      in_toto_record_main()
+
+  def test_main_wrong_args(self):
+    """Test CLI command record start/stop with missing arguments. """
+
+    wrong_args_list = [
+      ["in_toto_record.py"],
+      ["in_toto_record.py", "--step-name", "some"],
+      ["in_toto_record.py", "--key", self.key_path],
+      ["in_toto_record.py", "--step-name", "test-step", "--key",
+        self.key_path, "start", "--products"],
+      ["in_toto_record.py", "--step-name", "test-step", "--key",
+        self.key_path, "stop", "--materials"]
     ]
 
-  @classmethod
-  def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
-    shutil.rmtree(self.test_dir)
+    for wrong_args in wrong_args_list:
+      with patch.object(sys, 'argv',
+          wrong_args), self.assertRaises(SystemExit):
+        in_toto_record_main()
 
-  def test_command_start_stop_required_args(self):
-    """Test CLI command record start/stop with required arguments. """
-    with patch.object(sys, 'argv',  self.args + ["start"]):
+  def test_main_wrong_key_exits(self):
+    """Test CLI command record with wrong key exits and logs error """
+    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
+        "non-existing-key", "start"]
+    with patch.object(sys, 'argv',
+        args), self.assertRaises(
+        SystemExit):
       in_toto_record_main()
 
-    with patch.object(sys, 'argv', self.args + ["stop"]):
+  def test_main_verbose(self):
+    """Log level with verbose flag is lesser/equal than logging.INFO. """
+    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
+        self.key_path, "--verbose"]
+
+    original_log_level = logging.getLogger().getEffectiveLevel()
+    with patch.object(sys, 'argv', args + ["start"]):
       in_toto_record_main()
-
-  def test_command_start_stop_optional_args(self):
-    """Test CLI command record start/stop with optional arguments. """
-    with patch.object(sys, 'argv', self.args + ["start", "--materials",
-        self.test_artifact]):
+    with patch.object(sys, 'argv', args + ["stop"]):
       in_toto_record_main()
+    self.assertLessEqual(logging.getLogger().getEffectiveLevel(), logging.INFO)
+    # Reset log level
+    logging.getLogger().setLevel(original_log_level)
 
-    with patch.object(sys, 'argv', self.args + ["stop", "--products",
-        self.test_artifact]):
-      in_toto_record_main()
+  def test_in_toto_record_start_stop(self):
+    """in_toto_record_start/stop run through. """
+    in_toto_record_start("test-step", self.key, self.test_artifact)
+    in_toto_record_stop("test-step", self.key, self.test_artifact)
 
-
-class TestInTotoRecordStart(unittest.TestCase):
-  """"Test in_toto_record_start(step_name, key_path, material_list). """
-
-  @classmethod
-  def setUpClass(self):
-    """Create and change into temporary directory, generate key pair and dummy
-    material. """
-    self.test_dir = tempfile.mkdtemp()
-    os.chdir(self.test_dir)
-
-    self.step_name = "test-step"
-    self.link_name_unfinished = ".{}.link-unfinished".format(self.step_name)
-
-    self.key_path = "test_key"
-    generate_and_write_rsa_keypair(self.key_path)
-
-    self.test_material= "test_material"
-    open(self.test_material, "w").close()
-
-  @classmethod
-  def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
-    shutil.rmtree(self.test_dir)
-
-  def test_create_link_unfinished_file(self):
-    """Test record start creates a link metadata file. """
-    in_toto_record_start(self.step_name, self.key_path, [self.test_material])
-    open(self.link_name_unfinished)
-
-  def test_record_test_material(self):
-    """Test record start records expected material. """
-    in_toto_record_start(
-        self.step_name, self.key_path, [self.test_material])
-    link = Link.read_from_file(self.link_name_unfinished)
-    self.assertEquals(link.materials.keys(), [self.test_material])
-
-
-class TestInTotoRecordStop(unittest.TestCase):
-  """"Test in_toto_record_stop(step_name, key_path, product_list). """
-
-  @classmethod
-  def setUpClass(self):
-    """Create and change into temporary directory, generate two key pairs
-    and dummy product. """
-    self.test_dir = tempfile.mkdtemp()
-    os.chdir(self.test_dir)
-
-    self.step_name = "test-step"
-    self.link_name = "{}.link".format(self.step_name)
-    self.link_name_unfinished = ".{}.link-unfinished".format(self.step_name)
-
-    self.key_path = "test-key"
-    self.key_path2 = "test-key2"
-    generate_and_write_rsa_keypair(self.key_path)
-    generate_and_write_rsa_keypair(self.key_path2)
-
-    self.test_product = "test_product"
-    open(self.test_product, "w").close()
-
-  @classmethod
-  def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
-    shutil.rmtree(self.test_dir)
-
-  def test_record_test_product(self):
-    """Test record stop records expected product. """
-    in_toto_record_start(self.step_name, self.key_path, [])
-    in_toto_record_stop(
-        self.step_name, self.key_path, [self.test_product])
-    link = Link.read_from_file(self.link_name)
-    self.assertEquals(link.products.keys(), [self.test_product])
-
-  def test_replace_unfinished_file(self):
-    """Test record stop removes unfinished file. """
-    in_toto_record_start(self.step_name, self.key_path, [])
-    in_toto_record_stop(self.step_name, self.key_path, [])
-    with self.assertRaises(IOError):
-      open(self.link_name_unfinished, "r")
-    open(self.link_name, "r")
-
-  def test_missing_unfinished_file(self):
-    """Test record stop exits on missing unfinished file. """
+  def test_in_toto_record_start_bad_key_error_exit(self):
+    """Error exit in_toto_record_start with bad key. """
     with self.assertRaises(SystemExit):
-      in_toto_record_stop(self.step_name, self.key_path, [])
+      in_toto_record_start("test-step", "bad-key", self.test_artifact)
 
-  def test_wrong_signature_in_unfinished_file(self):
-    """Test record stop exits on wrong signature. """
-    in_toto_record_start(self.step_name, self.key_path, [])
+  def test_in_toto_record_stop_missing_unfinished_link_exit(self):
+    """Error exit in_toto_record_stop with missing unfinished link file. """
     with self.assertRaises(SystemExit):
-      in_toto_record_stop(self.step_name, self.key_path2, [])
-
+      in_toto_record_stop("test-step", self.key, self.test_artifact)
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -1,17 +1,160 @@
 #!/usr/bin/env python
 
 """
-    TODO: this
+<Program Name>
+  test_runlib.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Dec 01, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test runlib functions.
+
 """
 
+import os
 import unittest
+import shutil
+import tempfile
+from toto.runlib import in_toto_record_start, in_toto_record_stop, \
+    UNFINISHED_FILENAME_FORMAT
+from toto.util import generate_and_write_rsa_keypair, \
+    prompt_import_rsa_key_from_file
+from toto.models.link import Link
+from toto.exceptions import SignatureVerificationError
 
-class TestRunlib(unittest.TestCase):
 
-  @unittest.skip("Missing test implementation")
-  def test_unimplemented(self):
-    raise self.assertFalse("Missing test implementation!")
+WORKING_DIR = os.getcwd()
 
-# Run unit test.
+
+class TestInTotoRecordStart(unittest.TestCase):
+  """"Test in_toto_record_start(step_name, key, material_list). """
+
+  @classmethod
+  def setUpClass(self):
+    """Create and change into temporary directory, generate key pair and dummy
+    material, read key pai. """
+    self.test_dir = tempfile.mkdtemp()
+    os.chdir(self.test_dir)
+
+    self.step_name = "test_step"
+    self.link_name_unfinished = UNFINISHED_FILENAME_FORMAT.format(
+        step_name=self.step_name)
+
+    self.key_path = "test_key"
+    generate_and_write_rsa_keypair(self.key_path)
+    self.key = prompt_import_rsa_key_from_file(self.key_path)
+
+    self.test_material= "test_material"
+    open(self.test_material, "w").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(WORKING_DIR)
+    shutil.rmtree(self.test_dir)
+
+  def test_unfinished_filename_format(self):
+    """Test if the unfinished filname format. """
+    self.assertTrue(self.link_name_unfinished ==
+        ".{}.link-unfinished".format(self.step_name))
+
+  def test_create_unfinished_metadata_with_expected_material(self):
+    """Test record start creates metadata with expected material. """
+    in_toto_record_start(
+        self.step_name, self.key, [self.test_material])
+    link = Link.read_from_file(self.link_name_unfinished)
+    self.assertEquals(link.materials.keys(), [self.test_material])
+    os.remove(self.link_name_unfinished)
+
+  def test_create_unfininished_metadata_verify_signature(self):
+    """Test record start creates metadata with expected signature. """
+    in_toto_record_start(
+        self.step_name, self.key, [self.test_material])
+    link = Link.read_from_file(self.link_name_unfinished)
+    link.verify_signatures({self.key["keyid"] : self.key})
+    os.remove(self.link_name_unfinished)
+
+
+class TestInTotoRecordStop(unittest.TestCase):
+  """"Test in_toto_record_stop(step_name, key, product_list). """
+
+  @classmethod
+  def setUpClass(self):
+    """Create and change into temporary directory, generate two key pairs
+    and dummy product. """
+    self.test_dir = tempfile.mkdtemp()
+    os.chdir(self.test_dir)
+
+    self.step_name = "test-step"
+    self.link_name = "{}.link".format(self.step_name)
+    self.link_name_unfinished = UNFINISHED_FILENAME_FORMAT.format(
+        step_name=self.step_name)
+
+    self.key_path = "test-key"
+    self.key_path2 = "test-key2"
+    generate_and_write_rsa_keypair(self.key_path)
+    generate_and_write_rsa_keypair(self.key_path2)
+    self.key = prompt_import_rsa_key_from_file(self.key_path)
+    self.key2 = prompt_import_rsa_key_from_file(self.key_path2)
+
+    self.test_product = "test_product"
+    open(self.test_product, "w").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(WORKING_DIR)
+    shutil.rmtree(self.test_dir)
+
+  def test_create_metadata_with_expected_product(self):
+    """Test record stop records expected product. """
+    in_toto_record_start(self.step_name, self.key, [])
+    in_toto_record_stop(
+        self.step_name, self.key, [self.test_product])
+    link = Link.read_from_file(self.link_name)
+    self.assertEquals(link.products.keys(), [self.test_product])
+    os.remove(self.link_name)
+
+  def test_create_metadata_verify_signature(self):
+    """Test record start creates metadata with expected signature. """
+    in_toto_record_start(self.step_name, self.key, [])
+    in_toto_record_stop(
+        self.step_name, self.key, [])
+    link = Link.read_from_file(self.link_name)
+    link.verify_signatures({self.key["keyid"] : self.key})
+    os.remove(self.link_name)
+
+  def test_replace_unfinished_metadata(self):
+    """Test record stop removes unfinished file and creates link file. """
+    in_toto_record_start(self.step_name, self.key, [])
+    in_toto_record_stop(self.step_name, self.key, [])
+    with self.assertRaises(IOError):
+      open(self.link_name_unfinished, "r")
+    open(self.link_name, "r")
+    os.remove(self.link_name)
+
+  def test_missing_unfinished_file(self):
+    """Test record stop exits on missing unfinished file, no link recorded. """
+    with self.assertRaises(IOError):
+      in_toto_record_stop(self.step_name, self.key, [])
+    with self.assertRaises(IOError):
+      open(self.link_name, "r")
+
+  def test_wrong_signature_in_unfinished_metadata(self):
+    """Test record stop exits on wrong signature, no link recorded. """
+    in_toto_record_start(self.step_name, self.key, [])
+    with self.assertRaises(SignatureVerificationError):
+      in_toto_record_stop(self.step_name, self.key2, [])
+    with self.assertRaises(IOError):
+      open(self.link_name, "r")
+    os.remove(self.link_name_unfinished)
+
 if __name__ == '__main__':
   unittest.main()

--- a/toto/in_toto_record.py
+++ b/toto/in_toto_record.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  in_toto_record.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Nov 28, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides a command line interface to start and stop in-toto link metadata
+  recording.
+
+  start
+    Takes a step name, a functionary's signing key and optional
+    material paths.
+    Creates a temporary link file containing the file hashes of the passed
+    materials and signs it with the functionary's key under
+    .<step name>.link-unfinished
+
+  stop
+    Takes a step name, a functionary's signing key and optional
+    product paths.
+    Expects a .<step name>.link-unfinished in the current directory signed by
+    the functionary's signing key, adds the file hashes of the passed products,
+    updates the signature and renames the file  .<step name>.link-unfinished
+    to <step name>.link
+
+
+  The implementation of the tasks can be found in runlib.
+
+  Example Usage
+  ```
+  in-toto-run.py start --step-name edit-files --materials . --key bob
+  # Edit files manually ...
+  in-toto-run.py stop --step-name edit-files --products . --key bob
+  ```
+
+"""
+import os
+import sys
+import argparse
+import toto.util
+from toto import runlib
+from toto import log
+from toto.models.link import Link
+
+
+def in_toto_record_start(step_name, key_path, material_list):
+  """
+  <Purpose>
+    Starts creating link metadata for a multi-part in-toto step. I.e.
+    loads link signing private key from disk, records passed materials, creates
+    link meta data object from it, signs it with loaded key and stores it to
+    disk as ".<step_name>.link-unfinished".
+
+  <Arguments>
+    step_name:
+            A unique name to relate link metadata with a step defined in the
+            layout.
+    key_path:
+            Path to private key to sign link metadata (PEM).
+    material_list:
+            List of file or directory paths that should be recorded as
+            materials.
+
+  <Exceptions>
+    None.
+
+  <Side Effects>
+    Loads private key from disk
+    Creates a file with  name ".<step_name>.link-unfinished"
+    Calls sys.exit(1) if an exception is raised
+
+  <Returns>
+    Link object (unfinished)
+
+  """
+
+  unfinished_fn = "." + str(step_name) + ".link-unfinished"
+
+  try:
+    log.doing("Start recording '{0}'...".format(step_name))
+    key = toto.util.prompt_import_rsa_key_from_file(key_path)
+
+    log.doing("record materials...")
+    materials_dict = runlib.record_artifacts_as_dict(material_list)
+
+    log.doing("create preliminary link metadata...")
+    link = runlib.create_link_metadata(step_name, materials_dict)
+
+    log.doing("sign metadata...")
+    link.sign(key)
+
+    log.doing("store metadata to '{0}'...".format(unfinished_fn))
+    link.dump(unfinished_fn)
+
+    return link
+
+  except Exception, e:
+    log.error("in start record - %s" % e)
+    sys.exit(1)
+
+def in_toto_record_stop(step_name, key_path, product_list):
+  """
+  <Purpose>
+    Finishes creating link metadata for a multi-part in-toto step.
+    Loads signing key and unfinished link metadata file from disk, verifies
+    that the file was signed with the key, records products, updates unfinished
+    Link object (products and signature), removes unfinished link file from and
+    stores new link file to disk.
+
+  <Arguments>
+    step_name:
+            A unique name to relate link metadata with a step defined in the
+            layout.
+    key_path:
+            Path to private key to verify unfinished link metadata and
+            sign finished link metadata (PEM).
+    product_list:
+            List of file or directory paths that should be recorded as products.
+
+  <Exceptions>
+    Exception if signature fails
+    IOException if file ".<step_name>.link-unfinished" can't be read
+
+  <Side Effects>
+    Loads private key from disk
+    Writes link file to disk "<step_name>.link"
+    Remvoes unfinished link file ".<step_name>.link-unfinished" from disk
+    Calls sys.exit(1) if an exception is raised
+
+  <Returns>
+    Link object
+
+  """
+
+  unfinished_fn = "." + str(step_name) + ".link-unfinished"
+
+  try:
+    log.doing("load link signing key...")
+    key = toto.util.prompt_import_rsa_key_from_file(key_path)
+    keydict = {key["keyid"] : key}
+
+    # There must be a file .<step_name>.link-unfinished in the current dir
+    log.doing("load unfinished link file...")
+    link = Link.read_from_file(unfinished_fn)
+    # The unfinished link file must have been signed by the same key
+
+    log.doing("verify unfinished link signature...")
+    link.verify_signatures(keydict)
+
+    log.doing("record products...")
+    link.products = runlib.record_artifacts_as_dict(product_list)
+
+    log.doing("update signature...")
+    link.signatures = []
+    link.sign(key)
+
+    log.doing("store metadata to file...")
+    link.dump()
+
+    log.doing("remove unfinished file...")
+    os.remove(unfinished_fn)
+
+    return link
+
+  except Exception, e:
+    log.error("in stop record - %s" % e)
+    sys.exit(1)
+
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Starts or stops link metadata recording")
+
+  subparsers = parser.add_subparsers(dest="command")
+
+  subparser_start = subparsers.add_parser('start')
+  subparser_stop = subparsers.add_parser('stop')
+
+  # Whitespace padding to align with program name
+  lpad = (len(parser.prog) + 1) * " "
+  parser.usage = ("\n"
+      "%(prog)s  --step-name <unique step name>\n{0}"
+               " --key <functionary private key path>\n"
+      "Commands:\n{0}"
+               "start [--materials <filepath>[ <filepath> ...]]\n{0}"
+               "stop  [--products <filepath>[ <filepath> ...]]\n"
+               .format(lpad))
+
+  in_toto_args = parser.add_argument_group("Toto options")
+  # FIXME: Name has to be unique!!! Where will we check this?
+  # FIXME: Do we limit the allowed characters for the name?
+  in_toto_args.add_argument("-n", "--step-name", type=str, required=True,
+      help="Unique name for link metadata")
+
+  in_toto_args.add_argument("-k", "--key", type=str, required=True,
+      help="Path to private key to sign link metadata (PEM)")
+
+  subparser_start.add_argument("-m", "--materials", type=str, required=False,
+      nargs='+', help="Files to record before link command execution")
+
+  subparser_stop.add_argument("-p", "--products", type=str, required=False,
+      nargs='+', help="Files to record after link command execution")
+
+  args = parser.parse_args()
+
+  if args.command == "start":
+    in_toto_record_start(args.step_name, args.key, args.materials)
+  elif args.command == "stop":
+    in_toto_record_stop(args.step_name, args.key, args.products)
+
+if __name__ == '__main__':
+  main()

--- a/toto/in_toto_record.py
+++ b/toto/in_toto_record.py
@@ -36,9 +36,9 @@
 
   Example Usage
   ```
-  in-toto-run.py start --step-name edit-files --materials . --key bob
+  in_toto_record.py start --step-name edit-files --materials . --key bob
   # Edit files manually ...
-  in-toto-run.py stop --step-name edit-files --products . --key bob
+  in_toto_record.py stop --step-name edit-files --products . --key bob
   ```
 
 """

--- a/toto/in_toto_record.py
+++ b/toto/in_toto_record.py
@@ -70,7 +70,7 @@ def in_toto_record_start(step_name, key_path, material_list):
             materials.
 
   <Exceptions>
-    None.
+    SystemExit if any exception occurs
 
   <Side Effects>
     Loads private key from disk
@@ -78,11 +78,11 @@ def in_toto_record_start(step_name, key_path, material_list):
     Calls sys.exit(1) if an exception is raised
 
   <Returns>
-    Link object (unfinished)
+    None.
 
   """
 
-  unfinished_fn = "." + str(step_name) + ".link-unfinished"
+  unfinished_fn = ".{}.link-unfinished".format(step_name)
 
   try:
     log.doing("Start recording '{0}'...".format(step_name))
@@ -100,10 +100,8 @@ def in_toto_record_start(step_name, key_path, material_list):
     log.doing("store metadata to '{0}'...".format(unfinished_fn))
     link.dump(unfinished_fn)
 
-    return link
-
   except Exception, e:
-    log.error("in start record - %s" % e)
+    log.error("in start record - {}".format(e))
     sys.exit(1)
 
 def in_toto_record_stop(step_name, key_path, product_list):
@@ -126,21 +124,20 @@ def in_toto_record_stop(step_name, key_path, product_list):
             List of file or directory paths that should be recorded as products.
 
   <Exceptions>
-    Exception if signature fails
-    IOException if file ".<step_name>.link-unfinished" can't be read
+    SystemExit if any exception occurs
 
   <Side Effects>
     Loads private key from disk
     Writes link file to disk "<step_name>.link"
-    Remvoes unfinished link file ".<step_name>.link-unfinished" from disk
+    Removes unfinished link file ".<step_name>.link-unfinished" from disk
     Calls sys.exit(1) if an exception is raised
 
   <Returns>
-    Link object
+    None.
 
   """
 
-  unfinished_fn = "." + str(step_name) + ".link-unfinished"
+  unfinished_fn = ".{}.link-unfinished".format(step_name)
 
   try:
     log.doing("load link signing key...")
@@ -168,10 +165,8 @@ def in_toto_record_stop(step_name, key_path, product_list):
     log.doing("remove unfinished file...")
     os.remove(unfinished_fn)
 
-    return link
-
   except Exception, e:
-    log.error("in stop record - %s" % e)
+    log.error("in stop record - {}".format(e))
     sys.exit(1)
 
 
@@ -196,7 +191,6 @@ def main():
                .format(lpad))
 
   in_toto_args = parser.add_argument_group("Toto options")
-  # FIXME: Name has to be unique!!! Where will we check this?
   # FIXME: Do we limit the allowed characters for the name?
   in_toto_args.add_argument("-n", "--step-name", type=str, required=True,
       help="Unique name for link metadata")

--- a/toto/models/common.py
+++ b/toto/models/common.py
@@ -22,8 +22,6 @@
   Signable:
       sign self, store signature to self and verify signatures
 
-  ComparableHashDict: (helper class)
-      compare contained dictionary of hashes using "=", "!="
 """
 
 import attr
@@ -74,7 +72,7 @@ class Signable(Metablock):
   """Objects with base class Signable can sign their payload (a canonical
   pretty printed JSON string not containing the signatures attribute) and store
   the signature (signature format: ssl_crypto__formats.SIGNATURE_SCHEMA) """
-  signatures = attr.ib([])
+  signatures = attr.ib(default=attr.Factory(list))
 
   @property
   def payload(self):
@@ -107,45 +105,3 @@ class Signable(Metablock):
       if not keys.verify_signature(key, signature, self.payload):
         raise SignatureVerificationError("Invalid signature")
 
-@attr.s(repr=False, cmp=False)
-class ComparableHashDict(object):
-  """Helper class providing that wraps hash dicts (format:
-  toto.ssl_crypto.formats.HASHDICT_SCHEMA) in order to compare them using
-  `=` and `!=`"""
-
-  hash_dict = attr.ib({})
-
-  def __eq__(self, other):
-    """Equal if the dicts have the same keys and the according values
-    (strings) are equal"""
-
-    if self.hash_dict.keys() != other.hash_dict.keys():
-      return False
-
-    for key in self.hash_dict.keys():
-      if self.hash_dict[key] != other.hash_dict[key]:
-        return False
-    return True
-
-  def __ne__(self, other):
-    return not self.__eq__(other)
-
-
-# @attr.s(repr=False)
-# class GenericPathList(object):
-#   """ Helper class implementing __contains__ to provide <path> in <path list>
-#   where <path> can start with "./" or not
-#   """
-#   path_list = attr.ib([])
-
-#   def __contains__(self, item):
-
-#     if item.startswith("./"):
-#       other_item = item.lstrip("./")
-#     else:
-#       other_item = "./" + item
-
-#     if item in self.path_list or \
-#         other_item in self.path_list:
-#       return True
-#     return False

--- a/toto/models/layout.py
+++ b/toto/models/layout.py
@@ -69,7 +69,7 @@ class Layout(models__common.Signable):
         a list of Inspection objects
 
     keys:
-        A dictionary of  public keys used to verify the signature of link
+        A dictionary of public keys used to verify the signature of link
         metadata file related to a step. Format is
         ssl_crypto.formats.KEYDICT_SCHEMA
 

--- a/toto/models/layout.py
+++ b/toto/models/layout.py
@@ -69,17 +69,18 @@ class Layout(models__common.Signable):
         a list of Inspection objects
 
     keys:
-        a list of public keys used to verify the signature of link
-        metadata file related to a step
+        A dictionary of  public keys used to verify the signature of link
+        metadata file related to a step. Format is
+        ssl_crypto.formats.KEYDICT_SCHEMA
 
     expires:
         the expiration date of a layout
   """
 
   _type = attr.ib("layout", init=False)
-  steps = attr.ib([])
-  inspect = attr.ib([])
-  keys = attr.ib({})
+  steps = attr.ib(default=attr.Factory(list))
+  inspect = attr.ib(default=attr.Factory(list))
+  keys = attr.ib(default=attr.Factory(dict))
   expires = attr.ib("")
 
 
@@ -226,9 +227,9 @@ class Step(models__common.Metablock):
   """
   _type = attr.ib("step", init=False)
   name = attr.ib()
-  material_matchrules = attr.ib([])
-  product_matchrules = attr.ib([])
-  pubkeys = attr.ib([])
+  material_matchrules = attr.ib(default=attr.Factory(list))
+  product_matchrules = attr.ib(default=attr.Factory(list))
+  pubkeys = attr.ib(default=attr.Factory(list))
   expected_command = attr.ib("")
 
 
@@ -305,8 +306,8 @@ class Inspection(models__common.Metablock):
 
   _type = attr.ib("inspection", init=False)
   name = attr.ib()
-  material_matchrules = attr.ib([])
-  product_matchrules = attr.ib([])
+  material_matchrules = attr.ib(default=attr.Factory(list))
+  product_matchrules = attr.ib(default=attr.Factory(list))
   run = attr.ib("")
 
 

--- a/toto/models/link.py
+++ b/toto/models/link.py
@@ -59,9 +59,9 @@ class Link(models__common.Signable):
 
   _type = attr.ib("Link", init=False)
   name = attr.ib("")
-  materials = attr.ib({})
-  products = attr.ib({})
-  byproducts = attr.ib({})
+  materials = attr.ib(default=attr.Factory(dict))
+  products = attr.ib(default=attr.Factory(dict))
+  byproducts = attr.ib(default=attr.Factory(dict))
   command = attr.ib("")
   return_value = attr.ib(None)
 

--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -177,8 +177,8 @@ def execute_link(link_cmd_args, record_byproducts):
 
   return {"stdout": stdout_str, "stderr": stderr_str}, return_value
 
-def create_link_metadata(link_name, materials_dict, products_dict,
-    link_cmd_args, byproducts, return_value):
+def create_link_metadata(link_name, materials_dict={}, products_dict={},
+    link_cmd_args="", byproducts={}, return_value=None):
   """
   <Purpose>
     Takes the state of the materials (before link command execution), the state
@@ -190,20 +190,20 @@ def create_link_metadata(link_name, materials_dict, products_dict,
     link_name:
             A unique name to relate link metadata with a step defined in the
             layout.
-    materials_dict:
+    materials_dict: (optional)
             A dictionary with file paths as keys and the files' hashes as
             values.
-    products_dict:
+    products_dict: (optional)
             A dictionary with file paths as keys and the files' hashes as
             values.
-    link_cmd_args:
+    link_cmd_args: (optional)
             A list where the first element is a command and the remaining
             elements are arguments passed to that command.
-    byproducts:
+    byproducts: (optional)
             A dictionary in the format containing standard output and standard
             error of the executed link command, i.e.:
             {"stdout": "<standard output", "stderr": "<standard error>"}
-    return_value:
+    return_value: (optional)
             The return value of the executed command.
 
   <Exceptions>
@@ -268,5 +268,4 @@ def run_link(link_name, materials_list, products_list, link_cmd_args,
   products_dict = record_artifacts_as_dict(products_list)
   return create_link_metadata(link_name, materials_dict, products_dict,
       link_cmd_args, byproducts, return_value)
-
 

--- a/toto/runlib.py
+++ b/toto/runlib.py
@@ -103,7 +103,7 @@ def record_artifacts_as_dict(artifacts):
 
     if not os.path.exists(artifact):
       log.warning("path: {} does not exist, skipping..".format(artifact))
-      continue 
+      continue
 
     if os.path.isfile(artifact):
       artifacts_dict[_normalize_path(artifact)] = _hash_artifact(artifact)

--- a/toto/toto-run.py
+++ b/toto/toto-run.py
@@ -42,67 +42,6 @@ def _die(msg, exitcode=1):
   sys.exit(exitcode)
 
 
-def in_toto_start_record(step_name, key_path, material_list):
-  """Load link signing private keys from disk, record passed materials,
-  sign with key, store to disk as:
-  .<step_name>.link-unfinished
-
-  """
-  try:
-    log.doing("Start recording '{0}'...".format(step_name))
-    key = toto.util.prompt_import_rsa_key_from_file(key_path)
-
-    log.doing("record materials...")
-    materials_dict = toto.runlib.record_artifacts_as_dict(material_list)
-
-    log.doing("create preliminary link metadata...")
-    link = toto.runlib.create_link_metadata(step_name, materials_dict)
-
-    log.doing("sign metadata...")
-    link.sign(key)
-
-    log.doing("store metadata to '.{0}.link-unfinished'...".format(step_name))
-    link.dump()
-
-  except Exception, e:
-    _die("in start record - %s" % e)
-
-
-def in_toto_stop_record(step_name, key_path, product_list):
-  """Load key, load .<step_name>.link-unfinished exists
-  if exists, verify signature, record products, sign, dump, remove
-  link-unfinished.
-
-  """
-  unfinished_fn = "." + str(step_name) + ".link-unfinished"
-  try:
-    log.doing("load link signing key...")
-    key = toto.util.prompt_import_rsa_key_from_file(key_path)
-
-    # There must be a file .<step_name>.link-unfinished in the current dir
-    log.doing("load unfinished link file...")
-    link_unfinished = Link.read_from_file(unfinished_fn)
-
-    # The file must have been signed by the same key
-    log.doing("verify unfinished link signature...")
-    link_unfinished.verify_signatures(key)
-
-    log.doing("record products...")
-    link_unfinished.products = toto.runlib.record_artifacts_as_dict(product_list)
-
-    log.doing("update signature...")
-    link_unfinished.signatures = []
-    link_unfinished.sign(key)
-
-    log.doing("store metadata to file...")
-    link.dump()
-
-    log.doing("remove unfinished file...")
-    os.remove(unfinished_fn)
-
-  except Exception, e:
-    _die("in stop record - %s" % e)
-
 def in_toto_run(step_name, key_path, material_list, product_list,
     link_cmd_args, record_byproducts=False):
   """Load link signing private keys from disk and runs passed command, storing
@@ -155,26 +94,20 @@ def in_toto_run(step_name, key_path, material_list, product_list,
 def main():
   parser = argparse.ArgumentParser(
       description="Executes link command and records metadata")
+  # Whitespace padding to align with program name
+  lpad = (len(parser.prog) + 1) * " "
+
   parser.usage = ("\n"
       "%(prog)s  --step-name <unique step name>\n{0}"
                " --key <functionary private key path>\n{0}"
                "[--materials <filepath>[ <filepath> ...]]\n{0}"
                "[--products <filepath>[ <filepath> ...]]\n{0}"
                "[--record-byproducts] -- <cmd> [args]\n\n"
-
-      "%(prog)s  --start-record --step-name <unique step name>\n{0}"
-               " --key <functionary private key path>\n{0}"
-               "[--materials <filepath>[ <filepath> ...]]\n\n"
-
-      "%(prog)s --stop-record --step-name <unique step name>\n{0}"
-               "--key <functionary private key path>\n{0}"
-               "[--materials <filepath>[ <filepath> ...]]"
-                .format((len(parser.prog) + 1) * " "))
+               .format(lpad))
 
   toto_args = parser.add_argument_group("Toto options")
   # FIXME: Name has to be unique!!! Where will we check this?
   # FIXME: Do we limit the allowed characters for the name?
-  # FIXME: Should it be possible to add a path?
   toto_args.add_argument("-n", "--step-name", type=str, required=True,
       help="Unique name for link metadata")
 
@@ -183,9 +116,8 @@ def main():
   toto_args.add_argument("-p", "--products", type=str, required=False,
       nargs='+', help="Files to record after link command execution")
 
-  # FIXME: Specifiy a format or choice of formats to use
   toto_args.add_argument("-k", "--key", type=str, required=True,
-      help="Path to private key to sign link metadata")
+      help="Path to private key to sign link metadata (PEM)")
 
   toto_args.add_argument("-b", "--record-byproducts", dest='record_byproducts',
       help="If set redirects stdout/stderr and stores to link metadata",

--- a/toto/verifylib.py
+++ b/toto/verifylib.py
@@ -38,7 +38,6 @@ import toto.models.layout
 import toto.models.link
 import toto.ssl_crypto.keys
 from toto.exceptions import RuleVerficationFailed
-from toto.models.common import ComparableHashDict
 from toto.matchrule_validators import check_matchrule_syntax
 import toto.log as log
 


### PR DESCRIPTION
In some cases it is not feasible to wrap a single command with toto-run, e.g. when allowedly editing a bunch of files shortly before building.
To not disrupt the in-toto supply chain we provide two additional cli tools that, where one only records materials to a temporary file and the second records products and finalizes the link metadata file.

- Adds new command line tool (with two sub commands) to perform a multi-part in-toto step
- Adds unittests for in_toto_record start/stop (requires `mock` package)
- Adds default values to optional parameters of runlib.create_link_metadata
- Changes `attr` class attribute defaults to use `attr.Factory` in order to circumvent strange memory re-use (see. https://github.com/in-toto/in-toto/commit/be7619173e13cbfb17093ac945a16083eb3d12db commit message for more details).
- Fixes wrong default type for `layout.keys` attributes (https://github.com/in-toto/in-toto/issues/41)
- Removes two obsolete utility classes:  
 - `GenericPathList` 
was used to *normalize* relative artifact paths at verification, which now happens at recording 
 - `ComparableHashDict`
was used to compare artifact hashes with multiple hash algorithms, deprecated by `util.flatten_and_invert_artifact_dict`