### PR TITLE
Fix wrong arguments in in_toto_record tests

### DIFF
--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -126,18 +126,18 @@ class TestInTotoRecordTool(unittest.TestCase):
 
   def test_in_toto_record_start_stop(self):
     """in_toto_record_start/stop run through. """
-    in_toto_record_start("test-step", self.key, self.test_artifact)
-    in_toto_record_stop("test-step", self.key, self.test_artifact)
+    in_toto_record_start("test-step", self.key, [self.test_artifact])
+    in_toto_record_stop("test-step", self.key, [self.test_artifact])
 
   def test_in_toto_record_start_bad_key_error_exit(self):
     """Error exit in_toto_record_start with bad key. """
     with self.assertRaises(SystemExit):
-      in_toto_record_start("test-step", "bad-key", self.test_artifact)
+      in_toto_record_start("test-step", "bad-key", [self.test_artifact])
 
   def test_in_toto_record_stop_missing_unfinished_link_exit(self):
     """Error exit in_toto_record_stop with missing unfinished link file. """
     with self.assertRaises(SystemExit):
-      in_toto_record_stop("test-step", self.key, self.test_artifact)
+      in_toto_record_stop("test-step", self.key, [self.test_artifact])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The functions `in_toto_record_start` and `in_toto_record_stop` expect a list of file paths/ directory paths as third argument. This commit fixes 3 unittests that passed strings instead of lists.

While this modifies those specific unittests to behave as expected, two important problems remain:

- Unittests should focus on what they are testing, i.e. if a unittest contains logic that can pass or fail, maybe we shouldn't include that logic (fix with https://github.com/in-toto/in-toto/issues/87)
- We should employ more defensive programming, i.e. validate arguments to functions (do we want a "make-code-more-defensive" ticket?)