### PR TITLE
Add minimum test coverage threshold to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,3 +35,4 @@ commands =
     # Integrating tox with setup.py test is as of Oct 2016 discouraged
     # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
     coverage run test/runtests.py
+    coverage report -m --fail-under 99


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Adds 99% threshold for minimum test code coverage for unittests
run with tox.

If the coverage gets below 99% tox exits with non-zero.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


