### PR TITLE
Fix in-toto-sign args (#118) + huge refactor 

### DIFF
--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -32,6 +32,7 @@
 
     - verify signatures
 
+
   Usage:
   ```
   in-toto-sign [-h] -f FILE -k KEYS [KEYS ...] [-o OUTPUT] [-x] [-r] [-v]
@@ -166,10 +167,10 @@ def _load_metadata(file_path):
     with open(file_path, "r") as fp:
       file_object = json.load(fp)
 
-    if file_object["signed"].get("_type", {}) == "link":
+    if file_object.get("signed", {}).get("_type") == "link":
       return Link.read(file_object)
 
-    elif file_object["signed"].get("_type", {}) == "layout":
+    elif file_object.get("signed", {}).get("_type") == "layout":
       return Layout.read(file_object)
 
     else:

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -18,11 +18,19 @@
 
   The tool provides options to
     - add or replace signatures,
-    - add the short keyid of the signing key as infix to the filename
-      (only available for Link metadata, if multiple keys are passed the last
-      key in the argument list is used), and
-    - verify signatures
+    - write the signed file to a specified path,
+    - write the signed file to a path consisting of
+      the value from the metadata's `name` field, the first 8 characters
+      of the signing key's id as infix and '.link' as extension,
+      e.g.:  "package.c1ae1e51.link"
+      Note:
+        The naming scheme is used to distinguish Link files of steps that are
+        required to be carried out by a threshold of functionaries.
+        This option is only available for Link metadata.
+        If multiple keys are passed for signing, the short key id of the last
+        key in the arguments list is used as infix.
 
+    - verify signatures
 
   Usage:
   ```

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -42,7 +42,9 @@
   # Append two signatures to layout file and write to passed path
   in-toto-sign -f unsigned.layout -k priv_key1 priv_key2 -o root.layout -a
 
-  # Sign Link and use passed key's short id as filename infix
+  # Re-sign specified link
+  # Since -o is not specified, write to default output filename, using the
+  # short id for priv_key as a filename infix (in place of "c1ae1e51")
   in-toto-sign -f package.c1ae1e51.link -k priv_key
 
   # Verify Layout signed with three keys

--- a/test/test_in_toto_sign.py
+++ b/test/test_in_toto_sign.py
@@ -93,18 +93,17 @@ class TestInTotoSignTool(unittest.TestCase):
         "--verify",
         ], 0)
 
-    # Sign Layout "tmp.layout", replacing old signatures, write to "tmp.layout"
+    # Sign Layout "tmp.layout", appending new signature, write to "tmp.layout"
     self._test_cli_sys_exit([
         "-f", "tmp.layout",
         "-k", self.carl_path,
-        "-o", "tmp.layout",
-        "-r"
+        "-a"
         ], 0)
 
-    # Verify "tmp.layout" (has only one signature now)
+    # Verify "tmp.layout" (has three signatures now)
     self._test_cli_sys_exit([
         "-f", "tmp.layout",
-        "-k", self.carl_pub_path,
+        "-k", self.alice_pub_path, self.bob_pub_path, self.carl_pub_path,
         "--verify"
         ], 0)
 
@@ -113,7 +112,7 @@ class TestInTotoSignTool(unittest.TestCase):
     self._test_cli_sys_exit([
         "-f", self.link_path,
         "-k", self.bob_path,
-        "-r",
+        "-o", self.link_path,
         "-v"
         ], 0)
 
@@ -124,16 +123,16 @@ class TestInTotoSignTool(unittest.TestCase):
         "--verify", "-v"
         ], 0)
 
-    # Add signature to Link and use last passed key's (alice) id as infix
+    # Replace signature to Link and store to new file using passed
+    # key's (alice) id as infix
     self._test_cli_sys_exit([
         "-f", self.link_path,
-        "-k", self.carl_path, self.alice_path,
-        "-x",
+        "-k", self.alice_path
         ], 0)
     # Verify Link with alice's keyid as infix
     self._test_cli_sys_exit([
         "-f", "package.20a893b8.link",
-        "-k", self.alice_pub_path, self.bob_pub_path, self.carl_pub_path,
+        "-k", self.alice_pub_path,
         "--verify"
         ], 0)
 
@@ -164,24 +163,7 @@ class TestInTotoSignTool(unittest.TestCase):
 
 
   def test_bad_args(self):
-    """Fail with wrong comination of arguments. """
-
-    # Conflicting "infix" and "output" option
-    # Sign layout and dump to "tmp1.layout"
-    self._test_cli_sys_exit([
-        "-f", self.layout_path,
-        "-k", "key-not-used",
-        "-o", "file-not-written",
-        "-x"
-        ], 2)
-
-    # Conflicting "verify" and signing options (--verify -rx)
-    self._test_cli_sys_exit([
-        "-f", self.layout_path,
-        "-k", "key-not-used",
-        "--verify",
-        "-rx"
-        ], 2)
+    """Fail with wrong combination of arguments. """
 
     # Conflicting "verify" and signing options (--verify -o)
     self._test_cli_sys_exit([
@@ -191,13 +173,26 @@ class TestInTotoSignTool(unittest.TestCase):
         "-o", "file-not-written"
         ], 2)
 
-    # Wrong "infix" option for Layout metadata
+    # Conflicting "verify" and signing options (--verify -oa)
     self._test_cli_sys_exit([
         "-f", self.layout_path,
         "-k", "key-not-used",
-        "-x"
+        "--verify",
+        "-a",
         ], 2)
 
