### PR TITLE
Add in_toto_mock

### DIFF
--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -15,7 +15,8 @@
 <Purpose>
   Stripped down variant of in-toto-run command that can be used to mock metadata
   generation of in-toto-run, without the need to specify a key and knowing all
-  the command line arguments.
+  the command line arguments. Generated MockLink is unsigned and includes working
+  directory, byproducts and used current directory as material and products.
 
   Provides a command line interface which takes any link command of the software
   supply chain as input and generates mock in_toto metadata.
@@ -36,20 +37,16 @@ import os
 import sys
 import argparse
 from in_toto import (util, runlib, log)
-from in_toto.models.link import Link
-from in_toto.models.link import MOCK_FILENAME_FORMAT
 
 def in_toto_mock(name, link_cmd_args):
   """
   <Purpose>
-    Calls runlib.in_toto_run with current directory as material_list and
-    product_list. Without signing key and record_byproducts as True.
-    Writes the returned link to disk. And catches exceptions.
+    Calls runlib.in_toto_mock with name and link_cmd_args.
 
   <Arguments>
     name:
-            A unique name to relate link metadata with a step defined in the
-            layout.
+            A unique name to relate mock link metadata with a step defined
+            in the layout.
     link_cmd_args:
             A list where the first element is a command and the remaining
             elements are arguments passed to that command.
@@ -58,7 +55,6 @@ def in_toto_mock(name, link_cmd_args):
     SystemExit if any exception occurs
 
   <Side Effects>
-    Writes newly created mock link metadata file to disk "<name>.link-mock"
     Calls sys.exit(1) if an exception is raised
 
   <Returns>
@@ -66,12 +62,7 @@ def in_toto_mock(name, link_cmd_args):
   """
 
   try:
-    mock_link = runlib.in_toto_run(name, material_list=['.'],
-        product_list=['.'], link_cmd_args=link_cmd_args, record_byproducts=True)
-    mock_fn = MOCK_FILENAME_FORMAT.format(step_name=name)
-    log.info("Storing mock link metadata to '{}'...".format(mock_fn))
-    mock_link.dump(filename=mock_fn)
-
+    runlib.in_toto_mock(name, link_cmd_args)
   except Exception as e:
     log.error("in toto mock - {}".format(e))
     sys.exit(1)

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -27,8 +27,7 @@
 
   Example Usage
   ```
-  in-toto-mock --name write-code --materials . --products . --by-products \
-      -- touch foo.py
+  in-toto-mock --name write-code -- touch foo.py
   ```
 
 """
@@ -40,50 +39,39 @@ from in_toto import (util, runlib, log)
 from in_toto.models.link import Link
 from in_toto.models.link import MOCK_FILENAME_FORMAT
 
-def in_toto_mock(name, material_list, product_list, link_cmd_args,
-    record_byproducts):
+def in_toto_mock(name, link_cmd_args):
   """
   <Purpose>
-    Calls runlib.in_toto_run without signing key and writes the returned link
-    to disk. And catches exceptions.
+    Calls runlib.in_toto_run with current directory as material_list and
+    product_list. Without signing key and record_byproducts as True.
+    Writes the returned link to disk. And catches exceptions.
 
   <Arguments>
     name:
             A unique name to relate link metadata with a step defined in the
             layout.
-    material_list:
-            List of file or directory paths that should be recorded as
-            materials.
-    product_list:
-            List of file or directory paths that should be recorded as
-            products.
     link_cmd_args:
             A list where the first element is a command and the remaining
             elements are arguments passed to that command.
-    record_byproducts:
-            A bool that specifies whether to redirect standard output and
-            and standard error to a temporary file which is returned to the
-            caller (True) or not (False).
 
   <Exceptions>
     SystemExit if any exception occurs
 
   <Side Effects>
