### PR TITLE
Reorder final product verification routines

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1169,7 +1169,7 @@ def in_toto_verify(layout, layout_key_dict):
         8.  Verify rules defined in each Step's expected_materials and
             expected_products field
             NOTE: At this point no Inspection link metadata is available,
-            hence (MATCH) rulescannot reference materials or products of
+            hence (MATCH) rules cannot reference materials or products of
             Inspections.
             Verifying Steps' artifact rules before executing Inspections
             guarantees that Inspection commands don't run on compromised


### PR DESCRIPTION
Closes #132 

Postpone execution of Inspection commands to after having verified expected artifacts of Steps.

This guarantees that Inspection commands don't run on compromised target files, which would be a surface for attacks.

As a consequence `MATCH` rules defined for Steps won't be able to reference Inspection artifacts, because the required Inspection link metadata only gets generated when running the Inspections.

However, `MATCH` rules defined for Inspection are still able to reference Step artifacts.

This PR also updates and fixes a couple of minor issues in the long docstring of `verifylib.in_toto_verify`, which describes the final product verification routine.