### PR TITLE
Refactoring artifact rules field name

### DIFF
--- a/demo-opensuse/Offline-demo.md
+++ b/demo-opensuse/Offline-demo.md
@@ -132,7 +132,7 @@ This command will verify that
  1. the layout has not expired,
  2. was signed with Alice’s private key, and that according to the definitions in the layout
  3. each step was performed and signed by the authorized functionary
- 4. the recorded materials and products align with the matchrules and
+ 4. the recorded materials and products follow the artifact rules and
  5. the inspection `unpack` finds what it expects.
  6. the inspection `verify-signature` checks that the signature for connman tarball is correct.
 

--- a/demo-opensuse/README.md
+++ b/demo-opensuse/README.md
@@ -222,7 +222,7 @@ This command will verify that
  1. the layout has not expired,
  2. was signed with Alice’s private key, and that according to the definitions in the layout
  3. each step was performed and signed by the authorized functionary
- 4. the recorded materials and products align with the matchrules and
+ 4. the recorded materials and products follow the artifact rules and
  5. the inspection `unpack` finds what it expects.
  6. the inspection `verify-signature` checks that the signature for connman tarball is correct.
 

--- a/demo-opensuse/owner_alice/create_layout.py
+++ b/demo-opensuse/owner_alice/create_layout.py
@@ -17,16 +17,16 @@ def main():
     },
     "steps": [{
         "name": "setup-project",
-        "material_matchrules": [],
-        "product_matchrules": [["CREATE", "project.meta"],
+        "expected_materials": [],
+        "expected_products": [["CREATE", "project.meta"],
             ["CREATE", "package.meta"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",
         "threshold": 1,
       },{
         "name": "clone",
-        "material_matchrules": [],
-        "product_matchrules": [["CREATE", "connman/_service"],
+        "expected_materials": [],
+        "expected_products": [["CREATE", "connman/_service"],
             ["CREATE", "connman/connman-1.30.tar.gz"],
             ["CREATE", "connman/connman-1.30.tar.sign"],
             ["CREATE", "connman/connman-rpmlintrc"],
@@ -38,22 +38,22 @@ def main():
         "threshold": 1,
       },{
         "name": "update-changelog",
-        "material_matchrules": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
+        "expected_materials": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
         # FIXME: CREATE is more like an allow here, is fixed in next version
-        "product_matchrules": [["ALLOW", "connman/connman.changes"]],
+        "expected_products": [["ALLOW", "connman/connman.changes"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",
         "threshold": 1,
       },{
         "name": "test",
-        "material_matchrules": [],
-        "product_matchrules": [],
+        "expected_materials": [],
+        "expected_products": [],
         "pubkeys": [key_carl["keyid"]],
         "expected_command": "osc build openSUSE_Factory x86_64 connman/connman.spec",
         "threshold": 1,
       },{
         "name": "package",
-        "material_matchrules": [
+        "expected_materials": [
             ["MATCH", "connman/_service", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman-1.30.tar.gz", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman-1.30.tar.sign", "WITH", "PRODUCTS", "FROM", "clone"],
@@ -62,7 +62,7 @@ def main():
             ["MATCH", "connman/connman.keyring", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman.spec", "WITH", "PRODUCTS", "FROM", "clone"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["CREATE", "connman-1.30-1.1.src.rpm"],
         ],
         "pubkeys": [key_carl["keyid"]],
@@ -71,7 +71,7 @@ def main():
       }],
     "inspect": [{
         "name": "unpack",
-        "material_matchrules": [
+        "expected_materials": [
             ["MATCH", "connman-1.30-1.1.src.rpm", "WITH", "PRODUCTS", "FROM", "package"],
             # FIXME: If the routine running inspections would gather the
             # materials/products to record from the rules we wouldn't have to
@@ -81,7 +81,7 @@ def main():
             ["ALLOW", "verify-signature.sh"],
             ["ALLOW", "root.layout"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["MATCH", "connman-1.30-1.1.src.rpm", "WITH", "PRODUCTS", "FROM", "package"],
             ["MATCH", "connman-1.30.tar.gz", "WITH", "PRODUCTS", "IN", "connman", "FROM", "clone"],
             ["MATCH", "_service", "WITH", "PRODUCTS", "IN", "connman", "FROM", "clone"],
@@ -100,8 +100,8 @@ def main():
         "run": "unrpm connman-1.30-1.1.src.rpm",
       },{
         "name": "verify-signature",
-        "material_matchrules": [["ALLOW", "*"]],
-        "product_matchrules": [["ALLOW", "*"]],
+        "expected_materials": [["ALLOW", "*"]],
+        "expected_products": [["ALLOW", "*"]],
         "run": "./verify-signature.sh",
       }],
     "signatures": []

--- a/demo-opensuse/owner_alice/create_layout.py
+++ b/demo-opensuse/owner_alice/create_layout.py
@@ -39,7 +39,6 @@ def main():
       },{
         "name": "update-changelog",
         "expected_materials": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
-        # FIXME: CREATE is more like an allow here, is fixed in next version
         "expected_products": [["ALLOW", "connman/connman.changes"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",

--- a/demo-opensuse/owner_alice/create_layout_offline.py
+++ b/demo-opensuse/owner_alice/create_layout_offline.py
@@ -17,8 +17,8 @@ def main():
     },
     "steps": [{
         "name": "clone",
-        "material_matchrules": [],
-        "product_matchrules": [["CREATE", "connman/_service"],
+        "expected_materials": [],
+        "expected_products": [["CREATE", "connman/_service"],
             ["CREATE", "connman/connman-1.30.tar.gz"],
             ["CREATE", "connman/connman-1.30.tar.sign"],
             ["CREATE", "connman/connman-rpmlintrc"],
@@ -30,15 +30,15 @@ def main():
         "threshold": 1,
       },{
         "name": "update-changelog",
-        "material_matchrules": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
+        "expected_materials": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
         # FIXME: CREATE is more like an allow here, is fixed in next version
-        "product_matchrules": [["ALLOW", "connman/connman.changes"]],
+        "expected_products": [["ALLOW", "connman/connman.changes"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",
         "threshold": 1,
       },{
         "name": "package",
-        "material_matchrules": [
+        "expected_materials": [
             ["MATCH", "connman/_service", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman-1.30.tar.gz", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman-1.30.tar.sign", "WITH", "PRODUCTS", "FROM", "clone"],
@@ -47,7 +47,7 @@ def main():
             ["MATCH", "connman/connman.keyring", "WITH", "PRODUCTS", "FROM", "clone"],
             ["MATCH", "connman/connman.spec", "WITH", "PRODUCTS", "FROM", "clone"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["CREATE", "connman-1.30-1.1.src.rpm"],
         ],
         "pubkeys": [key_carl["keyid"]],
@@ -56,7 +56,7 @@ def main():
       }],
     "inspect": [{
         "name": "unpack",
-        "material_matchrules": [
+        "expected_materials": [
             ["MATCH", "connman-1.30-1.1.src.rpm", "WITH", "PRODUCTS", "FROM", "package"],
             # FIXME: If the routine running inspections would gather the
             # materials/products to record from the rules we wouldn't have to
@@ -66,7 +66,7 @@ def main():
             ["ALLOW", "verify-signature.sh"],
             ["ALLOW", "root.layout"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["MATCH", "connman-1.30-1.1.src.rpm", "WITH", "PRODUCTS", "FROM", "package"],
             ["MATCH", "connman-1.30.tar.gz", "WITH", "PRODUCTS", "IN", "connman", "FROM", "clone"],
             ["MATCH", "_service", "WITH", "PRODUCTS", "IN", "connman", "FROM", "clone"],
@@ -83,8 +83,8 @@ def main():
         "run": "unrpm connman-1.30-1.1.src.rpm",
       },{
         "name": "verify-signature",
-        "material_matchrules": [["ALLOW", "*"]],
-        "product_matchrules": [["ALLOW", "*"]],
+        "expected_materials": [["ALLOW", "*"]],
+        "expected_products": [["ALLOW", "*"]],
         "run": "./verify-signature.sh",
       }],
     "signatures": []

--- a/demo-opensuse/owner_alice/create_layout_offline.py
+++ b/demo-opensuse/owner_alice/create_layout_offline.py
@@ -31,7 +31,6 @@ def main():
       },{
         "name": "update-changelog",
         "expected_materials": [["MATCH", "connman/connman.changes", "WITH", "PRODUCTS", "FROM", "clone"]],
-        # FIXME: CREATE is more like an allow here, is fixed in next version
         "expected_products": [["ALLOW", "connman/connman.changes"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",

--- a/demo/README.md
+++ b/demo/README.md
@@ -178,7 +178,7 @@ This command will verify that
  2. was signed with Alice’s private key,
 <br>and that according to the definitions in the layout
  3. each step was performed and signed by the authorized functionary
- 4. the recorded materials and products align with the matchrules and
+ 4. the recorded materials and products follow the artifact rules and
  5. the inspection `untar` finds what it expects.
 
 

--- a/demo/owner_alice/create_layout.py
+++ b/demo/owner_alice/create_layout.py
@@ -17,25 +17,27 @@ def main():
     },
     "steps": [{
         "name": "clone",
-        "material_matchrules": [],
-        "product_matchrules": [["CREATE", "demo-project/foo.py"]],
+        "expected_materials": [],
+        "expected_products": [["CREATE", "demo-project/foo.py"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "git clone https://github.com/in-toto/demo-project.git",
         "threshold": 1,
       },{
         "name": "update-version",
-        "material_matchrules": [["MATCH", "demo-project/*", "WITH", "PRODUCTS", "FROM", "clone"]],
+        "expected_materials": [["MATCH", "demo-project/*", "WITH", "PRODUCTS",
+                              "FROM", "clone"]],
         # FIXME: CREATE is more like an allow here, is fixed in next version
-        "product_matchrules": [["ALLOW", "demo-project/foo.py"]],
+        "expected_products": [["ALLOW", "demo-project/foo.py"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",
         "threshold": 1,
       },{
         "name": "package",
-        "material_matchrules": [
-            ["MATCH", "demo-project/*", "WITH", "PRODUCTS", "FROM", "update-version"],
+        "expected_materials": [
+          ["MATCH", "demo-project/*", "WITH", "PRODUCTS", "FROM",
+           "update-version"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["CREATE", "demo-project.tar.gz"],
         ],
         "pubkeys": [key_carl["keyid"]],
@@ -44,7 +46,7 @@ def main():
       }],
     "inspect": [{
         "name": "untar",
-        "material_matchrules": [
+        "expected_materials": [
             ["MATCH", "demo-project.tar.gz", "WITH", "PRODUCTS", "FROM", "package"],
             # FIXME: If the routine running inspections would gather the
             # materials/products to record from the rules we wouldn't have to
@@ -53,9 +55,9 @@ def main():
             ["ALLOW", "alice.pub"],
             ["ALLOW", "root.layout"],
         ],
-        "product_matchrules": [
+        "expected_products": [
             ["MATCH", "demo-project/foo.py", "WITH", "PRODUCTS", "FROM", "update-version"],
-            # FIXME: See material_matchrules above
+            # FIXME: See expected_materials above
             ["ALLOW", "demo-project/.git/*"],
             ["ALLOW", "demo-project.tar.gz"],
             ["ALLOW", ".keep"],

--- a/demo/owner_alice/create_layout.py
+++ b/demo/owner_alice/create_layout.py
@@ -26,7 +26,6 @@ def main():
         "name": "update-version",
         "expected_materials": [["MATCH", "demo-project/*", "WITH", "PRODUCTS",
                               "FROM", "clone"]],
-        # FIXME: CREATE is more like an allow here, is fixed in next version
         "expected_products": [["ALLOW", "demo-project/foo.py"]],
         "pubkeys": [key_bob["keyid"]],
         "expected_command": "",

--- a/in_toto/artifact_rules.py
+++ b/in_toto/artifact_rules.py
@@ -13,8 +13,8 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  This module provides functions to ensure the syntax of the matchrules is
-  correct.
+  This module provides functions parse artifact rules and validate their
+  syntax.
 
 """
 import six

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -9,11 +9,11 @@ class LayoutExpiredError(Error):
   pass
 
 class RuleVerficationError(Error):
-  """Indicates that a match rule verification failed. """
+  """Indicates that artifact rule verification failed. """
   pass
 
 class ThresholdVerificationError(Error):
-  """Indicates that a match rule verification failed. """
+  """Indicates that signature threshold verification failed. """
   pass
 
 class BadReturnValueError(Error):

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -292,8 +292,9 @@ def main():
         else:
           path = args.signablepath
 
-      log.info("Dumping {0} to '{1}'...".format(
-      signable_object._type.lower(),path))
+      log.info("Dumping {0} to '{1}'...".format(signable_object._type.lower(),
+          path))
+
       signable_object.dump(path)
       sys.exit(0)
 

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -272,9 +272,9 @@ class Step(models__common.Metablock):
     name:
         a unique name used to identify the related link metadata
 
-    material_matchrules and product_matchrules:
-        a list of matchrules used to verify if the materials or products of the
-        step (found in the according link metadata file) link correctly with
+    expected_materials and expected_products:
+        a list of artifact rules used to verify if the materials or products of
+        the step (found in the according link metadata file) link correctly with
         other steps of the supply chain
 
     pubkeys:
@@ -289,8 +289,8 @@ class Step(models__common.Metablock):
   """
   _type = attr.ib()
   name = attr.ib()
-  material_matchrules = attr.ib()
-  product_matchrules = attr.ib()
+  expected_materials = attr.ib()
+  expected_products = attr.ib()
   pubkeys = attr.ib()
   expected_command = attr.ib()
   threshold = attr.ib()
@@ -299,8 +299,8 @@ class Step(models__common.Metablock):
     super(Step, self).__init__()
     self._type = "step"
     self.name = kwargs.get("name")
-    self.material_matchrules = kwargs.get("material_matchrules", [])
-    self.product_matchrules = kwargs.get("product_matchrules", [])
+    self.expected_materials = kwargs.get("expected_materials", [])
+    self.expected_products = kwargs.get("expected_products", [])
     self.pubkeys = kwargs.get("pubkeys", [])
 
     # Accept expected command as string or list, if it is a string we split it
@@ -334,23 +334,23 @@ class Step(models__common.Metablock):
           "Invalid threshold '{}', value must be an int."
           .format(self.threshold))
 
-  def _validate_material_matchrules(self):
-    """Private method to check the material matchrules are correctly formed."""
-    if type(self.material_matchrules) != list:
+  def _validate_expected_materials(self):
+    """Private method to check that material rules are correctly formed."""
+    if type(self.expected_materials) != list:
       raise securesystemslib.exceptions.FormatError(
-          "Material matchrules should be a list!")
+          "Material rules should be a list!")
 
-    for matchrule in self.material_matchrules:
-      in_toto.artifact_rules.unpack_rule(matchrule)
+    for rule in self.expected_materials:
+      in_toto.artifact_rules.unpack_rule(rule)
 
-  def _validate_product_matchrules(self):
-    """Private method to check the product matchrules are correctly formed."""
-    if type(self.product_matchrules) != list:
+  def _validate_expected_products(self):
+    """Private method to check that product rules are correctly formed."""
+    if type(self.expected_products) != list:
       raise securesystemslib.exceptions.FormatError(
-          "Product matchrules should be a list!")
+          "Product rules should be a list!")
 
-    for matchrule in self.product_matchrules:
-      in_toto.artifact_rules.unpack_rule(matchrule)
+    for rule in self.expected_products:
+      in_toto.artifact_rules.unpack_rule(rule)
 
   def _validate_pubkeys(self):
     """Private method to check that the pubkeys is a list of keyids."""
@@ -380,7 +380,7 @@ class Inspection(models__common.Metablock):
         link metadata for Inspections are just created and used on the fly
         and not stored to disk
 
-    material_matchrules and product_matchrules:
+    expected_materials and expected_products:
         cf. Step Attributes
 
     run:
@@ -389,8 +389,8 @@ class Inspection(models__common.Metablock):
   """
   _type = attr.ib()
   name = attr.ib()
-  material_matchrules = attr.ib()
-  product_matchrules = attr.ib()
+  expected_materials = attr.ib()
+  expected_products = attr.ib()
   run = attr.ib()
 
   def __init__(self, **kwargs):
@@ -398,8 +398,8 @@ class Inspection(models__common.Metablock):
 
     self._type = "inspection"
     self.name = kwargs.get("name")
-    self.material_matchrules = kwargs.get("material_matchrules", [])
-    self.product_matchrules = kwargs.get("product_matchrules", [])
+    self.expected_materials = kwargs.get("expected_materials", [])
+    self.expected_products = kwargs.get("expected_products", [])
 
     # Accept run command as string or list, if it is a string we split it
     # using shell like syntax.
@@ -422,23 +422,23 @@ class Inspection(models__common.Metablock):
       raise securesystemslib.exceptions.FormatError(
           "The _type field must be set to 'inspection'!")
 
-  def _validate_material_matchrules(self):
-    """Private method to check that the material matchrules are correct."""
-    if type(self.material_matchrules) != list:
+  def _validate_expected_materials(self):
+    """Private method to check that the material rules are correct."""
+    if type(self.expected_materials) != list:
       raise securesystemslib.exceptions.FormatError(
-          "The material matchrules should be a list!")
+          "The material rules should be a list!")
 
-    for matchrule in self.material_matchrules:
-      in_toto.artifact_rules.unpack_rule(matchrule)
+    for rule in self.expected_materials:
+      in_toto.artifact_rules.unpack_rule(rule)
 
-  def _validate_product_matchrules(self):
-    """Private method to check that the product matchrules are correct."""
-    if type(self.product_matchrules) != list:
+  def _validate_expected_products(self):
+    """Private method to check that the product rules are correct."""
+    if type(self.expected_products) != list:
       raise securesystemslib.exceptions.FormatError(
-          "The product matchrules should be a list!")
+          "The product rules should be a list!")
 
-    for matchrule in self.product_matchrules:
-      in_toto.artifact_rules.unpack_rule(matchrule)
+    for rule in self.expected_products:
+      in_toto.artifact_rules.unpack_rule(rule)
 
   def _validate_run(self):
     """Private method to check that the expected command is correct."""

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -22,7 +22,8 @@
     - verify if the expected command of a step aligns with the actual command
       as recorded in the link metadata file.
     - run inspections (records link metadata)
-    - verify product or material matchrules for steps or inspections
+    - verify product or material rules (artifact rules) for steps or
+      inspections
 
 """
 
@@ -123,7 +124,7 @@ def run_all_inspections(layout):
     # FIXME: What should we record as material/product?
     # Is the current directory a sensible default? In general?
     # If so, we should probably make it a default in run_link
-    # We could use matchrule paths.
+    # We could use artifact rule paths.
     material_list = product_list = ["."]
     link = in_toto.runlib.in_toto_run(inspection.name, material_list,
         product_list, inspection.run)
@@ -791,7 +792,7 @@ def verify_item_rules(source_name, source_type, rules, links):
 
     source_type:
             "materials" or "products" depending on whether the rules were in the
-            "material_matchrules" or "product_matchrules" field.
+            "expected_materials" or "expected_products" field.
 
     rules:
             The list of rules (material or product rules) for the item
@@ -901,13 +902,12 @@ def verify_item_rules(source_name, source_type, rules, links):
 def verify_all_item_rules(items, links):
   """
   <Purpose>
-    Iteratively verifies material matchrules and product matchrules of
-    passed items (Steps or Inspections).
+    Iteratively verifies artifact rules of passed items (Steps or Inspections).
 
   <Arguments>
     items:
             A list containing Step or Inspection objects whose material
-            and product matchrules will be verified.
+            and product rules will be verified.
 
     links:
             A dictionary of Link objects with Link names as keys. For each
@@ -926,10 +926,10 @@ def verify_all_item_rules(items, links):
 
     link = links[item.name]
     log.info("Verifying material rules for '{}'...".format(item.name))
-    verify_item_rules(item.name, "materials", item.material_matchrules, links)
+    verify_item_rules(item.name, "materials", item.expected_materials, links)
 
     log.info("Verifying product rules for '{}'...".format(item.name))
-    verify_item_rules(item.name, "products", item.product_matchrules, links)
+    verify_item_rules(item.name, "products", item.expected_products, links)
 
 
 def verify_threshold_constraints(layout, chain_link_dict):
@@ -1164,10 +1164,10 @@ def in_toto_verify(layout, layout_key_dict):
             will record materials before and products after command execution.
             For now it records everything in the current working directory.
         8.  Verify threshold constraints
-        9.  Verify rules defined in each Step's material_matchrules and
-            product_matchrules field.
-        10. Verify rules defined in each Inspection's material_matchrules and
-            product_matchrules field.
+        9.  Verify rules defined in each Step's expected_materials and
+            expected_products field.
+        10. Verify rules defined in each Inspection's expected_materials and
+            expected_products field.
 
     Note, this function will read the following files from disk:
       - link metadata files

--- a/test/demo_files/demo.layout.template
+++ b/test/demo_files/demo.layout.template
@@ -3,7 +3,7 @@
     "inspect": [
         {
             "_type": "inspection",
-            "material_matchrules": [
+            "expected_materials": [
                 [
                     "MATCH",
                     "foo.tar.gz",
@@ -18,7 +18,7 @@
                 ]
             ],
             "name": "untar",
-            "product_matchrules": [
+            "expected_products": [
                 [
                     "MATCH",
                     "foo.py",
@@ -58,9 +58,9 @@
         {
             "_type": "step",
             "expected_command": "",
-            "material_matchrules": [],
+            "expected_materials": [],
             "name": "write-code",
-            "product_matchrules": [
+            "expected_products": [
                 [
                     "CREATE",
                     "foo.py"
@@ -74,7 +74,7 @@
         {
             "_type": "step",
             "expected_command": "tar zcvf foo.tar.gz foo.py",
-            "material_matchrules": [
+            "expected_materials": [
                 [
                     "MATCH",
                     "foo.py",
@@ -85,7 +85,7 @@
                 ]
             ],
             "name": "package",
-            "product_matchrules": [
+            "expected_products": [
                 [
                     "CREATE",
                     "foo.tar.gz"

--- a/test/models/test_inspection.py
+++ b/test/models/test_inspection.py
@@ -41,48 +41,48 @@ class TestInspectionValidator(unittest.TestCase):
     self.inspection._type = "inspection"
     self.inspection._validate_type()
 
-  def test_wrong_material_matchrules(self):
-    """Test that the material matchrule validators catch malformed ones."""
+  def test_wrong_expected_materials(self):
+    """Test that the material rule validators catch malformed ones."""
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.material_matchrules = [["NONFOO"]]
-      self.inspection._validate_material_matchrules()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.material_matchrules = "PFF"
-      self.inspection._validate_material_matchrules()
+      self.inspection.expected_materials = [["NONFOO"]]
+      self.inspection._validate_expected_materials()
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.inspection.validate()
 
-    # for more thorough tests, check the test_matchrule.py module
-    self.inspection.material_matchrules = [["CREATE", "foo"]]
-    self.inspection._validate_material_matchrules()
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.inspection.expected_materials = "PFF"
+      self.inspection._validate_expected_materials()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.inspection.validate()
+
+    # for more thorough tests, check the test_artifact_rules.py module
+    self.inspection.expected_materials = [["CREATE", "foo"]]
+    self.inspection._validate_expected_materials()
     self.inspection.validate()
 
-  def test_wrong_product_matchrules(self):
-    """Test that the product matchrule validators catch malformed values."""
+  def test_wrong_expected_products(self):
+    """Test that the product rule validators catch malformed values."""
 
-    self.inspection.product_matchrules = [["NONFOO"]]
+    self.inspection.expected_products = [["NONFOO"]]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection._validate_product_matchrules()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    self.inspection.product_matchrules = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection._validate_product_matchrules()
+      self.inspection._validate_expected_products()
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.inspection.validate()
 
-    # for more thorough tests, check the test_matchrule.py module
-    self.inspection.product_matchrules = [["CREATE", "foo"]]
-    self.inspection._validate_product_matchrules()
+    self.inspection.expected_products = "PFF"
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.inspection._validate_expected_products()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.inspection.validate()
+
+    # for more thorough tests, check the test_artifact_rules.py module
+    self.inspection.expected_products = [["CREATE", "foo"]]
+    self.inspection._validate_expected_products()
     self.inspection.validate()
 
   def test_wrong_run(self):

--- a/test/models/test_layout.py
+++ b/test/models/test_layout.py
@@ -113,13 +113,13 @@ class TestLayoutValidator(unittest.TestCase):
 
     test_step = Step(name="this-is-a-step")
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      test_step.material_matchrules = ['this is a malformed step']
+      test_step.expected_materials = ['this is a malformed step']
       self.layout.steps = [test_step]
       self.layout.validate()
 
 
     test_step = Step(name="this-is-a-step")
-    test_step.material_matchrules = [["CREATE", "foo"]]
+    test_step.expected_materials = [["CREATE", "foo"]]
     test_step.threshold = 1
     self.layout.steps = [test_step]
     self.layout.validate()
@@ -132,13 +132,13 @@ class TestLayoutValidator(unittest.TestCase):
       self.layout.validate()
 
     test_inspection = Inspection(name="this-is-a-step")
-    test_inspection.material_matchrules = ['this is a malformed matchrule']
+    test_inspection.expected_materials = ['this is a malformed artifact rule']
     self.layout.inspect = [test_inspection]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout.validate()
 
     test_inspection = Inspection(name="this-is-a-step")
-    test_inspection.material_matchrules = [["CREATE", "foo"]]
+    test_inspection.expected_materials = [["CREATE", "foo"]]
     self.layout.inspect = [test_inspection]
     self.layout.validate()
 

--- a/test/models/test_step.py
+++ b/test/models/test_step.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 <Program Name>
-  test_layout.py
+  test_step.py
 
 <Author>
   Santiago Torres-Arias <santiago@nyu.edu>
@@ -58,48 +58,48 @@ class TestStepValidator(unittest.TestCase):
     self.step._validate_threshold()
     self.step.validate()
 
-  def test_wrong_material_matchrules(self):
-    """Test that the material matchrule validators catch malformed ones."""
+  def test_wrong_expected_materials(self):
+    """Test that the material rule validators catch malformed ones."""
 
-    self.step.material_matchrules = [["NONFOO"]]
+    self.step.expected_materials = [["NONFOO"]]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_material_matchrules()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    self.step.material_matchrules = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_material_matchrules()
+      self.step._validate_expected_materials()
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.step.validate()
 
-    # for more thorough tests, check the test_matchrule.py module
-    self.step.material_matchrules = [["CREATE", "foo"]]
-    self.step._validate_material_matchrules()
+    self.step.expected_materials = "PFF"
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.step._validate_expected_materials()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.step.validate()
+
+    # for more thorough tests, check the test_artifact_rules.py module
+    self.step.expected_materials = [["CREATE", "foo"]]
+    self.step._validate_expected_materials()
     self.step.validate()
 
-  def test_wrong_product_matchrules(self):
-    """Test that the product matchrule validators catch malformed ones."""
+  def test_wrong_expected_products(self):
+    """Test that the product rule validators catch malformed ones."""
 
-    self.step.product_matchrules = [["NONFOO"]]
+    self.step.expected_products = [["NONFOO"]]
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_product_matchrules()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    self.step.product_matchrules = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_product_matchrules()
+      self.step._validate_expected_products()
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.step.validate()
 
-    # for more thorough tests, check the test_matchrule.py module
-    self.step.product_matchrules = [["CREATE", "foo"]]
-    self.step._validate_product_matchrules()
+    self.step.expected_products = "PFF"
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.step._validate_expected_products()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.step.validate()
+
+    # for more thorough tests, check the test_artifact_rules.py module
+    self.step.expected_products = [["CREATE", "foo"]]
+    self.step._validate_expected_products()
     self.step.validate()
 
   def test_wrong_pubkeys(self):

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -765,15 +765,15 @@ class TestVerifyAllItemRules(unittest.TestCase):
 
     self.steps = [
         Step(name="write-code",
-            product_matchrules=[
+            expected_products=[
                 ["CREATE", "foo"]
             ],
         ),
         Step(name="package",
-            material_matchrules=[
+            expected_materials=[
                 ["MATCH", "foo", "WITH", "PRODUCTS", "FROM", "write-code"]
             ],
-            product_matchrules=[
+            expected_products=[
                 ["CREATE", "foo.tar.gz"],
                 ["DELETE", "foo"]
             ],
@@ -782,10 +782,10 @@ class TestVerifyAllItemRules(unittest.TestCase):
 
     self.inspections = [
         Inspection(name="untar",
-            material_matchrules=[
+            expected_materials=[
                 ["MATCH", "foo.tar.gz", "WITH", "PRODUCTS", "FROM", "package"]
             ],
-            product_matchrules=[
+            expected_products=[
                 ["MATCH", "foo", "IN", "dir", "WITH", "PRODUCTS",
                     "FROM", "write-code"]
             ]
@@ -913,14 +913,14 @@ class TestInTotoVerify(unittest.TestCase):
 
     # dump layout with failing step rule
     layout = copy.deepcopy(layout_template)
-    layout.steps[0].product_matchrules.insert(0,
+    layout.steps[0].expected_products.insert(0,
         ["MODIFY", "*"])
     layout.sign(alice)
     layout.dump(self.layout_failing_step_rule_path)
 
     # dump layout with failing inspection rule
     layout = copy.deepcopy(layout_template)
-    layout.inspect[0].material_matchrules.insert(0,
+    layout.inspect[0].expected_materials.insert(0,
         ["MODIFY", "*"])
     layout.sign(alice)
     layout.dump(self.layout_failing_inspection_rule_path)
@@ -987,14 +987,14 @@ class TestInTotoVerify(unittest.TestCase):
       in_toto_verify(layout, layout_key_dict)
 
   def test_verify_failing_step_rules(self):
-    """Test fail verification with failing step matchrule. """
+    """Test fail verification with failing step artifact rule. """
     layout = Layout.read_from_file(self.layout_failing_step_rule_path)
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
     with self.assertRaises(RuleVerficationError):
       in_toto_verify(layout, layout_key_dict)
 
   def test_verify_failing_inspection_rules(self):
-    """Test fail verification with failing inspection matchrule. """
+    """Test fail verification with failing inspection artifact rule. """
     layout = Layout.read_from_file(self.layout_failing_inspection_rule_path)
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
     with self.assertRaises(RuleVerficationError):


### PR DESCRIPTION
The names of the artifact rule properties of in-toto steps and inspections have been updated in the implementation. They are now called ```expected_materials``` and ```expected_products```.

Issue Referenced: #106 