### PR TITLE
Add constructors with default attribute assignments (fix #36)

### DIFF
--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -68,12 +68,16 @@ class Metablock(object):
         if method[0].startswith("_validate_"):
           method[1]()
 
-@attr.s(repr=False)
+@attr.s(repr=False, init=False)
 class Signable(Metablock):
   """Objects with base class Signable can sign their payload (a canonical
   pretty printed JSON string not containing the signatures attribute) and store
   the signature (signature format: securesystemslib.formats.SIGNATURE_SCHEMA) """
-  signatures = attr.ib(default=attr.Factory(list))
+  signatures = attr.ib()
+
+  def __init__(self, **kwargs):
+    super(Signable, self).__init__()
+    self.signatures =  kwargs.get("signatures", [])
 
   @property
   def payload(self):

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -47,7 +47,7 @@ import securesystemslib.formats
 # import validators
 from . import common as models__common
 from . import link as models__link
-@attr.s(repr=False)
+@attr.s(repr=False, init=False)
 class Layout(models__common.Signable):
   """
   The layout specifies each of the different steps and the requirements for
@@ -78,13 +78,22 @@ class Layout(models__common.Signable):
     expires:
         the expiration date of a layout
   """
+  _type = attr.ib()
+  steps = attr.ib()
+  inspect = attr.ib()
+  keys = attr.ib()
+  expires = attr.ib()
 
-  _type = attr.ib("layout", init=False)
-  steps = attr.ib(default=attr.Factory(list))
-  inspect = attr.ib(default=attr.Factory(list))
-  keys = attr.ib(default=attr.Factory(dict))
-  expires = attr.ib("")
+  def __init__(self, **kwargs):
+    super(Layout, self).__init__(**kwargs)
+    self._type = "layout"
+    self.steps = kwargs.get("steps", [])
+    self.inspect = kwargs.get("inspect", [])
+    self.keys = kwargs.get("keys", {})
 
+    # Assign a default expiration (on month) if not specified
+    self.expires = kwargs.get("expires", (datetime.today() +
+        relativedelta(months=1)).isoformat() + 'Z')
 
   def dump(self, filename='root.layout'):
     """Write pretty printed JSON represented of self to a file with filename.
@@ -103,23 +112,17 @@ class Layout(models__common.Signable):
   @staticmethod
   def read(data):
     """Static method to instantiate a new Layout from a Python dictionary """
-    layout = Layout()
-    tmp_steps = []
-    tmp_inspect = []
-
+    steps = []
     for step_data in data.get("steps"):
-      tmp_steps.append(Step.read(step_data))
+      steps.append(Step.read(step_data))
+    data["steps"] = steps
+
+    inspections = []
     for inspect_data in data.get("inspect"):
-      tmp_inspect.append(Inspection.read(inspect_data))
+      inspections.append(Inspection.read(inspect_data))
+    data["inspect"] = inspections
 
-    expires = data.get("expires")
-    if not expires:
-      # Set a month from now with Zulu offset as expiration date default
-      expires = (datetime.today() + relativedelta(months=1)).isoformat() + 'Z'
-
-    return Layout(steps=tmp_steps, inspect=tmp_inspect,
-        keys=data.get("keys"), expires=expires,
-        signatures=data.get("signatures"))
+    return Layout(**data)
 
   def import_step_metadata_from_files_as_dict(self):
     """
@@ -224,7 +227,7 @@ class Layout(models__common.Signable):
             "There is a repeated name in the steps! {}".format(inspection.name))
       names_seen.add(inspection.name)
 
-@attr.s(repr=False)
+@attr.s(repr=False, init=False)
 class Step(models__common.Metablock):
   """
   Represents a step of the supply chain performed by a functionary.
@@ -250,34 +253,38 @@ class Step(models__common.Metablock):
         the least number of functionaries expected to perform this step
 
   """
-  _type = attr.ib("step", init=False)
+  _type = attr.ib()
   name = attr.ib()
-  material_matchrules = attr.ib(default=attr.Factory(list))
-  product_matchrules = attr.ib(default=attr.Factory(list))
-  pubkeys = attr.ib(default=attr.Factory(list))
-  expected_command = attr.ib(default=attr.Factory(list))
-  threshold = attr.ib(default=1)
+  material_matchrules = attr.ib()
+  product_matchrules = attr.ib()
+  pubkeys = attr.ib()
+  expected_command = attr.ib()
+  threshold = attr.ib()
+
+  def __init__(self, **kwargs):
+    super(Step, self).__init__()
+    self._type = "step"
+    self.name = kwargs.get("name")
+    self.material_matchrules = kwargs.get("material_matchrules", [])
+    self.product_matchrules = kwargs.get("product_matchrules", [])
+    self.pubkeys = kwargs.get("pubkeys", [])
+
+    # Accept expected command as string or list, if it is a string we split it
+    # using shell like syntax.
+    self.expected_command = kwargs.get("expected_command")
+    if self.expected_command:
+      if not isinstance(self.expected_command, list):
+        self.expected_command = shlex.split(self.expected_command)
+
+    else:
+      self.expected_command = []
+
+    self.threshold = kwargs.get("threshold", 1)
 
 
   @staticmethod
   def read(data):
