### PR TITLE
Adds setting to exclude artifacts in link metadata

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -67,13 +67,6 @@ def _hash_artifact(filepath, hash_algorithms=['sha256']):
   return hash_dict
 
 
-def _normalize_path(path):
-  """Internal helper that strips "./" on the left side of the path. """
-  if path.startswith("./"):
-      return path[2:]
-  return path
-
-
 def _apply_exclude_patterns(names, exclude_patterns):
   """Exclude matched patterns from passed names. """
 
@@ -81,6 +74,7 @@ def _apply_exclude_patterns(names, exclude_patterns):
     excludes = fnmatch.filter(names, exclude_pattern)
     names = list(set(names) - set(excludes))
   return names
+
 
 def record_artifacts_as_dict(artifacts):
   """
@@ -92,13 +86,33 @@ def record_artifacts_as_dict(artifacts):
     The files that result form a link command execution are called
     products.
 
+    Paths are normalized for matching and storing by left stripping "./"
+
     Excludes files that are matched by the file patterns specified in
     ARTIFACT_EXCLUDES setting.
-    Note: Exclude patterns are applied on the basename, i.e. the pattern
-    "foo" excludes /foo as well as /subdir/foo
 
-    Exclude patterns are likely to become command line arguments or part of
-    a config file, e.g. .in-toto-ignore
+    EXCLUDES:
+      - Uses Python fnmatch
+            *       matches everything
+            ?       matches any single character
+            [seq]   matches any character in seq
+            [!seq]  matches any character not in seq
+
+      - Patterns are checked for match against the full path relative to each
+        path passed in the artifacts list
+
+      - If a directory is excluded, all its files and subdirectories are also
+        excluded
+
+      - How it differs from .gitignore
+            - No need to escape #
+            - No ignoring of trailing spaces
+            - No general negation with exclamation mark !
+            - No special treatment of slash /
+            - No special treatment of consecutive asterisks **
+
+      - Exclude patterns are likely to become command line arguments or part of
+        a config file.
 
   <Arguments>
     artifacts:
@@ -119,8 +133,14 @@ def record_artifacts_as_dict(artifacts):
   if not artifacts:
     return artifacts_dict
 
-  # Exclude excluded files and dirs from the first level of tree traversel
-  for artifact in _apply_exclude_patterns(artifacts,
+  # Normalize passed paths
+  norm_artifacts = []
+  for path in artifacts:
+    norm_artifacts.append(os.path.normpath(path))
+
+  # Iterate over remaining normalized artifact paths after
+  # having applied exclusion patterns
+  for artifact in _apply_exclude_patterns(norm_artifacts,
         settings.ARTIFACT_EXCLUDES):
 
     if not os.path.exists(artifact):
@@ -128,19 +148,41 @@ def record_artifacts_as_dict(artifacts):
       continue
 
     if os.path.isfile(artifact):
-      artifacts_dict[_normalize_path(artifact)] = _hash_artifact(artifact)
+      # Path was already normalized above
+      artifacts_dict[artifact] = _hash_artifact(artifact)
 
     elif os.path.isdir(artifact):
       for root, dirs, files in os.walk(artifact):
-        # Also exclude excluded subdirs
-        # Modifying the dirs variable makes walk only recurse into
-        # remaining dirs
-        dirs[:] = _apply_exclude_patterns(dirs, settings.ARTIFACT_EXCLUDES)
 
-        # Finally exclude excluded tree nodes (files)
-        for name in _apply_exclude_patterns(files, settings.ARTIFACT_EXCLUDES):
-          filepath = os.path.join(root, name)
-          artifacts_dict[_normalize_path(filepath)] = _hash_artifact(filepath)
+        # Create a list of normalized dirpaths
+        dirpaths = []
+        for dirname in dirs:
+          norm_dirpath = os.path.normpath(os.path.join(root, dirname))
+          dirpaths.append(norm_dirpath)
+
+        # Apply exlcude patterns on normalized dirpaths
+        dirpaths = _apply_exclude_patterns(dirpaths, settings.ARTIFACT_EXCLUDES)
+
+        # Reset and refill dirs with remaining names after exclusion
+        # Modify (not reassign) dirnames to only recurse into remaining dirs
+        dirs[:] = []
+        for dirpath in dirpaths:
+          # Dirs only contain the basename and not the full path
+          name = os.path.basename(dirpath)
+          dirs.append(name)
+
+        # Create a list of normalized filepaths
+        filepaths = []
+        for filename in files:
+          norm_filepath = os.path.normpath(os.path.join(root, filename))
+          filepaths.append(norm_filepath)
+
+        # Apply exclude patterns on normalized filepaths and
+        # store each remaining normalized filepath with it's files hash to
+        # the resulting artifact dict
+        for filepath in _apply_exclude_patterns(filepaths,
+            settings.ARTIFACT_EXCLUDES):
+          artifacts_dict[filepath] = _hash_artifact(filepath)
 
   return artifacts_dict
 

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -66,7 +66,7 @@ ED25519_CRYPTO_LIBRARY = 'ed25519'
 GENERAL_CRYPTO_LIBRARY = 'pycrypto'
 
 # FIXME: Add as command line argument or to config file, e.g .in-toto-ignore
-ARTIFACT_EXCLUDES=["*.link*", ".git"]
+ARTIFACT_EXCLUDES=["*.link*", ".git", "*.pyc", "*~"]
 
 # Debug level INFO shows a bunch of stuff that is happening
 LOG_LEVEL = logging.INFO

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -65,6 +65,8 @@ ED25519_CRYPTO_LIBRARY = 'ed25519'
 # 'pyca-cryptography']
 GENERAL_CRYPTO_LIBRARY = 'pycrypto'
 
+# FIXME: Add as command line argument or to config file, e.g .in-toto-ignore
+ARTIFACT_EXCLUDES=["*.link*", ".git"]
 
 # Debug level INFO shows a bunch of stuff that is happening
 LOG_LEVEL = logging.INFO

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -85,6 +85,10 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
 
+  def tearDown(self):
+    """Clear the ARTIFACT_EXLCUDES after every test. """
+    settings.ARTIFACT_EXCLUDES = []
+
   def test_empty_artifacts_list_record_nothing(self):
     """Empty list passed. Return empty dict. """
     self.assertDictEqual(record_artifacts_as_dict([]), {})
@@ -120,7 +124,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
     ssl_crypto.formats.HASHDICT_SCHEMA.check_match(artifacts_dict["bar"])
     self.assertListEqual(artifacts_dict.keys(), ["bar"])
-    settings.ARTIFACT_EXCLUDES = []
 
   def test_exclude_subsubdir(self):
     """Traverse dir and subdirs. Exclude subsubdir. """
@@ -132,7 +135,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
         sorted(["foo", "bar", "subdir/foosub"]))
-    settings.ARTIFACT_EXCLUDES = []
 
 
 class TestInTotoRecordStart(unittest.TestCase):

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -77,6 +77,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     os.mkdir("subdir")
     os.mkdir("subdir/subsubdir")
     open("subdir/foosub", "w").write("foosub")
+    open("subdir/foosub2", "w").write("foosub")
     open("subdir/subsubdir/foosubsub", "w").write("foosubsub")
 
   @classmethod
@@ -105,7 +106,8 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
-      sorted(["foo", "bar", "subdir/foosub", "subdir/subsubdir/foosubsub"]))
+      sorted(["foo", "bar", "subdir/foosub", "subdir/foosub2",
+          "subdir/subsubdir/foosubsub"]))
 
   def test_record_files_and_subdirs(self):
     """Explicitly record files and subdirs. """
@@ -115,7 +117,8 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
-      sorted(["foo", "subdir/foosub", "subdir/subsubdir/foosubsub"]))
+      sorted(["foo", "subdir/foosub", "subdir/foosub2",
+          "subdir/subsubdir/foosubsub"]))
 
   def test_record_dot_exclude_foo_star_from_recording(self):
     """Traverse dir and subdirs from. Exclude pattern. Record one file. """
@@ -134,7 +137,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
-        sorted(["foo", "bar", "subdir/foosub"]))
+        sorted(["foo", "bar", "subdir/foosub", "subdir/foosub2"]))
 
 
 class TestInTotoRecordStart(unittest.TestCase):

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -33,8 +33,6 @@ from in_toto.exceptions import SignatureVerificationError
 from simple_settings import settings
 
 
-WORKING_DIR = os.getcwd()
-
 class Test_ApplyExcludePatterns(unittest.TestCase):
   """Test _apply_exclude_patterns(names, exclude_patterns) """
 
@@ -66,6 +64,8 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
   @classmethod
   def setUpClass(self):
     """Create and change into temp test directory with dummy artifacts. """
+    self.working_dir = os.getcwd()
+
     # Clear user set excludes
     settings.ARTIFACT_EXCLUDES = []
 
@@ -82,7 +82,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
   @classmethod
   def tearDownClass(self):
     """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
