### PR TITLE
Add pylint and bandit to tox and adapt code to pass linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
     - "2.7"
 
 env:
-    TOXENV=py27
+    - TOXENV=lint
+    - TOXENV=py27
 
 install:
     - pip install tox

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -31,17 +31,12 @@
   python in_toto_keygen.py -p bob_keys 2048
 
 """
-import os
 import sys
 import argparse
-import json
-import getpass
 import in_toto.util
 import in_toto.user_settings
 from in_toto import log
-import securesystemslib.formats
-import securesystemslib.keys
-import securesystemslib.exceptions
+
 
 def parse_args():
   """

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -104,4 +104,4 @@ def main():
     sys.exit(1)
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -33,11 +33,10 @@
 
 """
 
-import os
 import sys
 import argparse
 import in_toto.user_settings
-from in_toto import (util, runlib, log)
+from in_toto import (runlib, log)
 
 def in_toto_mock(name, link_cmd_args):
   """

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -43,7 +43,6 @@
   ```
 
 """
-import os
 import sys
 import argparse
 import in_toto.util

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -167,7 +167,7 @@ def main():
   try:
     key = in_toto.util.prompt_import_rsa_key_from_file(args.key)
   except Exception as e:
-    log.error("in load key - {}".format(args.key))
+    log.error("in load key - {}".format(e))
     sys.exit(1)
 
   if args.command == "start":

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -29,7 +29,6 @@
 
 """
 
-import os
 import sys
 import argparse
 import in_toto.user_settings

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -146,7 +146,7 @@ def main():
   try:
     key = util.prompt_import_rsa_key_from_file(args.key)
   except Exception as e:
-    log.error("in load key - {}".format(args.key))
+    log.error("in load key - {}".format(e))
     sys.exit(1)
 
   if args.no_command:

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -71,10 +71,6 @@ def in_toto_run(step_name, material_list, product_list,
     None.
   """
 
-  """Load link signing private keys from disk and runs passed command, storing
-  its materials, by-products and return value, and products into link metadata
-  file. The link metadata file is signed and stored to disk. """
-
   try:
     runlib.in_toto_run(step_name, material_list, product_list,
         link_cmd_args, key, record_streams)

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -92,14 +92,14 @@ def _sign_and_dump_metadata(metadata, args):
     if args.output:
       out_path = args.output
 
-    elif metadata._type == "link":
+    elif metadata.type_ == "link":
       out_path = FILENAME_FORMAT.format(step_name=metadata.signed.name,
           keyid=keyid)
 
-    elif metadata._type == "layout":
+    elif metadata.type_ == "layout":
       out_path = args.file
 
-    log.info("Dumping {0} to '{1}'...".format(metadata._type,
+    log.info("Dumping {0} to '{1}'...".format(metadata.type_,
         out_path))
 
     metadata.dump(out_path)
@@ -216,7 +216,7 @@ def main():
 
   metadata = _load_metadata(args.file)
 
-  if metadata._type == "link":
+  if metadata.type_ == "link":
     if len(args.key) > 1:
       parser.print_help()
       parser.exit(2, "wrong arguments: Link metadata can only be signed by"

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -54,9 +54,7 @@
   ```
 
 """
-import os
 import sys
-import json
 import argparse
 import in_toto.user_settings
 from in_toto import log, exceptions, util

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -22,20 +22,20 @@ logging.basicConfig(level=in_toto.settings.LOG_LEVEL, format='%(message)s')
 
 def info(msg):
   """Verbose user feedback. """
-  logging.info("{}".format(msg))
+  logging.info("%s", msg)
 
 def warn(msg):
   """Verbose user warning. """
-  logging.warn("WARNING: {}".format(msg))
+  logging.warn("WARNING: %s", msg)
 
 def error(msg):
   """Prints unexpected errors """
-  logging.error("ERROR: {}".format(msg))
+  logging.error("ERROR: %s", msg)
 
 def pass_verification(msg):
   """Prints passing verification routines. """
-  logging.critical("PASSING: {}".format(msg))
+  logging.critical("PASSING: %s", msg)
 
 def fail_verification(msg):
   """Prints failing verification. """
-  logging.critical("FAILING: {}".format(msg))
+  logging.critical("FAILING: %s", msg)

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -99,6 +99,11 @@ class Layout(Signable):
 
     self.validate()
 
+  @property
+  def type_(self):
+    """Getter for protected _type attribute. Trailing underscore used by
+    convention (pep8) to avoid conflict with Python's type keyword. """
+    return self._type
 
   @staticmethod
   def read(data):

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -126,9 +126,10 @@ class Layout(Signable):
           "Invalid _type value for layout (Should be 'layout')")
 
   def _validate_expires(self):