-    # Accept expected command as string or list, if it is a string we split it using
-    # shell like syntax.
-    data_expected_cmd = data.get("expected_command")
-    if data_expected_cmd:
-      if not isinstance(data_expected_cmd, list):
-        data_expected_cmd = shlex.split(data_expected_cmd)
-
-    else:
-      data_expected_cmd = []
-
-    return Step(name=data.get("name"),
-        material_matchrules=data.get("material_matchrules"),
-        product_matchrules=data.get("product_matchrules"),
-        pubkeys=data.get("pubkeys"),
-        expected_command=data_expected_cmd,
-        threshold=data.get("threshold"))
-
+    return Step(**data)
 
   def _validate_type(self):
     """Private method to ensure that the type field is set to step."""
@@ -325,7 +332,9 @@ class Step(models__common.Metablock):
       raise securesystemslib.exceptions.FormatError(
           "The expected command field is malformed!")
 
-@attr.s(repr=False)
+
+
+@attr.s(repr=False, init=False)
 class Inspection(models__common.Metablock):
   """
   Represents an inspection which performs a command during layout verification.
@@ -343,29 +352,33 @@ class Inspection(models__common.Metablock):
         the command to execute during layout verification
 
   """
-
-  _type = attr.ib("inspection", init=False)
+  _type = attr.ib()
   name = attr.ib()
-  material_matchrules = attr.ib(default=attr.Factory(list))
-  product_matchrules = attr.ib(default=attr.Factory(list))
-  run = attr.ib(default=attr.Factory(list))
+  material_matchrules = attr.ib()
+  product_matchrules = attr.ib()
+  run = attr.ib()
+
+  def __init__(self, **kwargs):
+    super(Inspection, self).__init__()
+
+    self._type = "inspection"
+    self.name = kwargs.get("name")
+    self.material_matchrules = kwargs.get("material_matchrules", [])
+    self.product_matchrules = kwargs.get("product_matchrules", [])
+
+    # Accept run command as string or list, if it is a string we split it
+    # using shell like syntax.
+    self.run = kwargs.get("run")
+    if self.run:
+      if not isinstance(self.run, list):
+        self.run = shlex.split(self.run)
+    else:
+      self.run = []
 
 
   @staticmethod
   def read(data):
