### PR TITLE
Fixes dead symlink bug in `record_artifacts_as_dict`

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -182,7 +182,11 @@ def record_artifacts_as_dict(artifacts):
         filepaths = []
         for filename in files:
           norm_filepath = os.path.normpath(os.path.join(root, filename))
-          filepaths.append(norm_filepath)
+
+          # `os.walk` could also list dead symlinks, which would
+          # result in an error later when trying to read the file
+          if os.path.isfile(norm_filepath):
+            filepaths.append(norm_filepath)
 
         # Apply exclude patterns on normalized filepaths and
         # store each remaining normalized filepath with it's files hash to

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -187,6 +187,9 @@ def record_artifacts_as_dict(artifacts):
           # result in an error later when trying to read the file
           if os.path.isfile(norm_filepath):
             filepaths.append(norm_filepath)
+          else:
+            log.warning("File '{}' appears to be a broken symlink. Skipping..."
+                .format(norm_filepath))
 
         # Apply exclude patterns on normalized filepaths and
         # store each remaining normalized filepath with it's files hash to

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -188,7 +188,7 @@ def record_artifacts_as_dict(artifacts):
           if os.path.isfile(norm_filepath):
             filepaths.append(norm_filepath)
           else:
-            log.warning("File '{}' appears to be a broken symlink. Skipping..."
+            log.warn("File '{}' appears to be a broken symlink. Skipping..."
                 .format(norm_filepath))
 
         # Apply exclude patterns on normalized filepaths and

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -118,6 +118,11 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     open("subdir/foosub2", "w").write("foosub")
     open("subdir/subsubdir/foosubsub", "w").write("foosubsub")
 
+    # Add dead symlinks on each level, they should be excluded
+    os.symlink("this/file/does/not/exist", "deadlink")
+    os.symlink("this/file/does/not/exist", "subdir/deadlink")
+    os.symlink("this/file/does/not/exist", "subdir/subsubdir/deadlink")
+
   @classmethod
   def tearDownClass(self):
     """Change back to working dir, remove temp directory, restore settings. """


### PR DESCRIPTION
File existence is only checked on the first level of the file
system traversal. If we recurse in a directory using os.walk,
we might also record symlinks to non-existent files, which would
crash once we try reading the file.

This commit excludes non-existent files in our `os.walk` loop
and adapts the related unittest.