### PR TITLE
Removes external package simple_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ cd in-toto
 
 # Install with pip in "develop mode"
 pip install -e .
-
-# Export the envvar required for "simple settings"
-export SIMPLE_SETTINGS=in_toto.settings
-
-# Install additional requirements that for some good reason are not in the
-# requirements file
-pip install pycrypto cryptography
 ```
 ### Create layout, run supply chain steps and verify final product
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -26,9 +26,6 @@ cd in-toto
 # http://docs.python-guide.org/en/latest/dev/virtualenvs/
 pip install -e .
 
-# Export the envvar required for "simple settings"
-export SIMPLE_SETTINGS=in_toto.settings
-
 # Change into the demo directoy and you are ready to start
 cd demo
 ```

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -16,9 +16,9 @@
 """
 
 import logging
-from simple_settings import settings
+import in_toto.settings
 
-logging.basicConfig(level=settings.LOG_LEVEL, format='%(message)s')
+logging.basicConfig(level=in_toto.settings.LOG_LEVEL, format='%(message)s')
 
 def doing(msg):
   """Logs things that are currently being done """

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -30,8 +30,6 @@ import tempfile
 import logging
 import fnmatch
 
-from simple_settings import settings
-
 # POSIX users (Linux, BSD, etc.) are strongly encouraged to
 # install and use the much more recent subprocess32
 if os.name == 'posix' and sys.version_info[0] < 3:
@@ -44,6 +42,7 @@ if os.name == 'posix' and sys.version_info[0] < 3:
 else:
   import subprocess
 
+import in_toto.settings
 import in_toto.models.link
 import in_toto.log as log
 
@@ -137,10 +136,10 @@ def record_artifacts_as_dict(artifacts):
     return artifacts_dict
 
   # Temporarily change into base path dir if set
-  if settings.ARTIFACT_BASE_PATH:
+  if in_toto.settings.ARTIFACT_BASE_PATH:
     original_cwd = os.getcwd()
     try:
-      os.chdir(settings.ARTIFACT_BASE_PATH)
+      os.chdir(in_toto.settings.ARTIFACT_BASE_PATH)
     except OSError as e:
       raise OSError("Review your ARTIFACT_BASE_PATH setting - {}".format(e))
 
@@ -152,7 +151,7 @@ def record_artifacts_as_dict(artifacts):
   # Iterate over remaining normalized artifact paths after
   # having applied exclusion patterns
   for artifact in _apply_exclude_patterns(norm_artifacts,
-        settings.ARTIFACT_EXCLUDES):
+        in_toto.settings.ARTIFACT_EXCLUDES):
 
     if not os.path.exists(artifact):
       log.warning("path: {} does not exist, skipping..".format(artifact))
@@ -172,7 +171,7 @@ def record_artifacts_as_dict(artifacts):
           dirpaths.append(norm_dirpath)
 
         # Apply exlcude patterns on normalized dirpaths
-        dirpaths = _apply_exclude_patterns(dirpaths, settings.ARTIFACT_EXCLUDES)
+        dirpaths = _apply_exclude_patterns(dirpaths, in_toto.settings.ARTIFACT_EXCLUDES)
 
         # Reset and refill dirs with remaining names after exclusion
         # Modify (not reassign) dirnames to only recurse into remaining dirs
@@ -192,11 +191,11 @@ def record_artifacts_as_dict(artifacts):
         # store each remaining normalized filepath with it's files hash to
         # the resulting artifact dict
         for filepath in _apply_exclude_patterns(filepaths,
-            settings.ARTIFACT_EXCLUDES):
+            in_toto.settings.ARTIFACT_EXCLUDES):
           artifacts_dict[filepath] = _hash_artifact(filepath)
 
   # Change back to where original current working dir
-  if settings.ARTIFACT_BASE_PATH:
+  if in_toto.settings.ARTIFACT_BASE_PATH:
     os.chdir(original_cwd)
 
   return artifacts_dict

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -12,30 +12,33 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  A global settings file used througout the entire package, inspired
-  by Django's settings system.
+  Mostly for things that will eventually be moved to
+  separate configuration files or command line arguments.
 
+  Note:
+  This used to be a global settings file for in_toto and its submodules using
+  `simple_settings`. Since submodules were removed `simple_settings` is no
+  longer needed.
 
-<Pre-requisites>
-  To make this work we use the simple-settings module available on Pypi.
-  http://simple-settings.readthedocs.io/en/master/
+  The former submodule and now external dependency `securesystemslib` has its
+  own settings file, that should henceforth be used programmatically.
 
-  $ pip install simple-settings
-  $ export SIMPLE_SETTINGS=toto.settings
-
-  To access a settings:
-  from simple_settings import settings
+  E.g.:
+  ```
+  import securesystemslib.settings
+  securesystemslib.settings.RSA_CRYPTO_LIBRARY = "pyca-cryptography" # default
+  ```
 
 """
 import logging