+    Writes newly created mock link metadata file to disk "<name>.link-mock"
     Calls sys.exit(1) if an exception is raised
 
   <Returns>
     None.
   """
 
-  """Runs passed command, storing its materials, products and by-products into
-  mock link metadata file. The mock link metadata file is stored to disk. """
-
   try:
-    mock_link = runlib.in_toto_run(name, material_list, product_list,
-        link_cmd_args, key=False, record_byproducts=record_byproducts)
+    mock_link = runlib.in_toto_run(name, material_list=['.'],
+        product_list=['.'], link_cmd_args=link_cmd_args, record_byproducts=True)
     mock_fn = MOCK_FILENAME_FORMAT.format(step_name=name)
     log.info("Storing mock link metadata to '{}'...".format(mock_fn))
     mock_link.dump(filename=mock_fn)
+
   except Exception as e:
     log.error("in toto mock - {}".format(e))
     sys.exit(1)
@@ -98,10 +86,7 @@ def main():
 
   parser.usage = ("\n"
       "%(prog)s  --name <unique step name>\n{0}"
-               "[--materials <filepath>[ <filepath> ...]]\n{0}"
-               "[--products <filepath>[ <filepath> ...]]\n{0}"
-               "[--record-byproducts]\n{0}"
-               "[--verbose] -- <cmd> [args]\n\n"
+               " -- <cmd> [args]\n\n"
                .format(lpad))
 
   in_toto_args = parser.add_argument_group("in-toto options")
@@ -109,19 +94,6 @@ def main():
   # FIXME: Do we limit the allowed characters for the name?
   in_toto_args.add_argument("-n", "--name", type=str, required=True,
       help="Unique name for link metadata")
-
-  in_toto_args.add_argument("-m", "--materials", type=str, required=False,
-      nargs='+', help="Files to record before link command execution")
-
-  in_toto_args.add_argument("-p", "--products", type=str, required=False,
-      nargs='+', help="Files to record after link command execution")
-
-  in_toto_args.add_argument("-b", "--record-byproducts",
-      help="If set redirects stdout/stderr and stores to link metadata",
-      dest="record_byproducts", default=False, action="store_true")
-
-  in_toto_args.add_argument("-v", "--verbose", dest="verbose",
-      help="Verbose execution.", default=False, action="store_true")
 
   # FIXME: This is not yet ideal.
   # What should we do with tokens like > or ; ?
@@ -131,11 +103,9 @@ def main():
   args = parser.parse_args()
 
   # Turn on all the `log.info()` in the library
-  if args.verbose:
-    log.logging.getLogger().setLevel(log.logging.INFO)
+  log.logging.getLogger().setLevel(log.logging.INFO)
 
-  in_toto_mock(args.name, args.materials, args.products,
-      args.link_cmd, args.record_byproducts)
+  in_toto_mock(args.name, args.link_cmd)
 
 if __name__ == "__main__":
   main()

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  in_toto_mock.py
+
+<Author>
+  Shikher Verma <root@shikherverma.com>
+
+<Started>
+  June 12, 2017
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Stripped down variant of in-toto-run command that can be used to mock metadata
+  generation of in-toto-run, without the need to specify a key and knowing all
+  the command line arguments.
+
+  Provides a command line interface which takes any link command of the software
+  supply chain as input and generates mock in_toto metadata.
+
+  in_toto_mock options are separated from the command to be executed by
+  a double dash.
+
+  The implementation of the tasks can be found in runlib.
+
+  Example Usage
+  ```
+  in-toto-mock --name write-code --materials . --products . --by-products \
+      -- touch foo.py
+  ```
+
+"""
+
+import os
+import sys
+import argparse
+from in_toto import (util, runlib, log)
+from in_toto.models.link import Link
+from in_toto.models.link import MOCK_FILENAME_FORMAT
+
+def in_toto_mock(name, material_list, product_list, link_cmd_args,
+    record_byproducts):
+  """
+  <Purpose>
+    Calls runlib.in_toto_run without signing key and writes the returned link
+    to disk. And catches exceptions.
+
+  <Arguments>
+    name:
+            A unique name to relate link metadata with a step defined in the
+            layout.
+    material_list:
+            List of file or directory paths that should be recorded as
+            materials.
+    product_list:
+            List of file or directory paths that should be recorded as
+            products.
+    link_cmd_args:
+            A list where the first element is a command and the remaining
+            elements are arguments passed to that command.
+    record_byproducts:
+            A bool that specifies whether to redirect standard output and
+            and standard error to a temporary file which is returned to the
+            caller (True) or not (False).
+
+  <Exceptions>
+    SystemExit if any exception occurs
+
+  <Side Effects>
+    Calls sys.exit(1) if an exception is raised
+
+  <Returns>
+    None.
+  """
+
+  """Runs passed command, storing its materials, products and by-products into
+  mock link metadata file. The mock link metadata file is stored to disk. """
+
+  try:
+    mock_link = runlib.in_toto_run(name, material_list, product_list,
+        link_cmd_args, key=False, record_byproducts=record_byproducts)
+    mock_fn = MOCK_FILENAME_FORMAT.format(step_name=name)
+    log.info("Storing mock link metadata to '{}'...".format(mock_fn))
+    mock_link.dump(filename=mock_fn)
+  except Exception as e:
+    log.error("in toto mock - {}".format(e))
+    sys.exit(1)
+
+def main():
+  """Parse arguments and call in_toto_mock. """
+
+  parser = argparse.ArgumentParser(
+      description="Executes link command and records metadata")
+  # Whitespace padding to align with program name
+  lpad = (len(parser.prog) + 1) * " "
+
+  parser.usage = ("\n"
+      "%(prog)s  --name <unique step name>\n{0}"
+               "[--materials <filepath>[ <filepath> ...]]\n{0}"
+               "[--products <filepath>[ <filepath> ...]]\n{0}"
+               "[--record-byproducts]\n{0}"
+               "[--verbose] -- <cmd> [args]\n\n"
+               .format(lpad))
+
+  in_toto_args = parser.add_argument_group("in-toto options")
+
+  # FIXME: Do we limit the allowed characters for the name?
+  in_toto_args.add_argument("-n", "--name", type=str, required=True,
+      help="Unique name for link metadata")
+
+  in_toto_args.add_argument("-m", "--materials", type=str, required=False,
+      nargs='+', help="Files to record before link command execution")
+
+  in_toto_args.add_argument("-p", "--products", type=str, required=False,
+      nargs='+', help="Files to record after link command execution")
+
+  in_toto_args.add_argument("-b", "--record-byproducts",
+      help="If set redirects stdout/stderr and stores to link metadata",
+      dest="record_byproducts", default=False, action="store_true")
+
+  in_toto_args.add_argument("-v", "--verbose", dest="verbose",
+      help="Verbose execution.", default=False, action="store_true")
+
+  # FIXME: This is not yet ideal.
+  # What should we do with tokens like > or ; ?
+  in_toto_args.add_argument("link_cmd", nargs="+",
+    help="Link command to be executed with options and arguments")
+
+  args = parser.parse_args()
+
+  # Turn on all the `log.info()` in the library
+  if args.verbose:
+    log.logging.getLogger().setLevel(log.logging.INFO)
+
+  in_toto_mock(args.name, args.materials, args.products,
+      args.link_cmd, args.record_byproducts)
+
+if __name__ == "__main__":
+  main()

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -45,8 +45,8 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 
 # import validators
