### PR TITLE
Duplicating standard output streams

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -263,7 +263,7 @@ def execute_link(link_cmd_args, record_streams):
   # decide if s/he wants to see or store stdout/stderr
   # btw: we ignore them in the layout anyway
 
-  # Write subproc's stdin/out to a file and then read it back to python's output. 
+  # Write subproc's stdout/err to a file and then read it back to python's output. 
   # This simultaneously logs proc output while echoing it to the screen.
   # Processes that demand ttys will still complain, but this maintians
   # interactivity. Processes with buffered outputs or that use curses (eg nano)
@@ -271,13 +271,14 @@ def execute_link(link_cmd_args, record_streams):
   # still break on Windows. 
 
   if record_streams:
+
     # Windows doesn't allow reopening TemporaryFile()s
     stdout_file = tempfile.mkstemp()
     stderr_file = tempfile.mkstemp()
     stdout_name = stdout_file[1]
     stderr_name = stderr_file[1]
 
-    #Open the files as r+b cause the subprocess to block indefinitely
+    # Open the files as r+b cause the subprocess to block indefinitely
     with \
     io.open(stdout_name, 'wb') as writer, \
     io.open(stdout_name, 'rb', 1) as reader, \
@@ -290,7 +291,7 @@ def execute_link(link_cmd_args, record_streams):
         proc = subprocess.Popen((link_cmd_args), stdout=writer, \
              stderr=err_write) 
 
-        # echo proc's stdout to our stdout
+        # echo proc's logged stdout to our stdout
         while proc.poll() is None:
             sys.stdout.write(reader.read())
             sys.stderr.write(err_read.read())


### PR DESCRIPTION
Hi! This is a first attempt at issue #11. 

What I've done is adapted the current approach to log output to additionally echo it to the user's terminal. This approach uses subprocess.Popen instead of subprocess.call so toto-run can still do stuff (like echo output) while still redirecting output to files. These files are then read from during the subprocess' execution and outputted to the terminal, essentially redirecting the output while logging. 

As is, this program is completely functional with non-interactive programs on both UNIX and Windows systems, using the the "git clone" from the demo:
![image](https://user-images.githubusercontent.com/10876407/33802666-0ec1482c-dd4a-11e7-80a2-8c754ff8a93a.png)
![image](https://user-images.githubusercontent.com/10876407/33802670-1f7f5e10-dd4a-11e7-9dd3-abddaa4d6c29.png)

Certain interactive programs work well _enough_, such as Vim, where interactivity isn't hampered, and the output is logged properly. This still causes Vim to complain as it detects its output isn't connected to a tty:
![image](https://user-images.githubusercontent.com/10876407/33802698-9c35c49e-dd4a-11e7-918a-677097b2b3e9.png)
![image](https://user-images.githubusercontent.com/10876407/33802695-8eb70dbe-dd4a-11e7-8684-55cfb223f3b6.png)
Unfortunately, this doesn't seem to work on Windows, though - Vim just hangs. :( I'm not sure what causes this bug yet, might be how Vim interacts with the Windows console since I know Vim forces line buffering on unix. Curses applications like nano also behave weirdly and aren't very usable (control characters don't work). 

Subprocesses that use stdio's default buffering also have their own issues, such as in the following program I built that asks the user for a number and echoes it back. Without making an explicit call to fflush() in the program itself, toto-run blocks on input before the prompt is flushed to the terminal: 
![image](https://user-images.githubusercontent.com/10876407/33802731-b612e5c6-dd4b-11e7-9cdb-bc15b3155c78.png)
![image](https://user-images.githubusercontent.com/10876407/33802733-bbb63f1e-dd4b-11e7-83eb-5d469e5c8714.png)
An explicit flush in subprocess itself "fixes" this: 
![image](https://user-images.githubusercontent.com/10876407/33802736-d6db2c5a-dd4b-11e7-80ee-3df733c66a7b.png)

As an aside, I'm not entirely sure if it's even possible to portably simulate a connected tty device. I wonder if it might be worth considering checking the user's platform and interacting with the underlying terminal accordingly. While this contribution is portable, it still seems to have platform-related bugs, like with Vim hanging on Windows. 

*I understand stderr is not required anymore, though I thought to implement it anyway to keep the byproducts unchanged. If desired I can strip out all references to stderr though. 