-    """Private method to verify the expiration field."""
+    """Private method to verify if the expiration field has the right format
+    and can be parsed."""
     try:
-      date = parse(self.expires)
+      parse(self.expires)
       securesystemslib.formats.ISO8601_DATETIME_SCHEMA.check_match(
           self.expires)
     except Exception as e:
@@ -150,7 +151,7 @@ class Layout(Signable):
 
     securesystemslib.formats.KEYDICT_SCHEMA.check_match(self.keys)
 
-    for keyid, key in six.iteritems(self.keys):
+    for junk, key in six.iteritems(self.keys):
       securesystemslib.formats.PUBLIC_KEY_SCHEMA.check_match(key)
 
   def _validate_steps_and_inspections(self):

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -29,7 +29,6 @@
       represents a hook that is run at verification
 """
 
-import json
 import attr
 import six
 import shlex
@@ -38,7 +37,6 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from dateutil.parser import parse
 
-from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT)
 from in_toto.models.common import Signable, ValidationMixin
 import in_toto.artifact_rules
 import in_toto.exceptions

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -19,7 +19,6 @@
 """
 
 import attr
-import json
 import securesystemslib.formats
 from in_toto.models.common import Signable
 

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -99,6 +99,11 @@ class Link(Signable):
 
     self.validate()
 
+  @property
+  def type_(self):
+    """Getter for protected _type attribute. Trailing underscore used by
+    convention (pep8) to avoid conflict with Python's type keyword. """
+    return self._type
 
   @staticmethod
   def read(data):

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -116,10 +116,11 @@ class Metablock(object):
 
 
   @property
-  def _type(self):
-    """ Shortcut to the _type property of the contained Link or Layout object,
-    should be one of "link" or "layout". """
-    return self.signed._type
+  def type_(self):
+    """Shortcut to the _type property of the contained Link or Layout object,
+    should be one of "link" or "layout". Trailing underscore used by
+    convention (pep8) to avoid conflict with Python's type keyword. """
+    return self.signed.type_
 
 
   def sign(self, key):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -266,7 +266,8 @@ def execute_link(link_cmd_args, record_streams):
   # btw: we ignore them in the layout anyway
 
   if record_streams:
-    # Use SpooledTemporaryFile if we expect very large outputs
+    # We should consider using SpooledTemporaryFile if we expect very large
+    # outputs in the future
     stdout_file = tempfile.TemporaryFile()
     stderr_file = tempfile.TemporaryFile()
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -54,10 +54,13 @@ else:
   import subprocess
 
 
-def _hash_artifact(filepath, hash_algorithms=['sha256']):
+def _hash_artifact(filepath, hash_algorithms=None):
   """Internal helper that takes a filename and hashes the respective file's
   contents using the passed hash_algorithms and returns a hashdict conformant
   with securesystemslib.formats.HASHDICT_SCHEMA. """
