### PR TITLE
Adds parentheses in multi-line imports (fix #57)

### DIFF
--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -27,8 +27,8 @@ import shutil
 import tempfile
 from mock import patch
 
-from in_toto.util import generate_and_write_rsa_keypair, \
-    prompt_import_rsa_key_from_file
+from in_toto.util import (generate_and_write_rsa_keypair,
+    prompt_import_rsa_key_from_file)
 from in_toto.models.link import Link
 from in_toto.in_toto_record import main as in_toto_record_main
 from in_toto.in_toto_record import in_toto_record_start, in_toto_record_stop

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -22,12 +22,14 @@ import os
 import unittest
 import shutil
 import tempfile
+
 from in_toto import ssl_crypto
-from in_toto.runlib import in_toto_record_start, in_toto_record_stop, \
-    UNFINISHED_FILENAME_FORMAT, record_artifacts_as_dict, \
-    _apply_exclude_patterns
-from in_toto.util import generate_and_write_rsa_keypair, \
-    prompt_import_rsa_key_from_file
+from in_toto.runlib import (in_toto_record_start, in_toto_record_stop,
+    UNFINISHED_FILENAME_FORMAT, record_artifacts_as_dict,
+    _apply_exclude_patterns)
+from in_toto.util import (generate_and_write_rsa_keypair,
+    prompt_import_rsa_key_from_file)
+
 from in_toto.models.link import Link
 from in_toto.exceptions import SignatureVerificationError
 from simple_settings import settings

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -21,9 +21,9 @@
 import unittest
 from in_toto.models.link import Link
 from in_toto.models.layout import Step, Inspection
-from in_toto.verifylib import verify_delete_rule, verify_create_rule, \
-    verify_match_rule, verify_item_rules, verify_all_item_rules, \
-    verify_command_alignment
+from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
+    verify_match_rule, verify_item_rules, verify_all_item_rules,
+    verify_command_alignment)
 from in_toto.exceptions import RuleVerficationFailed
 from mock import patch
 


### PR DESCRIPTION
PEP8 suggests to use parentheses in line continuation in
preference to using backslashes.

This replaces backslash line continuation with parentheses in
all multi-line imports.

Fixes https://github.com/in-toto/in-toto/issues/57.