### PR TITLE
Adding partial verification

### DIFF
--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -33,7 +33,7 @@ import in_toto.util
 from in_toto import verifylib
 from in_toto.models.metadata import Metablock
 
-def in_toto_verify(layout_path, layout_key_paths):
+def in_toto_verify(layout_path, layout_key_paths, partial_verif):
   """
   <Purpose>
     Loads the layout metadata as Metablock object (containg a Layout object)
@@ -68,7 +68,7 @@ def in_toto_verify(layout_path, layout_key_paths):
     layout_key_dict = in_toto.util.import_rsa_public_keys_from_files_as_dict(
         layout_key_paths)
 
-    verifylib.in_toto_verify(layout, layout_key_dict)
+    verifylib.in_toto_verify(layout, layout_key_dict, partial_verif)
   except Exception as e:
     log.fail_verification("{0} - {1}".format(type(e).__name__, e))
     sys.exit(1)
@@ -98,6 +98,9 @@ def main():
   in_toto_args.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", default=False, action="store_true")
 
+  in_toto_args.add_argument("-p", "--partial", dest="partial_verif",
+      help="Enables partial verification", default=False, action="store_true")
+
   args = parser.parse_args()
 
   # Turn on all the `log.info()` in the library
@@ -107,7 +110,7 @@ def main():
   # Override defaults in settings.py with environment variables and RCfiles
   in_toto.user_settings.set_settings()
 
-  in_toto_verify(args.layout, args.layout_keys)
+  in_toto_verify(args.layout, args.layout_keys, args.partial_verif)
 
 if __name__ == "__main__":
   main()

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -84,7 +84,7 @@ def main():
   parser.usage = ("\n"
       "%(prog)s --layout <layout path>\n{0}"
                "--layout-keys <filepath>[ <filepath> ...]\n{0}"
-               "[--verbose]\n\n"
+               "[--verbose] [-p/--partial]\n\n"
                .format(lpad))
 
   in_toto_args = parser.add_argument_group("in-toto options")

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -33,7 +33,7 @@ import in_toto.util
 from in_toto import verifylib
 from in_toto.models.metadata import Metablock
 
-def in_toto_verify(layout_path, layout_key_paths, partial_verif):
+def in_toto_verify(layout_path, layout_key_paths, partial_verif=0):
   """
   <Purpose>
     Loads the layout metadata as Metablock object (containg a Layout object)
@@ -47,6 +47,10 @@ def in_toto_verify(layout_path, layout_key_paths, partial_verif):
     layout_key_paths:
             List of paths to project owner public keys, used to verify the
             layout's signature.
+
+    partial_verif:
+            [Optional] Determines the step at which to stop for partial
+            verification.
 
   <Exceptions>
     SystemExit if any exception occurs
@@ -84,7 +88,7 @@ def main():
   parser.usage = ("\n"
       "%(prog)s --layout <layout path>\n{0}"
                "--layout-keys <filepath>[ <filepath> ...]\n{0}"
-               "[--verbose] [-p/--partial]\n\n"
+               "[--verbose]\n\n"
                .format(lpad))
 
   in_toto_args = parser.add_argument_group("in-toto options")
@@ -98,8 +102,13 @@ def main():
   in_toto_args.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", default=False, action="store_true")
 
-  in_toto_args.add_argument("-p", "--partial", dest="partial_verif",
-      help="Enables partial verification", default=False, action="store_true")
+  in_toto_args.add_argument("-p", "--partial", type=str, required=False,
+      help="Enables partial verification to verify specified steps "
+           "(1) Verifies the layout signature(s) and expiration(s) "
+           "(2) Verifies all the link functionaries and signatures "
+           "(3) Verifies sublayouts, including steps, threshold constraints,"
+           "    and the materials/products for all steps "
+           "(4) Verifies the inspection rules for materials and products", default=0)
 
   args = parser.parse_args()
 
@@ -110,7 +119,7 @@ def main():
   # Override defaults in settings.py with environment variables and RCfiles
   in_toto.user_settings.set_settings()
 