-
-# FIXME: Add as command line argument or to config file, e.g .in-toto-ignore
-ARTIFACT_EXCLUDES=["*.link*", ".git", "*.pyc", "*~"]
 
 # Debug level INFO shows a bunch of stuff that is happening
 LOG_LEVEL = logging.INFO
 # Debug level CRITICAL only shows in_toto-verify passing and failing
 #LOG_LEVEL = logging.CRITICAL
+
+# FIXME: Add as command line argument or to config file, e.g .in-toto-ignore
+ARTIFACT_EXCLUDES = ["*.link*", ".git", "*.pyc", "*~"]
 
 # Used as base path for --materials and --products arguments when running
 # in-toto-run/in-toto-record

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -31,8 +31,8 @@ import datetime
 import iso8601
 import fnmatch
 from dateutil import tz
-from simple_settings import settings
 
+import in_toto.settings
 import in_toto.util
 import in_toto.runlib
 import in_toto.models.layout
@@ -69,8 +69,8 @@ def run_all_inspections(layout):
   for inspection in layout.inspect:
     # FIXME: We don't want to use the base path for runlib so we patch this
     # for now. This will not stay!
-    base_path_backup = settings.ARTIFACT_BASE_PATH
-    settings.ARTIFACT_BASE_PATH = None
+    base_path_backup = in_toto.settings.ARTIFACT_BASE_PATH
+    in_toto.settings.ARTIFACT_BASE_PATH = None
 
     # FIXME: What should we record as material/product?
     # Is the current directory a sensible default? In general?
@@ -86,7 +86,7 @@ def run_all_inspections(layout):
     # Keep in mind that this pollutes the verfier's (client's) filesystem.
     link.dump()
 
-    settings.ARTIFACT_BASE_PATH = base_path_backup
+    in_toto.settings.ARTIFACT_BASE_PATH = base_path_backup
 
   return inspection_links_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 securesystemslib==0.10.4
 sphinx
 attrs