-from . import common as models__common
-from . import link as models__link
+import in_toto.models.common as models__common
+import in_toto.models.link as models__link
 @attr.s(repr=False, init=False)
 class Layout(models__common.Signable):
   """

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -6,7 +6,6 @@
 <Author>
   Lukas Puehringer <lukas.puehringer@nyu.edu>
   Santiago Torres <santiago@nyu.edu>
-  Shikher Verma <root@shikherverma.com>
 
 <Started>
   Sep 23, 2016
@@ -21,12 +20,11 @@
 
 import attr
 import json
-from . import common as models__common
+import in_toto.models.common as models__common
 import securesystemslib.formats
 
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
 UNFINISHED_FILENAME_FORMAT = ".{step_name}.{keyid:.8}.link-unfinished"
-MOCK_FILENAME_FORMAT = "{step_name}.link-mock"
 
 @attr.s(repr=False, init=False)
 class Link(models__common.Signable):

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -6,6 +6,7 @@
 <Author>
   Lukas Puehringer <lukas.puehringer@nyu.edu>
   Santiago Torres <santiago@nyu.edu>
+  Shikher Verma <root@shikherverma.com>
 
 <Started>
   Sep 23, 2016
@@ -25,6 +26,7 @@ import securesystemslib.formats
 
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
 UNFINISHED_FILENAME_FORMAT = ".{step_name}.{keyid:.8}.link-unfinished"
+MOCK_FILENAME_FORMAT = "{step_name}.link-mock"
 
 @attr.s(repr=False, init=False)
 class Link(models__common.Signable):

--- a/in_toto/models/mock_link.py
+++ b/in_toto/models/mock_link.py
@@ -14,7 +14,9 @@
 
 <Purpose>
   Provides a class for mock link metadata which is information gathered when a
-  step of the supply chain is run as mock.
+  step of the supply chain is run as mock. A separate MockLink class is needed
+  because it also records current working directory which is not recorded in
+  Link class.
 """
 
 import attr
