### PR TITLE
Bump release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-## in-toto v0.1.0
+## in-toto v0.1.1
 * Initial pre-release

--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,7 @@
 """
 from setuptools import setup, find_packages
 
-version = "0.1.0"
-
-description = """
-A framework to define and secure the integrity of software supply chains"""
-
-long_description = """
-To learn more about in-toto visit our source code
-`repository on GitHub <https://github.com/in-toto/in-toto/tree/{version}>`__.
-""".format(version=version)
+version = "0.1.1"
 
 setup(
   name="in-toto",
@@ -49,8 +41,12 @@ setup(
   author="New York University: Secure Systems Lab",
   author_email="in-toto-dev@googlegroups.com",
   url="https://in-toto.io",
-  description=description,
-  long_description=long_description,
+  description=("A framework to define and secure the integrity of "
+    "software supply chains"),
+  long_description=("To learn more about in-toto visit our source code "
+    "`repository on GitHub "
+    "<https://github.com/in-toto/in-toto/tree/{version}>`__."
+    .format(version=version)),
   license="MIT",
   keywords="software supply chain security",
   classifiers = [


### PR DESCRIPTION
It turns out that PyPi's description parser breaks if there is a newline in the short description string.
As a consequence it does not display the string in `long_description` but a "summary" of the fields passed to setup.

This commit removes the newlines from description and long description, bumps the maintenance version number and replaces 0.1.0 with 0.1.1 (we can't replace packages on pypi but we can discard old ones).