+  if not hash_algorithms:
+    hash_algorithms = ['sha256']
+
   securesystemslib.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
   hash_dict = {}
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -251,7 +251,7 @@ def execute_link(link_cmd_args, record_streams):
       Note: If record_streams is False, the dict values are empty strings.
     - The return value of the executed command.
   """
-  # XXX: The first approach only redirects the stdout/stderr to a tempfile
+  # TODO: The first approach only redirects the stdout/stderr to a tempfile
   # but we actually want to duplicate it, ideas
   #  - Using a pipe won't work because processes like vi will complain
   #  - Wrapping stdout/sterr in Python does not work because the suprocess
@@ -263,7 +263,7 @@ def execute_link(link_cmd_args, record_streams):
   # btw: we ignore them in the layout anyway
 
   if record_streams:
-    # XXX: Use SpooledTemporaryFile if we expect very large outputs
+    # Use SpooledTemporaryFile if we expect very large outputs
     stdout_file = tempfile.TemporaryFile()
     stderr_file = tempfile.TemporaryFile()
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -277,8 +277,8 @@ def execute_link(link_cmd_args, record_streams):
     stderr_str = stderr_file.read()
 
   else:
-      return_value = subprocess.call(link_cmd_args)
-      stdout_str = stderr_str = ""
+    return_value = subprocess.call(link_cmd_args)
+    stdout_str = stderr_str = ""
 
   return {
       "stdout": stdout_str,

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -21,8 +21,8 @@
 
 """
 import os
-import log
 import ConfigParser
+import in_toto.log
 import in_toto.settings
 
 
@@ -202,11 +202,11 @@ def set_settings():
   for setting in IN_TOTO_SETTINGS:
     user_setting = user_settings.get(setting)
     if user_setting:
-      log.info("Setting (user): {0}={1}".format(
+      in_toto.log.info("Setting (user): {0}={1}".format(
           setting, user_setting))
       setattr(in_toto.settings, setting, user_setting)
 
     else:
       default_setting = getattr(in_toto.settings, setting)
-      log.info("Setting (default): {0}={1}".format(
+      in_toto.log.info("Setting (default): {0}={1}".format(
           setting, default_setting))

--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -1,10 +1,6 @@
-import os
 import sys
-import pickle
-import json
 import getpass
 
-from in_toto import log
 import securesystemslib.formats
 import securesystemslib.hash
 import securesystemslib.keys

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -126,7 +126,7 @@ def load_links_for_layout(layout):
         metadata = Metablock.load(filename)
         links_per_step[keyid] = metadata
 
-      except IOError as e:
+      except IOError:
         pass
 
     # Check if the step has been performed by enough number of functionaries
@@ -507,7 +507,7 @@ def verify_match_rule(rule, source_artifacts_queue, source_artifacts, links):
   # Extract destination link
   try:
     dest_link = links[dest_name]
-  except Exception as e:
+  except KeyError:
     raise RuleVerficationError("Rule '{rule}' failed, destination link"
         " '{dest_link}' not found in link dictionary".format(
             rule=" ".join(rule), dest_link=dest_name))
@@ -999,8 +999,6 @@ def verify_all_item_rules(items, links):
   """
 
   for item in items:
-
-    link = links[item.name]
     log.info("Verifying material rules for '{}'...".format(item.name))
     verify_item_rules(item.name, "materials", item.expected_materials, links)
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1168,7 +1168,7 @@ def verify_sublayouts(layout, chain_link_dict):
 
     for keyid, link in six.iteritems(key_link_dict):
 
-      if link._type == "layout":
+      if link.type_ == "layout":
         log.info("Verifying sublayout {}...".format(step_name))
         layout_key_dict = {}
 
@@ -1231,7 +1231,6 @@ def get_summary_link(layout, reduced_chain_link_dict):
   last_step_link = reduced_chain_link_dict[layout.steps[-1].name]
 
   summary_link.materials = first_step_link.signed.materials
-  summary_link._type = first_step_link.signed._type
   summary_link.name = first_step_link.signed.name
 
   summary_link.products = last_step_link.signed.products

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -38,7 +38,7 @@ import in_toto.models.link
 from in_toto.models.metadata import Metablock
 from in_toto.models.link import (FILENAME_FORMAT, FILENAME_FORMAT_SHORT)
 from in_toto.exceptions import (RuleVerficationError, LayoutExpiredError,
-    ThresholdVerificationError, BadReturnValueError)
+    ThresholdVerificationError, BadReturnValueError, AuthorizationError)
 import in_toto.artifact_rules
 import in_toto.log as log
 
@@ -1062,7 +1062,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
 
     # Take a reference link (e.g. the first in the step_link_dict)
     reference_keyid = key_link_dict.keys()[0]
-    reference_link = key_link_dict[reference_key]
+    reference_link = key_link_dict[reference_keyid]
 
     # Iterate over all links to compare their properties with a reference_link
     for keyid, link in six.iteritems(key_link_dict):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -36,8 +36,7 @@ import in_toto.runlib
 import in_toto.models.layout
 import in_toto.models.link
 from in_toto.models.metadata import Metablock
-from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
-    FILENAME_FORMAT_SHORT)
+from in_toto.models.link import (FILENAME_FORMAT, FILENAME_FORMAT_SHORT)
 from in_toto.exceptions import (RuleVerficationError, LayoutExpiredError,
     ThresholdVerificationError, BadReturnValueError)
 import in_toto.artifact_rules

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,426 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=parameter-unpacking, unpacking-in-except, long-suffix, old-ne-operator, old-octal-literal, import-star-module-level, raw-checker-failed, bad-inline-option, locally-disabled, locally-enabled, file-ignored, suppressed-message, useless-suppression, deprecated-pragma, apply-builtin, basestring-builtin, buffer-builtin, cmp-builtin, coerce-builtin, execfile-builtin, file-builtin, long-builtin, raw_input-builtin, reduce-builtin, standarderror-builtin, unicode-builtin, xrange-builtin, coerce-method, delslice-method, getslice-method, setslice-method, no-absolute-import, old-division, dict-iter-method, dict-view-method, next-method-called, metaclass-assignment, indexing-exception, raising-string, reload-builtin, oct-method, hex-method, nonzero-method, cmp-method, input-builtin, round-builtin, intern-builtin, unichr-builtin, map-builtin-not-iterating, zip-builtin-not-iterating, range-builtin-not-iterating, filter-builtin-not-iterating, using-cmp-argument, eq-without-hash, div-method, idiv-method, rdiv-method, exception-message-attribute, invalid-str-codec, sys-max-int, deprecated-str-translate-call, global-statement, broad-except, logging-not-lazy, C, R
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+#output-format=parseable
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[BASIC]
+
+# Naming hint for argument names
+argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct argument names
+argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for attribute names
+attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct attribute names
+attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming hint for function names
+function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct function names
+function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for method names
+method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct method names
+method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming hint for variable names
+variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='  '
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=XXX,
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local, six.moves
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_|junk
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict, _fields, _replace, _source, _make, _generate_and_write_metadata, _delete_obsolete_metadata, _log_status_of_top_level_roles, _load_top_level_metadata, _strip_version_number, _delegated_roles, _remove_invalid_and_duplicate_signatures
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     bandit
 
 commands =
-    # Run pylint, using securesystemslib's pylintrc configuration file
+    # Run pylint, using secure system lab's pylintrc configuration file
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
     pylint in_toto
 
@@ -21,6 +21,9 @@ commands =
     # subprocess32 modules, which are considered to have low severity security
     # implications, but are required by in-toto. We do not skip subprocess
     # calls with shell=True (B602).
+    # https://docs.openstack.org/bandit/latest/blacklists/blacklist_imports.html#b404-import-subprocess
+    # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
+    # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
     bandit -r in_toto --skip B404,B603
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,26 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27
+envlist = lint,py27
 
-[testenv]
+[testenv:lint]
+deps =
+    pylint
+    bandit
+
+commands =
+    # Run pylint, using securesystemslib's pylintrc configuration file
+    # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
+    pylint in_toto
+
+    # Run bandit, a security linter from OpenStack Security
+    # Note: We exclude tests that fail on importing or using the subprocess or
+    # subprocess32 modules, which are considered to have low severity security
+    # implications, but are required by in-toto. We do not skip subprocess
+    # calls with shell=True (B602).
+    bandit -r in_toto --skip B404,B603
+
+[testenv:py27]
 deps =
     -rrequirements.txt
     -rrequirements-ci.txt


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
Adds a lint test environment to tox.ini to run bandit and pylint using securesystemslib's generic (pylintrc)[https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc].
We separate static from dynamic testing, because former needs to run only once (not for each tested Python version).

The PR also fixes various issues pointed out by running the linters.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


