### PR TITLE
Raise exception on non-zero return of Inspection (fix #63)

### DIFF
--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -11,3 +11,7 @@ class LayoutExpiredError(Error):
 class RuleVerficationError(Error):
   """Indicates that a match rule verification failed. """
   pass
+
+class BadReturnValueError(Error):
+  """Indicates that a ran command exited with non-int or non-zero return
+  value. """

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -75,7 +75,7 @@ def _raise_on_bad_retval(return_value, command=None):
     raise BadReturnValueError(msg.format(what="int"))
 
   # TODO: in-toto specification suggests special behavior on
-  # return_value < 127, but does not fully define that behavior yet
+  # return_value == 127, but does not fully define that behavior yet
 
   if return_value != 0:
     raise BadReturnValueError(msg.format(what="zero"))


### PR DESCRIPTION
Fixes https://github.com/in-toto/in-toto/issues/63

- Adds internal function that checks return values of shell commands, e.g. from inspections. Raises exception if the passed value is non-int and non-zero.
- Adds call to function in `verifylib.run_all_inspections`, i.e. verification aborts if a ran inspection returns non-zero.
- Fixes typos in comments
- Adds unittests