### PR TITLE
Adds artifact base path setting (fix #44)

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -29,6 +29,7 @@ import os
 import tempfile
 import logging
 import fnmatch
+
 from simple_settings import settings
 
 # POSIX users (Linux, BSD, etc.) are strongly encouraged to
@@ -74,6 +75,27 @@ def _apply_exclude_patterns(names, exclude_patterns):
     excludes = fnmatch.filter(names, exclude_pattern)
     names = list(set(names) - set(excludes))
   return names
+
+
+def _add_base_path_to_artifacts(artifacts):
+  """Prefixes each artifact from the artifacts list with the basepath.
+  Replaces a single dot with basepath '.'.
+  """
+
+  if not settings.ARTIFACT_BASE_PATH:
+    return artifacts
+
+  full_paths = []
+  for path in artifacts:
+    if path == ".":
+      full_path = settings.ARTIFACT_BASE_PATH
+    else:
+      full_path = settings.ARTIFACT_BASE_PATH + path
+
+    full_paths.append(full_path)
+
+  return full_paths
+
 
 
 def record_artifacts_as_dict(artifacts):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -77,27 +77,6 @@ def _apply_exclude_patterns(names, exclude_patterns):
   return names
 
 
-def _add_base_path_to_artifacts(artifacts):
-  """Prefixes each artifact from the artifacts list with the basepath.
-  Replaces a single dot with basepath '.'.
-  """
-
-  if not settings.ARTIFACT_BASE_PATH:
-    return artifacts
-
-  full_paths = []
-  for path in artifacts:
-    if path == ".":
-      full_path = settings.ARTIFACT_BASE_PATH
-    else:
-      full_path = settings.ARTIFACT_BASE_PATH + path
-
-    full_paths.append(full_path)
-
-  return full_paths
-
-
-
 def record_artifacts_as_dict(artifacts):
   """
   <Purpose>
@@ -155,6 +134,14 @@ def record_artifacts_as_dict(artifacts):
   if not artifacts:
     return artifacts_dict
 
+  # Temporarily change into base path dir if set
+  if settings.ARTIFACT_BASE_PATH:
+    original_cwd = os.getcwd()
+    try:
+      os.chdir(settings.ARTIFACT_BASE_PATH)
+    except OSError as e:
+      raise OSError("Review your ARTIFACT_BASE_PATH setting - {}".format(e))
+
   # Normalize passed paths
   norm_artifacts = []
   for path in artifacts:
@@ -205,6 +192,10 @@ def record_artifacts_as_dict(artifacts):
         for filepath in _apply_exclude_patterns(filepaths,
             settings.ARTIFACT_EXCLUDES):
           artifacts_dict[filepath] = _hash_artifact(filepath)
+
+  # Change back to where original current working dir
+  if settings.ARTIFACT_BASE_PATH:
+    os.chdir(original_cwd)
 
   return artifacts_dict
 

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -72,3 +72,9 @@ ARTIFACT_EXCLUDES=["*.link*", ".git", "*.pyc", "*~"]
 LOG_LEVEL = logging.INFO
 # Debug level CRITICAL only shows in_toto-verify passing and failing
 #LOG_LEVEL = logging.CRITICAL
+
+# Used as base path for --materials and --products arguments when running
+# in-toto-run/in-toto-record
+# FIXME: This is likely to become a command line argument
+# FIXME: Do we want different base paths for materials and products?
+ARTIFACT_BASE_PATH = None

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -79,11 +79,17 @@ def run_all_inspections(layout):
     # for now. This will not stay!
     base_path_backup = settings.ARTIFACT_BASE_PATH
     settings.ARTIFACT_BASE_PATH = None
+
     link = in_toto.runlib.run_link(inspection.name, '.', '.',
         inspection.run.split())
-    link.dump()
     inspection_links_dict[inspection.name] = link
+
+    # Dump the inpsection link file for auditing
+    # Keep in mind that this pollutes the verfier's (client's) filesystem.
+    link.dump()
+
     settings.ARTIFACT_BASE_PATH = base_path_backup
+
   return inspection_links_dict
 
 def verify_layout_expiration(layout):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -41,6 +41,8 @@ from in_toto.exceptions import RuleVerficationFailed
 from in_toto.matchrule_validators import check_matchrule_syntax
 import in_toto.log as log
 
+from simple_settings import settings
+
 
 def run_all_inspections(layout):
   """
@@ -67,13 +69,21 @@ def run_all_inspections(layout):
   """
   inspection_links_dict = {}
   for inspection in layout.inspect:
-    # XXX LP: What should we record as material/product?
+
+    # FIXME LP: What should we record as material/product?
     # Is the current directory a sensible default? In general?
-    # If so, we should propably make it a default in run_link
-    # We could use matchrule paths
+    # If so, we should probably make it a default in run_link.
+    # We could use matchrule paths.
+
+    # FIXME: We don't want to use the base path for runlib so we patch this
+    # for now. This will not stay!
+    base_path_backup = settings.ARTIFACT_BASE_PATH
+    settings.ARTIFACT_BASE_PATH = None
     link = in_toto.runlib.run_link(inspection.name, '.', '.',
         inspection.run.split())
+    link.dump()
     inspection_links_dict[inspection.name] = link
+    settings.ARTIFACT_BASE_PATH = base_path_backup
   return inspection_links_dict
 
 def verify_layout_expiration(layout):

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -33,9 +33,6 @@ from in_toto.runlib import (in_toto_record_start, in_toto_record_stop,
 from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_import_rsa_key_from_file)
 
-
-
-
 class Test_ApplyExcludePatterns(unittest.TestCase):
   """Test _apply_exclude_patterns(names, exclude_patterns) """
 
@@ -91,7 +88,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     |-- bar
     |-- foo
     `-- subdir
-        |-- foosub
+        |-- foosub1
         |-- foosub2
         `-- subsubdir
             `-- foosubsub
@@ -99,11 +96,17 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
     self.working_dir = os.getcwd()
 
-    # Clear user set excludes
+    # Backup and clear user set excludes and base path
+    self.artifact_exclude_orig = settings.ARTIFACT_EXCLUDES
+    self.artifact_base_path_orig = settings.ARTIFACT_BASE_PATH
     settings.ARTIFACT_EXCLUDES = []
+    settings.ARTIFACT_BASE_PATH = None
 
-    self.test_dir = tempfile.mkdtemp()
+    # mkdtemp uses $TMPDIR, which might contain a symlink
+    # but we want the absolute location instead
+    self.test_dir = os.path.realpath(tempfile.mkdtemp())
     os.chdir(self.test_dir)
+
     open("foo", "w").write("foo")
     open("bar", "w").write("bar")
 
@@ -115,13 +118,41 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
+    """Change back to working dir, remove temp directory, restore settings. """
     os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
+    settings.ARTIFACT_EXCLUDES = self.artifact_exclude_orig
+    settings.ARTIFACT_BASE_PATH = self.artifact_base_path_orig
 
   def tearDown(self):
     """Clear the ARTIFACT_EXLCUDES after every test. """
     settings.ARTIFACT_EXCLUDES = []
+    settings.ARTIFACT_BASE_PATH = None
+
+  def test_not_existing_base_path(self):
+    """Raise exception with not existing base path setting. """
+    settings.ARTIFACT_BASE_PATH = "path_does_not_exist"
+    with self.assertRaises(OSError):
+      record_artifacts_as_dict(["."])
+
+  def test_base_path_is_child_dir(self):
+    """Test path of recorded artifacts and cd back with child as base."""
+    settings.ARTIFACT_BASE_PATH = "subdir"
+    artifacts_dict = record_artifacts_as_dict(["."])
+    self.assertListEqual(sorted(artifacts_dict.keys()),
+        sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
+    self.assertEquals(os.getcwd(), self.test_dir)
+
+  def test_base_path_is_parent_dir(self):
+    """Test path of recorded artifacts and cd back with parent as base. """
+    settings.ARTIFACT_BASE_PATH = ".."
+    os.chdir("subdir/subsubdir")
+    artifacts_dict = record_artifacts_as_dict(["."])
+    self.assertListEqual(sorted(artifacts_dict.keys()),
+        sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
+    self.assertEquals(os.getcwd(),
+        os.path.join(self.test_dir, "subdir/subsubdir"))
+    os.chdir(self.test_dir)
 
   def test_empty_artifacts_list_record_nothing(self):
     """Empty list passed. Return empty dict. """
@@ -174,7 +205,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     self.assertListEqual(sorted(artifacts_dict.keys()),
       sorted(["bar", "foo", "subdir/subsubdir/foosubsub"]))
 
-
   def test_exclude_subsubdir(self):
     """Traverse dot. Exclude subsubdir. """
     settings.ARTIFACT_EXCLUDES = ["*subsubdir"]
@@ -185,78 +215,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
     self.assertListEqual(sorted(artifacts_dict.keys()),
         sorted(["foo", "bar", "subdir/foosub1", "subdir/foosub2"]))
-
-
-class TestRecordArtifactsAsDict(unittest.TestCase):
-  """Test record_artifacts_as_dict(artifacts). """
-
-  @classmethod
-  def setUpClass(self):
-    """Create and change into temp test directory with dummy artifacts.
-    |-- bar
-    |-- foo
-    `-- subdir
-        |-- foosub1
-        |-- foosub2
-        `-- subsubdir
-            `-- foosubsub
-    """
-
-    self.working_dir = os.getcwd()
-
-    # Clear user set excludes
-    settings.ARTIFACT_EXCLUDES = []
-    settings.ARTIFACT_BASE_PATH = None
-
-    # mkdtemp uses $TMPDIR, which might contain a symlink
-    # but we want the absolute location instead
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
-
-    open("foo", "w").write("foo")
-    open("bar", "w").write("bar")
-
-    os.mkdir("subdir")
-    os.mkdir("subdir/subsubdir")
-    open("subdir/foosub1", "w").write("foosub")
-    open("subdir/foosub2", "w").write("foosub")
-    open("subdir/subsubdir/foosubsub", "w").write("foosubsub")
-
-  @classmethod
-  def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
-
-  def tearDown(self):
-    """Clear the ARTIFACT_EXLCUDES after every test. """
-    settings.ARTIFACT_EXCLUDES = []
-    settings.ARTIFACT_BASE_PATH = None
-
-  def test_not_existing_base_path(self):
-    """Raise exception with not existing base path setting. """
-    settings.ARTIFACT_BASE_PATH = "path_does_not_exist"
-    with self.assertRaises(OSError):
-      record_artifacts_as_dict(["."])
-
-  def test_base_path_is_child_dir(self):
-    """Test path of recorded artifacts and cd back with child as base."""
-    settings.ARTIFACT_BASE_PATH = "subdir"
-    artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()),
-        sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
-    self.assertEquals(os.getcwd(), self.test_dir)
-
-  def test_base_path_is_parent_dir(self):
-    """Test path of recorded artifacts and cd back with parent as base. """
-    settings.ARTIFACT_BASE_PATH = ".."
-    os.chdir("subdir/subsubdir")
-    artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()),
-        sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
-    self.assertEquals(os.getcwd(),
-        os.path.join(self.test_dir, "subdir/subsubdir"))
-    os.chdir(self.test_dir)
 
 
 class TestInTotoRecordStart(unittest.TestCase):
@@ -386,5 +344,5 @@ class TestInTotoRecordStop(unittest.TestCase):
       open(self.link_name, "r")
     os.remove(self.link_name_unfinished)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
   unittest.main()

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -22,17 +22,18 @@ import os
 import unittest
 import shutil
 import tempfile
+from simple_settings import settings
 
 from in_toto import ssl_crypto
+from in_toto.models.link import Link
+from in_toto.exceptions import SignatureVerificationError
 from in_toto.runlib import (in_toto_record_start, in_toto_record_stop,
     UNFINISHED_FILENAME_FORMAT, record_artifacts_as_dict,
     _apply_exclude_patterns)
 from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_import_rsa_key_from_file)
 
-from in_toto.models.link import Link
-from in_toto.exceptions import SignatureVerificationError
-from simple_settings import settings
+
 
 
 class Test_ApplyExcludePatterns(unittest.TestCase):

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -25,7 +25,7 @@ import unittest
 from simple_settings import settings
 
 from in_toto.models.link import Link
-from in_toto.models.layout import Step, Inspection
+from in_toto.models.layout import Step, Inspection, Layout
 from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
     verify_match_rule, verify_item_rules, verify_all_item_rules,
     verify_command_alignment, run_all_inspections)


### PR DESCRIPTION
Adds new optional setting `ARTIFACT_BASE_PATH`. If set, it will be used as starting point when traversing the file system to record artifacts, e.g. when using `in-toto-run` or `in-toto-record`.

Example:
```
# Given the following directory structure
├─/artifact/base/path/
      ├── bar
      └── foo

ARTIFACT_BASE_PATH = "/artifact/base/path"

# Run from any directory
in-toto-run --materials . --products . ...
# will record "bar" and "foo" as materials and products
```

- The base path is ignored when running inspection upon `in-toto-verify`.
- This PR will conflict with https://github.com/in-toto/in-toto/pull/56. Let's first merge https://github.com/in-toto/in-toto/pull/56 first and I will fix the conflicts.
- Fixes https://github.com/in-toto/in-toto/issues/44