-  in_toto_verify(args.layout, args.layout_keys, args.partial_verif)
+  in_toto_verify(args.layout, args.layout_keys, int(args.partial))
 
 if __name__ == "__main__":
   main()

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1344,7 +1344,8 @@ def in_toto_verify(layout, layout_key_dict, partial_verif=False):
   log.info("Verifying Inspection rules...")
   # Artifact rules for inspections can reference links that correspond to
   # Steps or Inspections, hence the concatenation of both collections of links
-  combined_links = _run_verification(reduced_chain_link_dict.copy, partial_verif=partial_verif, failures=failures)
+  combined_links = _run_verification(reduced_chain_link_dict.copy, req_comps=reduced_chain_link_dict,
+                                     partial_verif=partial_verif, failures=failures)
   _run_verification(combined_links.update, inspection_link_dict, partial_verif=partial_verif, failures=failures)
   _run_verification(verify_all_item_rules, layout.inspect, combined_links, partial_verif=partial_verif, failures=failures)
 
@@ -1364,6 +1365,7 @@ def _run_verification(func, *args, **kwargs):
   # Default flag values
   partial_verif = kwargs.get('partial_verif', False)
   failures = kwargs.get('failures', {})
+  required_components = kwargs.get('req_comps', [])
 
   # If not running partial verification, run the command as usual
   if not partial_verif:
@@ -1372,7 +1374,7 @@ def _run_verification(func, *args, **kwargs):
     retVal = None
 
     # If missing a required variable, fail immediately
-    if None in args:
+    if None in args or None in required_components:
       log.info("Cannot proceed due to previous failed step")
       return retVal
 

--- a/test/test_in_toto_verify.py
+++ b/test/test_in_toto_verify.py
@@ -154,5 +154,11 @@ class TestInTotoVerifyTool(unittest.TestCase):
     with self.assertRaises(SystemExit):
       in_toto_verify("wrong-layout-path", [self.alice_path])
 
+  def test_in_toto_verify_partial_verification(self):
+    in_toto_verify(self.layout_single_signed_path, [self.alice_path], 1)
+    in_toto_verify(self.layout_single_signed_path, [self.alice_path], 2)
+    in_toto_verify(self.layout_single_signed_path, [self.alice_path], 3)
+    in_toto_verify(self.layout_single_signed_path, [self.alice_path], 4)
+
 if __name__ == "__main__":
   unittest.main(buffer=True)

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -1016,6 +1016,15 @@ class TestInTotoVerify(unittest.TestCase):
     with self.assertRaises(RuleVerficationError):
       in_toto_verify(layout, layout_key_dict)
 
+  def test_partial_verification(self):
+    """Test partial-verification of single-signed layout. """
+    layout = Metablock.load(self.layout_single_signed_path)
+    layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
+    in_toto_verify(layout, layout_key_dict, 1)
+    in_toto_verify(layout, layout_key_dict, 2)
+    in_toto_verify(layout, layout_key_dict, 3)
+    in_toto_verify(layout, layout_key_dict, 4)
+
 
 class TestVerifySublayouts(unittest.TestCase):
   """Tests verifylib.verify_sublayouts(layout, reduced_chain_link_dict).


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:
Adding partial verification, #116 

**Description of the changes being introduced by the pull request**:
This pull request includes code that allows for partial verification of `in-toto-verify`.
Simply adding a `-p` flag followed by the step number at which the user wishes to
stop (as defined in the call to `in-toto-verify --help`) will run `in-toto-verify` until it reaches
that stopping point. Steps are divided logically into checking the layout signature, 
functionary signatures, sub-layouts/steps, and inspection. Sub-layouts did not include
their own partial verification, so sub-layouts are completely verified; however, this can
easily be changed by adding the `partial_verif` variable as a parameter in `verify_sublayouts()`
and by adding a specific return value to the `progress` dictionary in the `in-toto-verify()`
function of `verifylib.py`.

Originally, partial verification was written to step over failed functions. This was changed to
the above version of partial verification. Previous commits were left in the commit history.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