@@ -51,7 +53,7 @@ class MockLink(link.Link):
 
   def dump(self):
     """
-    Write pretty printed JSON represented of self to a file. with filename.
+    Write pretty printed JSON represented of self to a file with filename.
     A filename will be created using the link name + '.link-mock'-suffix
     """
     fn = MOCK_FILENAME_FORMAT.format(step_name=self.name)

--- a/in_toto/models/mock_link.py
+++ b/in_toto/models/mock_link.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  mock_link.py
+
+<Author>
+  Shikher Verma <root@shikherverma.com>
+
+<Started>
+  June, 2017
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides a class for mock link metadata which is information gathered when a
+  step of the supply chain is run as mock.
+"""
+
+import attr
+import json
+import in_toto.models.link as link
+import securesystemslib.formats
+
+MOCK_FILENAME_FORMAT = "{step_name}.link-mock"
+
+@attr.s(repr=False, init=False)
+class MockLink(link.Link):
+  """
+  A mock link is the metadata representation of a supply chain step mocked
+  by a functionary.
+
+  Mock links are recorded and stored to a file when a functionary
+  wraps a command with in_toto_mock.
+
+  Mock links also contain materials and products which are hashes of
+  the file before the command was executed and after the command was executed.
+
+  <Attributes>
+    working_directory:
+        the path of the directory where the command was executed
+   """
+  working_directory = attr.ib()
+
+  def __init__(self, **kwargs):
+    super(MockLink, self).__init__(**kwargs)
+
+    self._type = "MockLink"
+    self.working_directory = kwargs.get("working_directory", None)
+
+
+  def dump(self):
+    """
+    Write pretty printed JSON represented of self to a file. with filename.
+    A filename will be created using the link name + '.link-mock'-suffix
+    """
+    fn = MOCK_FILENAME_FORMAT.format(step_name=self.name)
+    super(MockLink, self).dump(fn)
+
+  @staticmethod
+  def read(data):
+    """Static method to instantiate a new MockLink from a Python dictionary """
+    return MockLink(**data)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -312,6 +312,7 @@ def in_toto_mock(name, link_cmd_args):
   mock_link = in_toto.models.mock_link.MockLink(name=name, materials=materials_dict,
     products=products_dict, command=link_cmd_args, byproducts=byproducts,
     return_value=return_value, working_directory=os.getcwd())
+
   mock_fn = MOCK_FILENAME_FORMAT.format(step_name=name)
   log.info("Storing mock link metadata to '{}'...".format(mock_fn))
   mock_link.dump()

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -266,67 +266,6 @@ def execute_link(link_cmd_args, record_byproducts):
 
   return {"stdout": stdout_str, "stderr": stderr_str}, return_value
 
-def create_link_metadata(link_name, materials_dict=None, products_dict=None,
-    link_cmd_args=None, byproducts=None, return_value=None):
-  """
-  <Purpose>
-    Takes the state of the materials (before link command execution), the state
-    of the products (after link command execution) and the by-products and
-    return value of the link command execution and creates and returns a
-    Link metadata object.
-
-  <Arguments>
-    link_name:
-            A unique name to relate link metadata with a step defined in the
-            layout.
-    materials_dict: (optional)
-            A dictionary with file paths as keys and the files' hashes as
-            values.
-    products_dict: (optional)
-            A dictionary with file paths as keys and the files' hashes as
-            values.
-    link_cmd_args: (optional)
-            A list where the first element is a command and the remaining
-            elements are arguments passed to that command.
-    byproducts: (optional)
-            A dictionary in the format containing standard output and standard
-            error of the executed link command, i.e.:
-            {"stdout": "<standard output", "stderr": "<standard error>"}
-    return_value: (optional)
-            The return value of the executed command.
-
-  <Exceptions>
-    None.
-
-  <Side Effects>
-    Creates a Link object from a Python dictionary.
-
-  <Returns>
-    - A Link metadata object
-  """
-  if not materials_dict:
-    materials_dict = {}
-
-  if not products_dict:
-    products_dict = {}
-
-  if not link_cmd_args:
-    link_cmd_args = []
-
-  if not byproducts:
-    byproducts = {}
-
-  link_dict = {
-    "name" : link_name,
-    "materials" : materials_dict,
-    "products" : products_dict,
-    "command" : link_cmd_args,
-    "byproducts" : byproducts,
-    "return_value" : return_value
-  }
-
-  return in_toto.models.link.Link.read(link_dict)
-
 
 def in_toto_mock(name, link_cmd_args):
   """