-    # Accept run as string or list, if it is a string we split it using
-    # shell like syntax.
-    data_run = data.get("run")
-    if data_run:
-      if not isinstance(data_run, list):
-        data_run = shlex.split(data_run)
-
-    else:
-      data_run = []
-
-    return Inspection(name=data.get("name"), run=data_run,
-        material_matchrules=data.get("material_matchrules"),
-        product_matchrules=data.get("product_matchrules"))
+    return Inspection(**data)
 
   def _validate_type(self):
     """Private method to ensure that the type field is set to inspection."""

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -93,7 +93,9 @@ class Layout(models__common.Signable):
 
     # Assign a default expiration (on month) if not specified
     self.expires = kwargs.get("expires", (datetime.today() +
-        relativedelta(months=1)).isoformat() + 'Z')
+        relativedelta(months=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    self.validate()
 
   def dump(self, filename='root.layout'):
     """Write pretty printed JSON represented of self to a file with filename.
@@ -281,6 +283,7 @@ class Step(models__common.Metablock):
 
     self.threshold = kwargs.get("threshold", 1)
 
+    self.validate()
 
   @staticmethod
   def read(data):
@@ -375,6 +378,7 @@ class Inspection(models__common.Metablock):
     else:
       self.run = []
 
+    self.validate()
 
   @staticmethod
   def read(data):

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -26,7 +26,7 @@ import securesystemslib.formats
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
 UNFINISHED_FILENAME_FORMAT = ".{step_name}.{keyid:.8}.link-unfinished"
 
-@attr.s(repr=False)
+@attr.s(repr=False, init=False)
 class Link(models__common.Signable):
   """
   A link is the metadata representation of a supply chain step performed
@@ -60,14 +60,25 @@ class Link(models__common.Signable):
     return_value:
         the return value of the executed command
    """
+  _type = attr.ib()
+  name = attr.ib()
+  materials = attr.ib()
+  products = attr.ib()
+  byproducts = attr.ib()
+  command = attr.ib()
+  return_value = attr.ib()
 
-  _type = attr.ib("Link", init=False)
-  name = attr.ib("")
-  materials = attr.ib(default=attr.Factory(dict))
-  products = attr.ib(default=attr.Factory(dict))
-  byproducts = attr.ib(default=attr.Factory(dict))
-  command = attr.ib(default=attr.Factory(list))
-  return_value = attr.ib(None)
+  def __init__(self, **kwargs):
+    super(Link, self).__init__(**kwargs)
+
+    self._type = "Link"
+    self.name = kwargs.get("name")
+    self.materials = kwargs.get("materials", {})
+    self.products = kwargs.get("products", {})
+    self.byproducts = kwargs.get("byproducts", {})
+    self.command = kwargs.get("command", [])
+    self.return_value = kwargs.get("return_value", None)
+
 
   def dump(self, filename=False, key=False):
     """Write pretty printed JSON represented of self to a file with filename.
@@ -97,8 +108,4 @@ class Link(models__common.Signable):
   @staticmethod
   def read(data):
     """Static method to instantiate a new Link from a Python dictionary """
-    # XXX LP: ugly workaround for attrs underscore strip
-    # but _type is exempted from __init__ anyway
-    if data.get("_type"):
-      data.pop(u"_type")
     return Link(**data)

--- a/test/models/test_inspection.py
+++ b/test/models/test_inspection.py
@@ -26,7 +26,7 @@ class TestInspectionValidator(unittest.TestCase):
 
   def setUp(self):
     """Populate a base layout that we can use."""
-    self.inspection = Inspection("some-inspection")
+    self.inspection = Inspection(name="some-inspection")
 
   def test_wrong_type(self):
     """Test the type field within Validate()."""

--- a/test/models/test_layout.py
+++ b/test/models/test_layout.py
@@ -108,14 +108,14 @@ class TestLayoutValidator(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
-    test_step = Step("this-is-a-step")
+    test_step = Step(name="this-is-a-step")
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       test_step.material_matchrules = ['this is a malformed step']
       self.layout.steps = [test_step]
       self.layout.validate()
 
 
-    test_step = Step("this-is-a-step")
+    test_step = Step(name="this-is-a-step")
     test_step.material_matchrules = [["CREATE", "foo"]]
     test_step.threshold = 1
     self.layout.steps = [test_step]
@@ -128,13 +128,13 @@ class TestLayoutValidator(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
-    test_inspection = Inspection("this-is-a-step")
+    test_inspection = Inspection(name="this-is-a-step")
     test_inspection.material_matchrules = ['this is a malformed matchrule']
     self.layout.inspect = [test_inspection]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
-    test_inspection = Inspection("this-is-a-step")
+    test_inspection = Inspection(name="this-is-a-step")
     test_inspection.material_matchrules = [["CREATE", "foo"]]
     self.layout.inspect = [test_inspection]
     self.layout.validate()
@@ -142,17 +142,17 @@ class TestLayoutValidator(unittest.TestCase):
   def test_repeated_step_names(self):
     """Check that only unique names exist in the steps and inspect lists"""
 
-    self.layout.steps = [Step("name"), Step("name")]
+    self.layout.steps = [Step(name="name"), Step(name="name")]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
-    self.layout.steps = [Step("name")]
-    self.layout.inspect = [Inspection("name")]
+    self.layout.steps = [Step(name="name")]
+    self.layout.inspect = [Inspection(name="name")]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
-    self.layout.step = [Step("name"), Step("othername")]
-    self.layout.inspect = [Inspection("thirdname")]
+    self.layout.step = [Step(name="name"), Step(name="othername")]
+    self.layout.inspect = [Inspection(name="thirdname")]
     self.layout.validate()
 
 if __name__ == '__main__':

--- a/test/models/test_step.py
+++ b/test/models/test_step.py
@@ -28,7 +28,7 @@ class TestStepValidator(unittest.TestCase):
 
   def setUp(self):
     """Populate a base layout that we can use."""
-    self.step = Step("this-step")
+    self.step = Step(name="this-step")
 
   def test_wrong_type(self):
     """Test the type field within Validate()."""

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -907,8 +907,8 @@ class TestInTotoVerify(unittest.TestCase):
 
     # dump expired layout
     layout = copy.deepcopy(layout_template)
-    layout.expires = (datetime.today()
-       + relativedelta(months=-1)).isoformat() + "Z"
+    layout.expires = (datetime.today() +
+        relativedelta(months=-1)).strftime("%Y-%m-%dT%H:%M:%SZ")
     layout.sign(alice)
     layout.dump(self.layout_expired_path)
 


### PR DESCRIPTION
This PR adds a constructor to `Signable`, `Layout`, `Step`,`Inspection` and `Link` and moves the default attribute logic from the `read` methods to the constructors.
Note: The constructors henceforth only accept keyword arguments.

Additionally, it adds model validation to the constructors of `Layout`, `Step` and `Inspection`, which guarantees that no objects of above classes are created with malformed attributes.

*Background:*
The in-toto metadata classes used to perform some default attribute assignments in their static `read` methods, i.e. methods that create the respective object from a passed Python
dictionary using the auto-constructors from the `attr` module.

The following default assignments are performed:
- Default expiration date (1 month)
- Default empty data structures, if a value was not passed
- `shlex`-splitting Step commands (`expected_command`) and Inspection commands (`run`) if passed as String

This lead to inconsistencies between objects created using `read` and objects created the default constructors.

This PR also fixes a bug in the default expiration date format (i.e. removes milliseconds from the date string).

Fixes https://github.com/in-toto/in-toto/issues/36