+    os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
 
   def test_empty_artifacts_list_record_nothing(self):
@@ -142,6 +142,8 @@ class TestInTotoRecordStart(unittest.TestCase):
   def setUpClass(self):
     """Create and change into temporary directory, generate key pair and dummy
     material, read key pair. """
+    self.working_dir = os.getcwd()
+
     self.test_dir = tempfile.mkdtemp()
     os.chdir(self.test_dir)
 
@@ -159,7 +161,7 @@ class TestInTotoRecordStart(unittest.TestCase):
   @classmethod
   def tearDownClass(self):
     """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
+    os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
 
   def test_unfinished_filename_format(self):
@@ -191,6 +193,8 @@ class TestInTotoRecordStop(unittest.TestCase):
   def setUpClass(self):
     """Create and change into temporary directory, generate two key pairs
     and dummy product. """
+    self.working_dir = os.getcwd()
+
     self.test_dir = tempfile.mkdtemp()
     os.chdir(self.test_dir)
 
@@ -212,7 +216,7 @@ class TestInTotoRecordStop(unittest.TestCase):
   @classmethod
   def tearDownClass(self):
     """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
+    os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
 
   def test_create_metadata_with_expected_product(self):

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -75,7 +75,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     open("bar", "w").write("bar")
 
     os.mkdir("subdir")