+    # Wrong "append" option for Link metadata
+    self._test_cli_sys_exit([
+        "-f", self.link_path,
+        "-k", "key-not-used",
+        "-a"
+        ], 2)
+
+    # Wrong multiple keys for Link metadata
+    self._test_cli_sys_exit([
+        "-f", self.link_path,
+        "-k", self.alice_path, self.bob_path,
+        ], 2)
 
   def test_bad_metadata(self):
     """Fail with wrong metadata. """

--- a/test/test_in_toto_sign.py
+++ b/test/test_in_toto_sign.py
@@ -4,6 +4,7 @@
   test_in_toto_sign.py
 <Author>
   Sachit Malik <i.sachitmalik@gmail.com>
+  Lukas Puehringer <luk.puehringer@gmail.com>
 <Started>
   Wed Jun 21, 2017
 <Copyright>
@@ -14,15 +15,15 @@
 
 import os
 import sys
-import unittest
-import logging
-import argparse
+import json
 import shutil
+import logging
 import tempfile
+import unittest
+
 from mock import patch
+from in_toto import log, exceptions
 from in_toto.in_toto_sign import main as in_toto_sign_main
-from in_toto import log
-from in_toto import exceptions
 
 WORKING_DIR = os.getcwd()
 
@@ -191,9 +192,18 @@ class TestInTotoSignTool(unittest.TestCase):
 
 
   def test_bad_metadata(self):
-    """Fail with wrong metadata type. """
+    """Fail with wrong metadata. """
+
+    # Not valid JSON
     self._test_cli_sys_exit([
         "-f", self.alice_pub_path,
+        "-k", "key-not-used",
+        ], 2)
+
+    # Valid JSON but not valid Link or Layout
+    open("tmp.json", "w").write(json.dumps({}))
+    self._test_cli_sys_exit([
+        "-f", "tmp.json",
         "-k", "key-not-used",
         ], 2)
 

--- a/test/test_in_toto_sign.py
+++ b/test/test_in_toto_sign.py
@@ -147,12 +147,20 @@ class TestInTotoSignTool(unittest.TestCase):
 
 
   def test_fail_verification(self):
-    """Fail verification with key that was not used for signing. """
+    """Fail signature verification. """
+    # Fail with wrong key (not used for signing)
     self._test_cli_sys_exit([
         "-f", self.layout_path,
         "-k", self.carl_pub_path,
         "--verify"
         ], 1)
+
+    # Fail with wrong key (not a valid pub key)
+    self._test_cli_sys_exit([
+        "-f", self.layout_path,
+        "-k", self.carl_path,
+        "--verify"
+        ], 2)
 
 
   def test_bad_args(self):

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -888,6 +888,7 @@ class TestInTotoVerify(unittest.TestCase):
     # Store various layout paths to be used in tests
     self.layout_single_signed_path = "single-signed.layout"
     self.layout_double_signed_path = "double-signed.layout"
+    self.layout_bad_sig = "bad-sig.layout"
     self.layout_expired_path = "expired.layout"
     self.layout_failing_step_rule_path = "failing-step-rule.layout"
     self.layout_failing_inspection_rule_path = "failing-inspection-rule.layout"
@@ -909,6 +910,12 @@ class TestInTotoVerify(unittest.TestCase):
     layout.sign(alice)
     layout.sign(bob)
     layout.dump(self.layout_double_signed_path)
+
+    # dump layout with bad signature
+    layout = copy.deepcopy(layout_template)
+    layout.sign(alice)
+    layout.signed.readme = "this breaks the signature"
+    layout.dump(self.layout_bad_sig)
 
     # dump expired layout
     layout = copy.deepcopy(layout_template)
@@ -959,6 +966,13 @@ class TestInTotoVerify(unittest.TestCase):
     """Test fail verification with wrong layout key. """
     layout = Layout.read_from_file(self.layout_single_signed_path)
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.bob_path])
+    with self.assertRaises(SignatureVerificationError):
+      in_toto_verify(layout, layout_key_dict)
+
+  def test_verify_failing_bad_signature(self):
+    """Test fail verification with bad layout signature. """
+    layout = Layout.read_from_file(self.layout_bad_sig)
+    layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
     with self.assertRaises(SignatureVerificationError):
       in_toto_verify(layout, layout_key_dict)
 
@@ -1125,4 +1139,4 @@ class TestGetSummaryLink(unittest.TestCase):
 
 
 if __name__ == "__main__":
-  unittest.main(buffer=True)
+  unittest.main(buffer=False)


### PR DESCRIPTION
This commit started as fix for in-toto/in-toto#118 but ended up as bigger refactor of the signing and signature verification command line tool. IMHO the structure makes more sense now.

It's probably easiest to just take a look at the code as it is now and not think too much about the diff.

The fix:
- fix whitespace problem with `-k KEYS [KEYS ...]` by replacing positional argument `signablepath` with required optional argument `-f FILE` (c.f. [python issue9338](https://bugs.python.org/issue9338) and [stackoverflow](https://stackoverflow.com/questions/26985650/argparse-do-not-catch-positional-arguments-with-nargs))
- fix funny `in-toto-sign sign` idiom by removing subparsers, making signing the default action and adding a `--verify` option

The refactor:
- Reduce redundancy by merging signing functionality
- Declutter huge nested control flow in `main()`
- Reduce docstrings to minimum
- Add early argument checking for conflicting args
- replace `-d, --destination` with `-o, --output`
- replace `-i, --infix` with `-x, --infix`

This PR also updates the unit tests to conform with the interface changes and removes tests for internally called helper functions and tests the interface more thoroughly instead.
It also removes big parts of test case setup as this can be done as part of the tests.