### PR TITLE
Store all commands as list and use `shlex` to split command strings

### DIFF
--- a/demo/run_demo.py
+++ b/demo/run_demo.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shlex
 import subprocess
 import argparse
 import time
@@ -24,7 +25,7 @@ def supply_chain():
   os.chdir("owner_alice")
   create_layout_cmd = "python create_layout.py"
   print create_layout_cmd
-  subprocess.call(create_layout_cmd.split())
+  subprocess.call(shlex.split(create_layout_cmd))
 
   prompt_key("Clone source code (Bob)")
   os.chdir("../functionary_bob")
@@ -32,7 +33,7 @@ def supply_chain():
                     " --step-name clone --products demo-project/foo.py"
                     " --key bob -- git clone https://github.com/in-toto/demo-project.git")
   print clone_cmd
-  subprocess.call(clone_cmd.split())
+  subprocess.call(shlex.split(clone_cmd))
 
   prompt_key("Update version number (Bob)")
   update_version_start_cmd = ("in-toto-record"
@@ -42,7 +43,7 @@ def supply_chain():
                     " --materials demo-project/foo.py")
 
   print update_version_start_cmd
-  subprocess.call(update_version_start_cmd.split())
+  subprocess.call(shlex.split(update_version_start_cmd))
 
   update_version = "echo 'VERSION = \"foo-v1\"\n\nprint(\"Hello in-toto\")\n' > demo-project/foo.py"
   print update_version
@@ -55,7 +56,7 @@ def supply_chain():
                     " --products demo-project/foo.py")
 
   print update_version_stop_cmd
-  subprocess.call(update_version_stop_cmd.split())
+  subprocess.call(shlex.split(update_version_stop_cmd))
 
   copytree("demo-project", "../functionary_carl/demo-project")
 
@@ -67,7 +68,7 @@ def supply_chain():
                  " --key carl --record-byproducts"
                  " -- tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
   print package_cmd
-  subprocess.call(package_cmd.split())
+  subprocess.call(shlex.split(package_cmd))
 
 
   prompt_key("Create final product")
@@ -86,7 +87,7 @@ def supply_chain():
                 " --layout root.layout"
                 " --layout-key alice.pub")
   print verify_cmd
-  retval = subprocess.call(verify_cmd.split())
+  retval = subprocess.call(shlex.split(verify_cmd))
   print "Return value: " + str(retval)
 
 
@@ -107,7 +108,7 @@ def supply_chain():
                  " --key carl --record-byproducts"
                  " -- tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
   print package_cmd
-  subprocess.call(package_cmd.split())
+  subprocess.call(shlex.split(package_cmd))
 
 
   prompt_key("Create final product")
@@ -127,7 +128,7 @@ def supply_chain():
                 " --layout-key alice.pub")
 
   print verify_cmd
-  retval = subprocess.call(verify_cmd.split())
+  retval = subprocess.call(shlex.split(verify_cmd))
   print "Return value: " + str(retval)
 
 

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -348,12 +348,22 @@ class Inspection(models__common.Metablock):
   name = attr.ib()
   material_matchrules = attr.ib(default=attr.Factory(list))
   product_matchrules = attr.ib(default=attr.Factory(list))
-  run = attr.ib("")
+  run = attr.ib(default=attr.Factory(list))
 
 
   @staticmethod
   def read(data):
