### PR TITLE
Add optional argument flag for no command

### DIFF
--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -98,6 +98,7 @@ def main():
                "[--materials <filepath>[ <filepath> ...]]\n{0}"
                "[--products <filepath>[ <filepath> ...]]\n{0}"
                "[--record-byproducts]\n{0}"
+               "[--no-command]\n{0}"
                "[--verbose] -- <cmd> [args]\n\n"
                .format(lpad))
 
@@ -120,12 +121,16 @@ def main():
       help="If set redirects stdout/stderr and stores to link metadata",
       dest="record_byproducts", default=False, action="store_true")
 
+  in_toto_args.add_argument("-x", "--no-command",
+      help="Set if step does not have a command",
+      dest="no_command", default=False, action="store_true")
+
   in_toto_args.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", default=False, action="store_true")
 
   # FIXME: This is not yet ideal.
   # What should we do with tokens like > or ; ?
-  in_toto_args.add_argument("link_cmd", nargs="+",
+  in_toto_args.add_argument("link_cmd", nargs="*",
     help="Link command to be executed with options and arguments")
 
   args = parser.parse_args()
@@ -142,7 +147,13 @@ def main():
     log.error("in load key - {}".format(args.key))
     sys.exit(1)
 
-  in_toto_run(args.step_name, args.materials, args.products,
+  if args.no_command:
+    in_toto_run(args.step_name, {}, {}, [], key, args.record_byproducts)
+  else:
+    if not args.link_cmd:
+      parser.print_usage()
+      parser.exit("For no command use --no-command option")
+    in_toto_run(args.step_name, args.materials, args.products,
       args.link_cmd, key, args.record_byproducts)
 
 if __name__ == "__main__":

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -148,7 +148,8 @@ def main():
     sys.exit(1)
 
   if args.no_command:
-    in_toto_run(args.step_name, {}, {}, [], key, args.record_byproducts)
+    in_toto_run(args.step_name, args.materials, args.products, [],
+      key, args.record_byproducts)
   else:
     if not args.link_cmd:
       parser.print_usage()

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -378,7 +378,7 @@ def in_toto_run(name, material_list, product_list,
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
     byproducts, return_value = execute_link(link_cmd_args, record_byproducts)
   else:
-    byproducts, return_value = 0, 0
+    byproducts, return_value = {}, None
 
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -374,8 +374,11 @@ def in_toto_run(name, material_list, product_list,
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
   materials_dict = record_artifacts_as_dict(material_list)
 
-  log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
-  byproducts, return_value = execute_link(link_cmd_args, record_byproducts)
+  if link_cmd_args:
+    log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
+    byproducts, return_value = execute_link(link_cmd_args, record_byproducts)
+  else:
+    byproducts, return_value = 0, 0
 
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))

--- a/test/test_in_toto_run.py
+++ b/test/test_in_toto_run.py
@@ -95,6 +95,17 @@ class TestInTotoRunTool(unittest.TestCase):
 
     self.assertTrue(os.path.exists(self.test_link))
 
+  def test_main_no_command_arg(self):
+    """Test CLI command with --no-command argument. """
+
+    args = [ "in_toto_run.py", "--step-name", self.test_step, "--key",
+        self.key_path, "--no-command"]
+
+    with patch.object(sys, 'argv', args):
+      in_toto_run_main()
+
+    self.assertTrue(os.path.exists(self.test_link))
+
   def test_main_wrong_args(self):
     """Test CLI command with missing arguments. """
 
@@ -102,7 +113,11 @@ class TestInTotoRunTool(unittest.TestCase):
       ["in_toto_run.py"],
       ["in_toto_run.py", "--step-name", "some"],
       ["in_toto_run.py", "--key", self.key_path],
-      ["in_toto_run.py", "--step-name", "test-step", "--key", self.key_path]]
+      ["in_toto_run.py", "--", "echo", "blub"],
+      ["in_toto_run.py", "--step-name", "test-step", "--key", self.key_path],
+      ["in_toto_run.py", "--step-name", "--", "echo", "blub"],
+      ["in_toto_run.py", "--key", self.key_path, "--", "echo", "blub"],
+      ["in_toto_run.py", "--step-name", "test-step", "--key", self.key_path, "--"]]
 
     for wrong_args in wrong_args_list:
       with patch.object(sys, 'argv', wrong_args), self.assertRaises(SystemExit):


### PR DESCRIPTION
* **What does this PR do?**
Adds `--no-command` argument flag to `in-toto-run` for steps which don't have a command such as code review or quality assurance.

* **Are there points in the code the reviewer needs to double check?**
Commands like `in-toto-run --step-name name --key bob --no-command -- cmd` work even though `--no-command` specifies that there will be no `cmd`.  The above will run by ignoring the `cmd` if both `cmd` and `--no-command` are given.

* **Who do you think should review this PR?**
@lukpueh 

* **What are the relevant issue numbers fixed?**
Partially fixes [layout-web-tool#10](https://github.com/in-toto/layout-web-tool/issues/10)
