### PR TITLE
Comment out unused user settings parsing calls

### DIFF
--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -93,7 +93,7 @@ def main():
   args = parse_args()
 
   # Override defaults in settings.py with environment variables and RCfiles
-  in_toto.user_settings.set_settings()
+  #in_toto.user_settings.set_settings()
 
   try:
     if args.prompt:

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -97,7 +97,7 @@ def main():
   log.logging.getLogger().setLevel(log.logging.INFO)
 
   # Override defaults in settings.py with environment variables and RCfiles
-  in_toto.user_settings.set_settings()
+  #in_toto.user_settings.set_settings()
 
   in_toto_mock(args.name, args.link_cmd)
 

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -209,7 +209,7 @@ def main():
     log.logging.getLogger().setLevel(log.logging.INFO)
 
   # Override defaults in settings.py with environment variables and RCfiles
-  in_toto.user_settings.set_settings()
+  #in_toto.user_settings.set_settings()
 
   if args.verify and (args.append or args.output):
     parser.print_help()

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -105,7 +105,7 @@ def main():
     log.logging.getLogger().setLevel(log.logging.INFO)
 
   # Override defaults in settings.py with environment variables and RCfiles
-  in_toto.user_settings.set_settings()
+  #in_toto.user_settings.set_settings()
 
   in_toto_verify(args.layout, args.layout_keys)
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information 
that is provided, the better.

**Fixes issue #**:
No issue for this PR

**Description of the changes being introduced by the pull request**:
Settings are currently only available for in-toto-run/record.
There is no need to parse user settings from envvars and rcfiles in other in-toto command line interfaces, this just pollutes the log (confusing the user) with lines like:
```
Setting (default): ARTIFACT_EXCLUDE_PATTERNS=['*.link*', '.git', '*.pyc', '*~']
Setting (default): ARTIFACT_BASE_PATH=None
```
We can re-add the call to the user settings parser once we provide settings for the tools in question as well. Also, we can re-think the (user) settings verbosity in general, e.g. with in-toto/in-toto#117

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