-    open("subdir/foosub", "w").write("subfoo")
+    os.mkdir("subdir/subsubdir")
+    open("subdir/foosub", "w").write("foosub")
+    open("subdir/subsubdir/foosubsub", "w").write("foosubsub")
 
   @classmethod
   def tearDownClass(self):
@@ -92,32 +94,44 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     self.assertDictEqual(record_artifacts_as_dict(["baz"]), {})
 
   def test_record_dot_check_files_hash_dict_schema(self):
-    """Traverse dir and subdir. Record three files. """
+    """Traverse dir and subdirs. Record three files. """
     artifacts_dict = record_artifacts_as_dict(["."])
 
     for key, val in artifacts_dict.iteritems():
       ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
-      sorted(["foo", "bar", "subdir/foosub"]))
+      sorted(["foo", "bar", "subdir/foosub", "subdir/subsubdir/foosubsub"]))
 
-  def test_record_files_and_subdir(self):
-    """Explicitly record files and subdir. """
+  def test_record_files_and_subdirs(self):
+    """Explicitly record files and subdirs. """
     artifacts_dict = record_artifacts_as_dict(["foo", "subdir"])
 
     for key, val in artifacts_dict.iteritems():
       ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
-      sorted(["foo", "subdir/foosub"]))
+      sorted(["foo", "subdir/foosub", "subdir/subsubdir/foosubsub"]))
 
   def test_record_dot_exclude_foo_star_from_recording(self):
-    """Traverse dir and subdir from. Exclude pattern. Record one file. """
+    """Traverse dir and subdirs from. Exclude pattern. Record one file. """
     settings.ARTIFACT_EXCLUDES = ["foo*"]
     artifacts_dict = record_artifacts_as_dict(["."])
 
     ssl_crypto.formats.HASHDICT_SCHEMA.check_match(artifacts_dict["bar"])
     self.assertListEqual(artifacts_dict.keys(), ["bar"])
+    settings.ARTIFACT_EXCLUDES = []
+
+  def test_exclude_subsubdir(self):
+    """Traverse dir and subdirs. Exclude subsubdir. """
+    settings.ARTIFACT_EXCLUDES = ["subsubdir"]
+    artifacts_dict = record_artifacts_as_dict(["."])
+
+    for key, val in artifacts_dict.iteritems():
+      ssl_crypto.formats.HASHDICT_SCHEMA.check_match(val)
+
+    self.assertListEqual(sorted(artifacts_dict.keys()),
+        sorted(["foo", "bar", "subdir/foosub"]))
     settings.ARTIFACT_EXCLUDES = []
 
 


### PR DESCRIPTION
- Adds routine to exclude files, matched by defined patterns (uses fnmatch), when recording artifacts (materials or products) upon in-toto-run/in-toto-record
- For now the exclude patterns can be defined as a setting ARTIFACT_EXCLUDES. This is likely to become a command line arg or part of a config file, e.g. .in-toto-ignore
- Set ARTIFACT_EXLCUDES to ignore ".git" and link metadata files
- Adds unit tests