### PR TITLE
Add readme Layout field (fix #108)

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -77,12 +77,17 @@ class Layout(models__common.Signable):
 
     expires:
         the expiration date of a layout
+
+    readme:
+        Can be used to provide a human-readable description of the supply
+        chain
   """
   _type = attr.ib()
   steps = attr.ib()
   inspect = attr.ib()
   keys = attr.ib()
   expires = attr.ib()
+  readme = attr.ib()
 
   def __init__(self, **kwargs):
     super(Layout, self).__init__(**kwargs)
@@ -90,6 +95,7 @@ class Layout(models__common.Signable):
     self.steps = kwargs.get("steps", [])
     self.inspect = kwargs.get("inspect", [])
     self.keys = kwargs.get("keys", {})
+    self.readme = kwargs.get("readme", "")
 
     # Assign a default expiration (on month) if not specified
     self.expires = kwargs.get("expires", (datetime.today() +

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -219,6 +219,13 @@ class Layout(models__common.Signable):
       raise securesystemslib.exceptions.FormatError(
           "Malformed date string in layout. Exception: {}".format(e))
 
+  def _validate_readme(self):
+    """Private method to check that the readme field is a string."""
+    if not isinstance(self.readme, basestring):
+      raise securesystemslib.exceptions.FormatError(
+          "Invalid readme '{}', value must be a string."
+          .format(self.readme))
+
   def _validate_keys(self):
     """Private method to ensure that the keys contained are right."""
     if type(self.keys) != dict:

--- a/test/models/test_layout.py
+++ b/test/models/test_layout.py
@@ -126,7 +126,6 @@ class TestLayoutValidator(unittest.TestCase):
       self.layout.steps = [test_step]
       self.layout.validate()
 
-
     test_step = Step(name="this-is-a-step")
     test_step.expected_materials = [["CREATE", "foo"]]
     test_step.threshold = 1
@@ -188,8 +187,6 @@ class TestLayoutValidator(unittest.TestCase):
 
     # Clean up
     os.remove(link_path)
-
-
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/models/test_layout.py
+++ b/test/models/test_layout.py
@@ -44,6 +44,15 @@ class TestLayoutValidator(unittest.TestCase):
     self.layout._type = "layout"
     self.layout._validate_type()
 
+  def test_validate_readme_field(self):
+    """Tests the readme field data type validator. """
+    self.layout.readme = 1
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      self.layout._validate_readme()
+
+    self.layout.readme = "This is a test supply chain"
+    self.layout._validate_readme()
+
   def test_wrong_expires(self):
     """Test the expires field is properly populated."""
 
@@ -179,6 +188,8 @@ class TestLayoutValidator(unittest.TestCase):
 
     # Clean up
     os.remove(link_path)
+
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Add `readme` field to in-toto Layout model (fix in-toto/in-toto#108)

With version 0.9 of the in-toto specification, the Layout metadata has a `readme` field for an optional human-readable description of the supply chain.

Note that while this change allows to load existing layouts (without readme field, defaulting to an empty string), it will break any existing signatures.

The PR also adds a data type validator (must be string) and a unittest for that validator.