-simple-settings
 python-dateutil
 iso8601
 canonicaljson

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
                "the integrity of software supply chains"),
   license="MIT",
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-  install_requires=["six", "securesystemslib==0.10.4", "simple-settings", "attrs",
-                    "canonicaljson",
+  install_requires=["six", "securesystemslib==0.10.4", "attrs", "canonicaljson",
                     "python-dateutil", "iso8601"],
   test_suite="test.runtests",
   entry_points={

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -22,8 +22,8 @@ import os
 import unittest
 import shutil
 import tempfile
-from simple_settings import settings
 
+import in_toto.settings
 from in_toto.models.link import Link
 from in_toto.exceptions import SignatureVerificationError
 from in_toto.runlib import (in_toto_run, in_toto_record_start,
@@ -99,10 +99,10 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     self.working_dir = os.getcwd()
 
     # Backup and clear user set excludes and base path
-    self.artifact_exclude_orig = settings.ARTIFACT_EXCLUDES
-    self.artifact_base_path_orig = settings.ARTIFACT_BASE_PATH
-    settings.ARTIFACT_EXCLUDES = []
-    settings.ARTIFACT_BASE_PATH = None
+    self.artifact_exclude_orig = in_toto.settings.ARTIFACT_EXCLUDES
+    self.artifact_base_path_orig = in_toto.settings.ARTIFACT_BASE_PATH
+    in_toto.settings.ARTIFACT_EXCLUDES = []
+    in_toto.settings.ARTIFACT_BASE_PATH = None
 
     # mkdtemp uses $TMPDIR, which might contain a symlink
     # but we want the absolute location instead
@@ -123,23 +123,23 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Change back to working dir, remove temp directory, restore settings. """
     os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
-    settings.ARTIFACT_EXCLUDES = self.artifact_exclude_orig
-    settings.ARTIFACT_BASE_PATH = self.artifact_base_path_orig
+    in_toto.settings.ARTIFACT_EXCLUDES = self.artifact_exclude_orig
+    in_toto.settings.ARTIFACT_BASE_PATH = self.artifact_base_path_orig
 
   def tearDown(self):
     """Clear the ARTIFACT_EXLCUDES after every test. """
-    settings.ARTIFACT_EXCLUDES = []
-    settings.ARTIFACT_BASE_PATH = None
+    in_toto.settings.ARTIFACT_EXCLUDES = []
+    in_toto.settings.ARTIFACT_BASE_PATH = None
 
   def test_not_existing_base_path(self):
     """Raise exception with not existing base path setting. """
-    settings.ARTIFACT_BASE_PATH = "path_does_not_exist"
+    in_toto.settings.ARTIFACT_BASE_PATH = "path_does_not_exist"
     with self.assertRaises(OSError):
       record_artifacts_as_dict(["."])
 
   def test_base_path_is_child_dir(self):
     """Test path of recorded artifacts and cd back with child as base."""
-    settings.ARTIFACT_BASE_PATH = "subdir"
+    in_toto.settings.ARTIFACT_BASE_PATH = "subdir"
     artifacts_dict = record_artifacts_as_dict(["."])
     self.assertListEqual(sorted(artifacts_dict.keys()),
         sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
@@ -147,7 +147,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
   def test_base_path_is_parent_dir(self):
     """Test path of recorded artifacts and cd back with parent as base. """
-    settings.ARTIFACT_BASE_PATH = ".."
+    in_toto.settings.ARTIFACT_BASE_PATH = ".."
     os.chdir("subdir/subsubdir")
     artifacts_dict = record_artifacts_as_dict(["."])
     self.assertListEqual(sorted(artifacts_dict.keys()),
@@ -188,7 +188,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
   def test_record_dot_exclude_star_foo_star_from_recording(self):
     """Traverse dot. Exclude pattern. Record one file. """
-    settings.ARTIFACT_EXCLUDES = ["*foo*"]
+    in_toto.settings.ARTIFACT_EXCLUDES = ["*foo*"]
     artifacts_dict = record_artifacts_as_dict(["."])
 
     securesystemslib.formats.HASHDICT_SCHEMA.check_match(artifacts_dict["bar"])
@@ -196,20 +196,20 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
   def test_exclude_subdir(self):
     """Traverse dot. Exclude subdir (and subsubdir). """
-    settings.ARTIFACT_EXCLUDES = ["*subdir"]
+    in_toto.settings.ARTIFACT_EXCLUDES = ["*subdir"]
     artifacts_dict = record_artifacts_as_dict(["."])
     self.assertListEqual(sorted(artifacts_dict.keys()), sorted(["bar", "foo"]))
 
   def test_exclude_files_in_subdir(self):
     """Traverse dot. Exclude files in subdir but not subsubdir. """
-    settings.ARTIFACT_EXCLUDES = ["*foosub?"]
+    in_toto.settings.ARTIFACT_EXCLUDES = ["*foosub?"]
     artifacts_dict = record_artifacts_as_dict(["."])
     self.assertListEqual(sorted(artifacts_dict.keys()),
       sorted(["bar", "foo", "subdir/subsubdir/foosubsub"]))
 
   def test_exclude_subsubdir(self):
     """Traverse dot. Exclude subsubdir. """
-    settings.ARTIFACT_EXCLUDES = ["*subsubdir"]
+    in_toto.settings.ARTIFACT_EXCLUDES = ["*subsubdir"]
     artifacts_dict = record_artifacts_as_dict(["."])
 
     for key, val in artifacts_dict.iteritems():

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -24,10 +24,10 @@ import copy
 import tempfile
 import unittest
 from mock import patch
-from simple_settings import settings
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
+import in_toto.settings
 from in_toto.models.link import Link
 from in_toto.models.layout import Step, Inspection, Layout
 from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
@@ -73,14 +73,14 @@ class TestRunAllInspections(unittest.TestCase):
     ignore_dir = os.path.realpath(tempfile.mkdtemp())
     ignore_foo = os.path.join(ignore_dir, "ignore_foo")
     open(ignore_foo, "w").write("ignore foo")
-    settings.ARTIFACT_BASE_PATH = ignore_dir
+    in_toto.settings.ARTIFACT_BASE_PATH = ignore_dir
 
     run_all_inspections(self.layout)
     link = Link.read_from_file("touch-bar.link")
     self.assertListEqual(link.materials.keys(), ["foo"])
     self.assertListEqual(sorted(link.products.keys()), sorted(["foo", "bar"]))
 
-    settings.ARTIFACT_BASE_PATH = None
+    in_toto.settings.ARTIFACT_BASE_PATH = None
     shutil.rmtree(ignore_dir)
 
 


### PR DESCRIPTION
in-toto used to use simple_settings to provide a global settings
file that could also be accessed from submodules without specifying
the full path. Since submodules were removed `simple_settings` is
no longer needed.

The former submodule and now external dependency `securesystemslib`
has its own settings file, that should henceforth be accessed
programmatically.

E.g.:
```python
import securesystemslib.settings
securesystemslib.settings.RSA_CRYPTO_LIBRARY = "pyca-cryptography" # default
```