-    return Inspection(name=data.get("name"), run=data.get("run"),
+    # Accept run as string or list, if it is a string we split it using
+    # shell like syntax.
+    data_run = data.get("run")
+    if data_run:
+      if not isinstance(data_run, list):
+        data_run = shlex.split(data_run)
+
+    else:
+      data_run = []
+
+    return Inspection(name=data.get("name"), run=data_run,
         material_matchrules=data.get("material_matchrules"),
         product_matchrules=data.get("product_matchrules"))
 
@@ -383,6 +393,6 @@ class Inspection(models__common.Metablock):
 
   def _validate_run(self):
     """Private method to check that the expected command is correct."""
-    if type(self.run) != str:
+    if type(self.run) != list:
       raise securesystemslib.exceptions.FormatError(
           "The run field is malformed!")

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -66,7 +66,7 @@ class Link(models__common.Signable):
   materials = attr.ib(default=attr.Factory(dict))
   products = attr.ib(default=attr.Factory(dict))
   byproducts = attr.ib(default=attr.Factory(dict))
-  command = attr.ib("")
+  command = attr.ib(default=attr.Factory(list))
   return_value = attr.ib(None)
 
   def dump(self, filename=False, key=False):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -265,8 +265,8 @@ def execute_link(link_cmd_args, record_byproducts):
 
   return {"stdout": stdout_str, "stderr": stderr_str}, return_value
 
-def create_link_metadata(link_name, materials_dict={}, products_dict={},
-    link_cmd_args="", byproducts={}, return_value=None):
+def create_link_metadata(link_name, materials_dict=None, products_dict=None,
+    link_cmd_args=None, byproducts=None, return_value=None):
   """
   <Purpose>
     Takes the state of the materials (before link command execution), the state
@@ -303,6 +303,18 @@ def create_link_metadata(link_name, materials_dict={}, products_dict={},
   <Returns>
     - A Link metadata object
   """
+  if not materials_dict:
+    materials_dict = {}
+
+  if not products_dict:
+    products_dict = {}
+
+  if not link_cmd_args:
+    link_cmd_args = []
+
+  if not byproducts:
+    byproducts = {}
+
   link_dict = {
     "name" : link_name,
     "materials" : materials_dict,
@@ -312,7 +324,7 @@ def create_link_metadata(link_name, materials_dict={}, products_dict={},
     "return_value" : return_value
   }
 
-  return  in_toto.models.link.Link.read(link_dict)
+  return in_toto.models.link.Link.read(link_dict)
 
 
 def in_toto_run(name, material_list, product_list,

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -125,7 +125,7 @@ def run_all_inspections(layout):
     # We could use matchrule paths.
     material_list = product_list = ["."]
     link = in_toto.runlib.in_toto_run(inspection.name, material_list,
-        product_list, inspection.run.split())
+        product_list, inspection.run)
 
     _raise_on_bad_retval(link.return_value, inspection.run)
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -313,7 +313,7 @@ def verify_all_steps_command_alignment(layout, chain_link_dict):
   """
   for step in layout.steps:
     # Find the according link for this step
-    expected_command = step.expected_command.split()
+    expected_command = step.expected_command
     key_link_dict = chain_link_dict[step.name]
 
     # FIXME: I think we could do this for one link per step only

--- a/test/models/test_inspection.py
+++ b/test/models/test_inspection.py
@@ -95,7 +95,7 @@ class TestInspectionValidator(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.inspection.validate()
 
-    self.inspection.run = "somecommand"
+    self.inspection.run = ["somecommand"]
     self.inspection._validate_run()
     self.inspection.validate()
 

--- a/test/models/test_step.py
+++ b/test/models/test_step.py
@@ -131,7 +131,7 @@ class TestStepValidator(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.step.validate()
 
-    self.step.expected_command = "somecommand"
+    self.step.expected_command = ["somecommand"]
     self.step._validate_expected_command()
     self.step.validate()
 

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -928,7 +928,7 @@ class TestInTotoVerify(unittest.TestCase):
 
     # dump layout with failing inspection retval
     layout = copy.deepcopy(layout_template)
-    layout.inspect[0].run = "expr 1 / 0"
+    layout.inspect[0].run = ["expr",  "1", "/", "0"]
     layout.sign(alice)
     layout.dump(self.layout_failing_inspection_retval)
 
@@ -978,8 +978,8 @@ class TestInTotoVerify(unittest.TestCase):
     os.rename("package.2dc02526.link", "package.link.bak")
     with self.assertRaises(in_toto.exceptions.LinkNotFoundError):
       in_toto_verify(self.layout_single_signed_path, [self.alice_path])
-    os.rename("package.link.bak", "package.2dc02526.link") 
-  
+    os.rename("package.link.bak", "package.2dc02526.link")
+
   def test_verify_failing_inspection_exits_non_zero(self):
     """Test fail verification with inspection returning non-zero. """
     with self.assertRaises(BadReturnValueError):


### PR DESCRIPTION
This commit modifies the metadata format so that commands are always stored as list (empty list, if no command provided). Which fixes a warnings like: ```WARNING: Run command '' differs from expected command '[]'```

Changed metadata fields were: `Step.expected_command`, `Link.command` and `Inspection.run`. In case a command is supplied.

The metadata creation "factory" (`read`, `create_link_metadata`) functions still accept non-lists as input, but turn them into lists using `shlex.split` for shell like syntax.

The logic in the metadata creation functions will be moved to the respective constructors at some point, c.f. https://github.com/in-toto/in-toto/issues/36.