@@ -370,18 +309,9 @@ def in_toto_mock(name, link_cmd_args):
   products_dict = record_artifacts_as_dict(product_list)
 
   log.info("Creating mock link metadata...")
-
-  mock_link_dict = {
-    "name" : name,
-    "materials" : materials_dict,
-    "products" : products_dict,
-    "command" : link_cmd_args,
-    "byproducts" : byproducts,
-    "return_value" : return_value,
-    "working_directory" : os.getcwd()
-  }
-
-  mock_link = in_toto.models.mock_link.MockLink.read(mock_link_dict)
+  mock_link = in_toto.models.mock_link.MockLink(name=name, materials=materials_dict,
+    products=products_dict, command=link_cmd_args, byproducts=byproducts,
+    return_value=return_value, working_directory=os.getcwd())
   mock_fn = MOCK_FILENAME_FORMAT.format(step_name=name)
   log.info("Storing mock link metadata to '{}'...".format(mock_fn))
   mock_link.dump()
@@ -451,8 +381,9 @@ def in_toto_run(name, material_list, product_list,
   products_dict = record_artifacts_as_dict(product_list)
 
   log.info("Creating link metadata...")
-  link = create_link_metadata(name, materials_dict, products_dict,
-      link_cmd_args, byproducts, return_value)
+  link = in_toto.models.link.Link(name=name, materials=materials_dict,
+    products=products_dict, command=link_cmd_args, byproducts=byproducts,
+    return_value=return_value)
 
   if key:
     log.info("Signing link metadata with key '{:.8}...'...".format(key["keyid"]))
@@ -502,7 +433,8 @@ def in_toto_record_start(step_name, key, material_list):
   materials_dict = record_artifacts_as_dict(material_list)
 
   log.info("Creating preliminary link metadata...")
-  link = create_link_metadata(step_name, materials_dict)
+  link = in_toto.models.link.Link(name=step_name, materials=materials_dict,
+    products={}, command=[], byproducts={}, return_value=None)
 
   log.info("Signing link metadata with key '{:.8}...'...".format(key["keyid"]))
   link.sign(key)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
   test_suite="test.runtests",
   entry_points={
     "console_scripts": ["in-toto-run = in_toto.in_toto_run:main",
+                        "in-toto-mock = in_toto.in_toto_mock:main",
                         "in-toto-record = in_toto.in_toto_record:main",
                         "in-toto-verify = in_toto.in_toto_verify:main"]
   },

--- a/test/test_in_toto_mock.py
+++ b/test/test_in_toto_mock.py
@@ -75,18 +75,6 @@ class TestInTotoMockTool(unittest.TestCase):
 
     self.assertTrue(os.path.exists(self.test_link))
 
-  def test_main_optional_args(self):
-    """Test CLI command with optional arguments. """
-
-    args = [ "in_toto_mock.py", "--name", self.test_step, "--materials",
-        self.test_artifact, "--products", self.test_artifact,
-        "--record-byproducts", "--", "echo", "test"]
-
-    with patch.object(sys, 'argv', args):
-      in_toto_mock_main()
-
-    self.assertTrue(os.path.exists(self.test_link))
-
   def test_main_wrong_args(self):
     """Test CLI command with missing arguments. """
 
@@ -101,29 +89,16 @@ class TestInTotoMockTool(unittest.TestCase):
         in_toto_mock_main()
       self.assertFalse(os.path.exists(self.test_link))
 
-  def test_main_verbose(self):
-    """Log level with verbose flag is lesser/equal than logging.INFO. """
-
-    args = [ "in_toto_mock.py", "--name", self.test_step, "--materials",
-        self.test_artifact, "--products",
-        self.test_artifact, "--record-byproducts", "--verbose",
-        "--", "echo", "test"]
-
-    original_log_level = logging.getLogger().getEffectiveLevel()
-    with patch.object(sys, 'argv', args ):
-      in_toto_mock_main()
-    self.assertTrue(os.path.exists(self.test_link))
-
-    self.assertLessEqual(logging.getLogger().getEffectiveLevel(), logging.INFO)
-    # Reset log level
-    logging.getLogger().setLevel(original_log_level)
-
   def test_successful_in_toto_mock(self):
     """Call in_toto_mock successfully """
-    in_toto_mock(self.test_step, [self.test_artifact],
-      [self.test_artifact], ["echo", "test"], True)
+    in_toto_mock(self.test_step, ["echo", "test"])
 
     self.assertTrue(os.path.exists(self.test_link))
+
+  def test_in_toto_run_bad_command_exit(self):
+    """Error exit in_toto_mock for bad command. """
+    with self.assertRaises(SystemExit):
+      in_toto_mock(self.test_step, ["exit", "1"])
 
 if __name__ == "__main__":
   unittest.main(buffer=True)

--- a/test/test_in_toto_mock.py
+++ b/test/test_in_toto_mock.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_in_toto_mock.py
+
+<Author>
+  Shikher Verma <root@shikherverma.com>
+
+<Started>
+  June 12, 2017
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test in_toto_mock command line tool.
+
+"""
+
+import os
+import sys
+import unittest
+import logging
+import argparse
+import shutil
+import tempfile
+from mock import patch
+
+from in_toto.models.link import Link
+from in_toto.in_toto_mock import main as in_toto_mock_main
+from in_toto.in_toto_mock import in_toto_mock
+from in_toto.models.link import MOCK_FILENAME_FORMAT
+
+# Suppress all the user feedback that we print using a base logger
+logging.getLogger().setLevel(logging.CRITICAL)
+
+class TestInTotoMockTool(unittest.TestCase):
+  """Test in_toto_mock's main() - requires sys.argv patching; and
+  in_toto_mock- calls runlib and error logs/exits on Exception. """
+
+  @classmethod
+  def setUpClass(self):
+    """Create and change into temporary directory,
+    dummy artifact and base arguments. """
+
+    self.working_dir = os.getcwd()
+
+    self.test_dir = tempfile.mkdtemp()
+    os.chdir(self.test_dir)
+
+    self.test_step = "test_step"
+    self.test_link = MOCK_FILENAME_FORMAT.format(step_name=self.test_step)
+    self.test_artifact = "test_artifact"
+    open(self.test_artifact, "w").close()
+
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(self.working_dir)
+    shutil.rmtree(self.test_dir)
+
+  def tearDown(self):
+    try:
+      os.remove(self.test_link)
+    except OSError:
+      pass
+
+  def test_main_required_args(self):
+    """Test CLI command with required arguments. """
+
+    args = [ "in_toto_mock.py", "--name", self.test_step, "--", "echo", "test"]
+    with patch.object(sys, 'argv', args):
+      in_toto_mock_main()
+
+    self.assertTrue(os.path.exists(self.test_link))
+
+  def test_main_optional_args(self):
+    """Test CLI command with optional arguments. """
+
+    args = [ "in_toto_mock.py", "--name", self.test_step, "--materials",
+        self.test_artifact, "--products", self.test_artifact,
+        "--record-byproducts", "--", "echo", "test"]
+
+    with patch.object(sys, 'argv', args):
+      in_toto_mock_main()
+
+    self.assertTrue(os.path.exists(self.test_link))
+
+  def test_main_wrong_args(self):
+    """Test CLI command with missing arguments. """
+
+    wrong_args_list = [
+      ["in_toto_mock.py"],
+      ["in_toto_mock.py", "--name", "test-step"],
+      ["in_toto_mock.py", "--", "echo", "blub"],
+      ["in_toto_record.py", "--", "echo", "blub"]]
+
+    for wrong_args in wrong_args_list:
+      with patch.object(sys, 'argv', wrong_args), self.assertRaises(SystemExit):
+        in_toto_mock_main()
+      self.assertFalse(os.path.exists(self.test_link))
+
+  def test_main_verbose(self):
+    """Log level with verbose flag is lesser/equal than logging.INFO. """
+
+    args = [ "in_toto_mock.py", "--name", self.test_step, "--materials",
+        self.test_artifact, "--products",
+        self.test_artifact, "--record-byproducts", "--verbose",
+        "--", "echo", "test"]
+
+    original_log_level = logging.getLogger().getEffectiveLevel()
+    with patch.object(sys, 'argv', args ):
+      in_toto_mock_main()
+    self.assertTrue(os.path.exists(self.test_link))
+
+    self.assertLessEqual(logging.getLogger().getEffectiveLevel(), logging.INFO)
+    # Reset log level
+    logging.getLogger().setLevel(original_log_level)
+
+  def test_successful_in_toto_mock(self):
+    """Call in_toto_mock successfully """
+    in_toto_mock(self.test_step, [self.test_artifact],
+      [self.test_artifact], ["echo", "test"], True)
+
+    self.assertTrue(os.path.exists(self.test_link))
+
+if __name__ == "__main__":
+  unittest.main(buffer=True)

--- a/test/test_in_toto_mock.py
+++ b/test/test_in_toto_mock.py
@@ -81,8 +81,7 @@ class TestInTotoMockTool(unittest.TestCase):
     wrong_args_list = [
       ["in_toto_mock.py"],
       ["in_toto_mock.py", "--name", "test-step"],
-      ["in_toto_mock.py", "--", "echo", "blub"],
-      ["in_toto_record.py", "--", "echo", "blub"]]
+      ["in_toto_mock.py", "--", "echo", "blub"]]
 
     for wrong_args in wrong_args_list:
       with patch.object(sys, 'argv', wrong_args), self.assertRaises(SystemExit):

--- a/test/test_in_toto_mock.py
+++ b/test/test_in_toto_mock.py
@@ -30,7 +30,7 @@ from mock import patch
 from in_toto.models.link import Link
 from in_toto.in_toto_mock import main as in_toto_mock_main
 from in_toto.in_toto_mock import in_toto_mock
-from in_toto.models.link import MOCK_FILENAME_FORMAT
+from in_toto.models.mock_link import MOCK_FILENAME_FORMAT
 
 # Suppress all the user feedback that we print using a base logger
 logging.getLogger().setLevel(logging.CRITICAL)

--- a/test/test_in_toto_run.py
+++ b/test/test_in_toto_run.py
@@ -102,8 +102,7 @@ class TestInTotoRunTool(unittest.TestCase):
       ["in_toto_run.py"],
       ["in_toto_run.py", "--step-name", "some"],
       ["in_toto_run.py", "--key", self.key_path],
-      ["in_toto_run.py", "--step-name", "test-step", "--key", self.key_path],
-      ["in_toto_record.py", "--", "echo", "blub"]]
+      ["in_toto_run.py", "--step-name", "test-step", "--key", self.key_path]]
 
     for wrong_args in wrong_args_list:
       with patch.object(sys, 'argv', wrong_args), self.assertRaises(SystemExit):
@@ -145,7 +144,7 @@ class TestInTotoRunTool(unittest.TestCase):
     self.assertTrue(os.path.exists(self.test_link))
 
   def test_in_toto_run_bad_key_error_exit(self):
-    """Error exit in_toto_record_start with bad key. """
+    """Error exit in_toto_run with bad key. """
     with self.assertRaises(SystemExit):
       in_toto_run(self.test_step, [self.test_artifact],
         [self.test_artifact], ["echo", "test"], "bad-key", False)


### PR DESCRIPTION
* **What does this PR do?**
Adds in_toto_mock command, which is a stripped down version of in_toto_run.

* **Are there points in the code the reviewer needs to double check?**
No, its basically a rip off of [in-toto-run](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py). Opened both files in [Meld](http://meldmerge.org/) and copy pasted shamelessly :stuck_out_tongue: 

* **Who do you think should review this PR?**
@lukpueh 

* **Does this PR meet the acceptance criteria?**

   - Documentation created/updated (e.g., did you update the docstrings?)
      * README.md requires editing.

   - All builds are passing (did you run the tests locally?)
      * Yes

   - Code follows the [style guide](https://github.com/secure-systems-lab/code-style-guidelines)
      * Followed manually. Is there some code formatter you are using ? like [yapf](https://github.com/google/yapf).

* **What are the relevant issue numbers fixed (add one line for each)?**
Fixed #93 

* **Steps Required**
- [x] Add in-toto-mock and tests
- [x]  Fix code formatting issues
- [x] Check possible error in tests. In [test_in_toto_run#L106](https://github.com/in-toto/in-toto/blob/develop/test/test_in_toto_run.py#L106) it seems to be a minor copy pasting error, I guess it should be `in-toto-run` instead of `in-toto-record`, [test_in_toto_run#L148](https://github.com/in-toto/in-toto/blob/develop/test/test_in_toto_run.py#L148) again should be run instead of record. I have left it in _in_toto_mock test too, if its an error I'll rebase and edit that commit.
- [ ] Update README.md
