### PR TITLE
Remove implicit `DISALLOW *` from rule verification

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -891,13 +891,6 @@ def verify_item_rules(source_name, source_type, rules, links):
       elif source_type == "products":
         source_artifacts_queue = source_products_queue
 
-  # All artifacts have to be consumed by a rule. If we have applied all rules
-  # of a list and there are still artifacts in the queue, we fail.
-  if source_artifacts_queue:
-    raise RuleVerficationError("{0} '{1}' were not authorized by any rule"
-        " of item '{2}'".format(source_type, source_artifacts_queue,
-            source_name))
-
 
 def verify_all_item_rules(items, links):
   """

--- a/test/demo_files/demo.layout.template
+++ b/test/demo_files/demo.layout.template
@@ -13,10 +13,6 @@
                     "PRODUCTS",
                     "FROM",
                     "package"
-                ],
-                [
-                    "ALLOW",
-                    "*"
                 ]
             ],
             "expected_products": [
@@ -27,10 +23,6 @@
                     "PRODUCTS",
                     "FROM",
                     "write-code"
-                ],
-                [
-                    "ALLOW",
-                    "*"
                 ]
             ],
             "name": "untar",

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -742,11 +742,10 @@ class TestVerifyItemRules(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       verify_item_rules(self.item_name, "artifacts", [], self.links)
 
-  def test_fail_not_consumed_artifacts(self):
-    """Fail with not consumed artifacts after applying all rules. """
+  def test_pass_not_consumed_artifacts(self):
+    """Pass with not consumed artifacts (implicit ALLOW *) """
     rules = []
-    with self.assertRaises(RuleVerficationError):
-      verify_item_rules(self.item_name, "materials", rules, self.links)
+    verify_item_rules(self.item_name, "materials", rules, self.links)
 
 
 class TestVerifyAllItemRules(unittest.TestCase):


### PR DESCRIPTION
Closes #131 

Until now every recorded artifact had to be consumed by a rule. That is, when verifying the batch of rules for a certain artifact type (material or product) reported for a step or inspection, the verification routine would keep a temporary queue of all artifacts of that type for that step or inspection and remove them from the queue each time an artifact was matched by a rule's artifact pattern.

If any artifacts remained in the queue after verifying all rules (for that artifact type of that step or inspection) a RuleVerficationError was raised.

This behavior amounted to an implicit `DISALLOW *` at the end of a given `expected_materials` or `expected_products` list.

With this change the implicit `DISALLOW *` is removed, i.e. replaced with an implicit `ALLOW *`.

However a layout designer can still add an explicit `DISALLOW *` at the end of a given rule list to fail if corresponding artifacts are not matched by any prior rule's pattern.

The rationale for this change can be found in in-toto/docs#4.