### PR TITLE
Adds unit tests for util functions

### DIFF
--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -103,6 +103,10 @@ def import_rsa_public_keys_from_files_as_dict(filepaths):
   key_dict = {}
   for filepath in filepaths:
     key = import_rsa_key_from_file(filepath)
+    #FIXME: Add public key format check to ssl_crypto formats
+    if key["keyval"].get("private"):
+      raise in_toto.ssl_commons.exceptions.FormatError(
+          "Public keys should not have a private portion.")
     keyid = key["keyid"]
     key_dict[keyid] = key
   return key_dict

--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -41,8 +41,8 @@ def generate_and_write_rsa_keypair(filepath, password=None):
 
   rsa_key = in_toto.ssl_crypto.keys.generate_rsa_key()
 
-  public = rsa_key['keyval']['public']
-  private = rsa_key['keyval']['private']
+  public = rsa_key["keyval"]["public"]
+  private = rsa_key["keyval"]["private"]
 
   if password:
     private_pem = in_toto.ssl_crypto.keys.create_rsa_encrypted_pem(private,
@@ -50,11 +50,11 @@ def generate_and_write_rsa_keypair(filepath, password=None):
   else:
     private_pem = private
 
-  with open(filepath + '.pub', 'w') as fo_public:
-    fo_public.write(public.encode('utf-8'))
+  with open(filepath + ".pub", "w") as fo_public:
+    fo_public.write(public.encode("utf-8"))
 
-  with open(filepath, 'w') as fo_private:
-    fo_private.write(private_pem.encode('utf-8'))
+  with open(filepath, "w") as fo_private:
+    fo_private.write(private_pem.encode("utf-8"))
 
 
 def import_rsa_key_from_file(filepath, password=None):
@@ -83,8 +83,8 @@ def import_rsa_key_from_file(filepath, password=None):
   """
   in_toto.ssl_crypto.formats.PATH_SCHEMA.check_match(filepath)
 
-  with open(filepath, 'rb') as fo_pem:
-    rsa_pem = fo_pem.read().decode('utf-8')
+  with open(filepath, "rb") as fo_pem:
+    rsa_pem = fo_pem.read().decode("utf-8")
 
   if in_toto.ssl_crypto.keys.is_pem_private(rsa_pem):
     rsa_key = in_toto.ssl_crypto.keys.import_rsakey_from_pem(rsa_pem, password)
@@ -92,8 +92,8 @@ def import_rsa_key_from_file(filepath, password=None):
   elif in_toto.ssl_crypto.keys.is_pem_public(rsa_pem):
     rsa_key = in_toto.ssl_crypto.keys.format_rsakey_from_pem(rsa_pem)
   else:
-    raise in_toto.ssl_commons.exceptions.FormatError('The key has to be either'
-            'a private or public RSA key in PEM format')
+    raise in_toto.ssl_commons.exceptions.FormatError("The key has to be either"
+            " a private or public RSA key in PEM format")
 
   return rsa_key
 
@@ -103,7 +103,7 @@ def import_rsa_public_keys_from_files_as_dict(filepaths):
   key_dict = {}
   for filepath in filepaths:
     key = import_rsa_key_from_file(filepath)
-    keyid = key['keyid']
+    keyid = key["keyid"]
     key_dict[keyid] = key
   return key_dict
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,17 +1,155 @@
 #!/usr/bin/env python
 
 """
-    TODO: this
+<Program Name>
+  test_verifylib.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Jan 17, 2017
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test util functions.
+
 """
 
+import os
+import shutil
+import tempfile
 import unittest
+from mock import patch
 
-class Test(unittest.TestCase):
+from in_toto.util import (generate_and_write_rsa_keypair,
+    import_rsa_key_from_file, import_rsa_public_keys_from_files_as_dict,
+    prompt_password, prompt_generate_and_write_rsa_keypair,
+    prompt_import_rsa_key_from_file, flatten_and_invert_artifact_dict)
+from in_toto.ssl_crypto import formats
+from in_toto.ssl_commons import exceptions
 
-  @unittest.skip("Missing test implementation")
-  def test_unimplemented(self):
-    raise self.assertFalse("Missing test implementation!")
+class TestUtil(unittest.TestCase):
+  """Test various util functions. Mostly related to RSA key creation or
+  loading."""
 
-# Run unit test.
-if __name__ == '__main__':
+  @classmethod
+  def setUpClass(self):
+    # Create directory where the verification will take place
+    self.working_dir = os.getcwd()
+    self.test_dir = os.path.realpath(tempfile.mkdtemp())
+    os.chdir(self.test_dir)
+
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(self.working_dir)
+    shutil.rmtree(self.test_dir)
+
+  def test_create_and_import_rsa(self):
+    """Create RS key and import private and public key separately. """
+    name = "key1"
+    generate_and_write_rsa_keypair(name)
+    private_key = import_rsa_key_from_file(name)
+    public_key = import_rsa_key_from_file(name + ".pub")
+
+    formats.KEY_SCHEMA.check_match(private_key)
+    self.assertTrue(private_key["keyval"].get("private"))
+    formats.KEY_SCHEMA.check_match(public_key)
+    self.assertFalse(public_key["keyval"].get("private"))
+
+  def test_create_and_import_encrypted_rsa(self):
+    """Create ecrypted RSA key and import private and public key separately. """
+    name = "key2"
+    password = "123456"
+    generate_and_write_rsa_keypair(name, password)
+    private_key = import_rsa_key_from_file(name, password)
+    public_key = import_rsa_key_from_file(name + ".pub")
+
+    formats.KEY_SCHEMA.check_match(private_key)
+    self.assertTrue(private_key["keyval"].get("private"))
+    formats.KEY_SCHEMA.check_match(public_key)
+    self.assertFalse(public_key["keyval"].get("private"))
+
+  def test_create_and_import_encrypted_rsa_no_password(self):
+    """Try import encrypted RSA key without or wrong pw, raises exception. """
+    name = "key3"
+    password = "123456"
+    generate_and_write_rsa_keypair(name, password)
+    with self.assertRaises(exceptions.CryptoError):
+      private_key = import_rsa_key_from_file(name)
+    with self.assertRaises(exceptions.CryptoError):
+      private_key = import_rsa_key_from_file(name, "wrong-password")
+
+  def test_import_non_existing_rsa(self):
+    """Try import non-existing RSA key, raises exception. """
+    with self.assertRaises(IOError):
+      import_rsa_key_from_file("key-does-not-exist")
+
+  def test_import_rsa_wrong_format(self):
+    """Try import wrongly formatted RSA key, raises exception. """
+    not_an_rsa = "not_an_rsa"
+    open(not_an_rsa, "w").write(not_an_rsa)
+    with self.assertRaises(exceptions.FormatError):
+      import_rsa_key_from_file(not_an_rsa)
+
+  def test_import_rsa_public_keys_from_files_as_dict(self):
+    """Create and import multiple rsa public keys and return KEYDICT. """
+    name1 = "key4"
+    name2 = "key5"
+    generate_and_write_rsa_keypair(name1)
+    generate_and_write_rsa_keypair(name2)
+
+    # Succefully import public keys as keydictionary
+    key_dict = import_rsa_public_keys_from_files_as_dict([name1 + ".pub",
+        name2 + ".pub"])
+    formats.KEYDICT_SCHEMA.check_match(key_dict)
+
+    # Import wrongly formatted key raises an exception
+    not_an_rsa = "not_an_rsa"
+    open(not_an_rsa, "w").write(not_an_rsa)
+    with self.assertRaises(exceptions.FormatError):
+      import_rsa_public_keys_from_files_as_dict([name1 + ".pub", not_an_rsa])
+
+    # Import private key raises an exception
+    with self.assertRaises(exceptions.FormatError):
+      import_rsa_public_keys_from_files_as_dict([name1, name2])
+
+  def test_prompt_password(self):
+    """Call password prompt. """
+    password = "123456"
+    with patch("getpass.getpass", return_value=password):
+      self.assertEqual(prompt_password(), password)
+
+  def test_prompt_create_and_import_encrypted_rsa(self):
+    """Create and import password encrypted RSA using prompt input. """
+    key = "key6"
+    password = "123456"
+    with patch("getpass.getpass", return_value=password):
+      prompt_generate_and_write_rsa_keypair(key)
+      rsa_key = prompt_import_rsa_key_from_file(key)
+      formats.KEY_SCHEMA.check_match(rsa_key)
+      self.assertTrue(rsa_key["keyval"].get("private"))
+
+    with patch("getpass.getpass",
+        return_value="wrong-password"), self.assertRaises(
+        exceptions.CryptoError):
+      prompt_import_rsa_key_from_file(key)
+
+  def test_flatten_and_invert_artifact_dict(self):
+    """Test basic aritfact dictionary flattening and inversion. """
+    artifacts = {
+    "foo": {
+      "sha512" : "23432df87ab",
+      "sha256" : "34324abc34df",
+      }
+    }
+    flat_artifacts = flatten_and_invert_artifact_dict(artifacts)
+    self.assertEqual(flat_artifacts, {"34324abc34df" : "foo"})
+    flat_artifacts = flatten_and_invert_artifact_dict(artifacts, "sha512")
+    self.assertEqual(flat_artifacts, {"23432df87ab" : "foo"})
+
+if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
`in_toto/util.py` mostly consists of interface function that use ssl_crypto to create and load encrypted and non-encrypted RSA keys. This PR adds unit tests for these functions.

Additionally, it fixes a whitespace, unifies quotes and adds a format check in `util.py` 