### PR TITLE
Add gpg support to in-toto-record cli tool and library functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,22 @@ in-toto-run  --step-name <unique step name>
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
 multi-part software supply chain steps, i.e. steps that are not carried out
-by a single command. Use `in-toto-record ... start ...` to create a
+by a single command. Use `in-toto-record start ...` to create a
 preliminary link file that only records the *materials*, then run the
-commands of that step, and finally use `in-toto-record ... stop ...` to
-record the *products* and generate the actual link metadata file. *Note:
-`in-toto-record` does not support GPG signing yet.*
+commands of that step or edit files manually and finally use
+`in-toto-record stop ...` to record the *products* and generate the actual
+link metadata file.
 
 ```shell
-in-toto-record  --step-name <unique step name>
-                --key <functionary private key path>
-               [--verbose]
-Commands:
-               start [--materials <filepath>[ <filepath> ...]]
-               stop  [--products <filepath>[ <filepath> ...]]
+usage: in-toto-record start --step-name <unique step name>
+                            (--key <signing key path> | --gpg [<gpg keyid>])
+                            [--gpg-home <gpg keyring path>] [-v]
+                            [--materials <material path> [<material path> ...]]
+
+usage: in-toto-record stop -step-name <unique step name>
+                           (--key <signing key path> | --gpg [<gpg keyid>])
+                           [--gpg-home <gpg keyring path>] [-v]
+                           [--products <product path> [<product path> ...]]
 ```
 
 #### Release final product

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 """
 <Program Name>
   in_toto_record.py
@@ -14,32 +13,41 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  Provides a command line interface to start and stop in-toto link metadata
-  recording.
+  Provides a command line interface to create a link metadata file in multiple
+  steps. The commands are:
 
   start
-    Takes a step name, a functionary's signing key and optional
-    material paths.
     Creates a temporary link file containing the file hashes of the passed
-    materials and signs it with the functionary's key under
-    .<step name>.link-unfinished
+    materials and signs it with the passed functionary's key under
+    .<step name>.<keyid>.link-unfinished
 
   stop
-    Takes a step name, a functionary's signing key and optional
-    product paths.
-    Expects a .<step name>.link-unfinished in the current directory signed by
-    the functionary's signing key, adds the file hashes of the passed products,
-    updates the signature and renames the file  .<step name>.link-unfinished
-    to <step name>.link
-
+    Expects a .<step name>.<keyid>.link-unfinished in the current directory
+    signed by the passed functionary's key, adds the file hashes of the passed
+    products, updates the signature and renames the file
+    .<step name>.<keyid>.link-unfinished to <step name>.<keyid>.link
 
   The implementation of the tasks can be found in runlib.
 
-  Example Usage
+<Example Usage>
+  Create link file signed with specified 'key' stored on disk and record all
+  files in current working directory as materials and products.
+  Any files in the current working directory that you edit between running
+  the commands will have different hashes in their corresponding material and
+  product entries of the resulting link file 'edit-files.<keyid>.link'.
+
   ```
-  in-toto-record --step-name edit-files start --materials . --key bob
-  # Edit files manually ...
-  in-toto-record --step-name edit-files stop --products . --key bob
+  in-toto-record start --step-name edit-files -key /path/to/key --materials .
+  in-toto-record stop --step-name edit-files -key /path/to/key --products .
+  ```
+
+  # Create link file signed with the default gpg key and record a file named
+  # 'foo' as material and product.
+  # If you edit foo between running the commands the recorded hashes in the
+  # resulting link file 'edit-foo.<keyid>.link' will differ.
+  ```
+  in-toto-record start --step-name edit-foo --gpg --materials path/to/foo
+  in-toto-record stop --step-name edit-foo --gpg --products path/to/foo
   ```
 
 """

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -108,10 +108,10 @@ def main():
 
   try:
     if args.command == "start":
-      in_toto.runlib.in_toto_record_start(args.step_name, key, args.materials)
+      in_toto.runlib.in_toto_record_start(args.step_name, args.materials, key)
 
     elif args.command == "stop": # pragma: no branch
-      in_toto.runlib.in_toto_record_stop(args.step_name, key, args.products)
+      in_toto.runlib.in_toto_record_stop(args.step_name, args.products, key)
 
     # Else is caught by argparser
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -56,10 +56,9 @@ def main():
   parser = argparse.ArgumentParser(
       description="Starts or stops link metadata recording")
 
+  # The subparsers inherit the arguments from the parent parser
+  parent_parser = argparse.ArgumentParser(add_help=False)
   subparsers = parser.add_subparsers(dest="command")
-
-  subparser_start = subparsers.add_parser('start')
-  subparser_stop = subparsers.add_parser('stop')
 
   # Whitespace padding to align with program name
   lpad = (len(parser.prog) + 1) * " "
@@ -72,16 +71,18 @@ def main():
                "stop  [--products <filepath>[ <filepath> ...]]\n"
                .format(lpad))
 
-  in_toto_args = parser.add_argument_group("in-toto options")
   # FIXME: Do we limit the allowed characters for the name?
-  in_toto_args.add_argument("-n", "--step-name", type=str, required=True,
+  parent_parser.add_argument("-n", "--step-name", type=str, required=True,
       help="Unique name for link metadata")
 
-  in_toto_args.add_argument("-k", "--key", type=str, required=True,
+  parent_parser.add_argument("-k", "--key", type=str, required=True,
       help="Path to private key to sign link metadata (PEM)")
 
-  in_toto_args.add_argument("-v", "--verbose", dest='verbose',
-      help="Verbose execution.", default=False, action='store_true')
+  parent_parser.add_argument("-v", "--verbose", dest="verbose",
+      help="Verbose execution.", default=False, action="store_true")
+
+  subparser_start = subparsers.add_parser("start", parents=[parent_parser])
+  subparser_stop = subparsers.add_parser("stop", parents=[parent_parser])
 
   subparser_start.add_argument("-m", "--materials", type=str, required=False,
       nargs='+', help="Files to record before link command execution")

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -117,9 +117,9 @@ def main():
   # we will try to sign with the default key
   gpg_use_default = (args.gpg == True)
 
-  # Otherwise we interpret it as actual keyid
+  # Otherwise gpg_keyid stays either None or gets the passed argument assigned
   gpg_keyid = None
-  if args.gpg != True:
+  if not gpg_use_default and args.gpg:
     gpg_keyid = args.gpg
 
   # We load the key here because it might prompt the user for a password in
@@ -139,12 +139,11 @@ def main():
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home)
 
-    elif args.command == "stop": # pragma: no branch
+    # Mutually exclusiveness is guaranteed by argparser
+    else: # args.command == "stop":
       in_toto.runlib.in_toto_record_stop(args.step_name, args.products,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home)
-
-    # Else is caught by argparser
 
   except Exception as e:
     in_toto.log.error("in {} record - {}".format(args.command, e))

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -147,5 +147,7 @@ def main():
     in_toto.log.error("in {} record - {}".format(args.command, e))
     sys.exit(1)
 
+  sys.exit(0)
+
 if __name__ == "__main__":
   main()

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -60,23 +60,13 @@ def main():
   parent_parser = argparse.ArgumentParser(add_help=False)
   subparsers = parser.add_subparsers(dest="command")
 
-  # Whitespace padding to align with program name
-  lpad = (len(parser.prog) + 1) * " "
-  parser.usage = ("\n"
-      "%(prog)s  --step-name <unique step name>\n{0}"
-               " --key <functionary private key path>\n"
-               "[--verbose]\n"
-      "Commands:\n{0}"
-               "start [--materials <filepath>[ <filepath> ...]]\n{0}"
-               "stop  [--products <filepath>[ <filepath> ...]]\n"
-               .format(lpad))
-
   # FIXME: Do we limit the allowed characters for the name?
   parent_parser.add_argument("-n", "--step-name", type=str, required=True,
-      help="Unique name for link metadata")
+      help="Unique name for link metadata", metavar="<unique step name>")
 
   parent_parser.add_argument("-k", "--key", type=str, required=True,
-      help="Path to private key to sign link metadata (PEM)")
+      help="Path to private key to sign link metadata (PEM)",
+      metavar="<signing key path>")
 
   parent_parser.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", default=False, action="store_true")
@@ -85,10 +75,12 @@ def main():
   subparser_stop = subparsers.add_parser("stop", parents=[parent_parser])
 
   subparser_start.add_argument("-m", "--materials", type=str, required=False,
-      nargs='+', help="Files to record before link command execution")
+      nargs='+', help="Files to record before link command execution",
+      metavar="<material path>")
 
   subparser_stop.add_argument("-p", "--products", type=str, required=False,
-      nargs='+', help="Files to record after link command execution")
+      nargs='+', help="Files to record after link command execution",
+      metavar="<product path>")
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -13,8 +13,11 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  Provides a command line interface to create a link metadata file in multiple
-  steps. The commands are:
+  Provides a command line interface to create a link metadata file in two
+  steps, in order to provide evidence for activities that can't be expressed
+  by a single command (for which you should use in-toto-run).
+
+  The commands to start and stop recording evidence are:
 
   start
     Creates a temporary link file containing the file hashes of the passed

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -26,6 +26,7 @@ from in_toto.models.common import Signable
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
 FILENAME_FORMAT_SHORT = "{step_name}.link"
 UNFINISHED_FILENAME_FORMAT = ".{step_name}.{keyid:.8}.link-unfinished"
+UNFINISHED_FILENAME_FORMAT_GLOB = ".{step_name}.{pattern}.link-unfinished"
 
 
 @attr.s(repr=False, init=False)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -28,12 +28,13 @@ import sys
 import os
 import tempfile
 import fnmatch
+import glob
 
 import in_toto.settings
 import in_toto.exceptions
 from in_toto import log
 from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
-    FILENAME_FORMAT_SHORT)
+    FILENAME_FORMAT_SHORT, UNFINISHED_FILENAME_FORMAT_GLOB)
 
 import securesystemslib.formats
 import securesystemslib.hash
@@ -327,6 +328,17 @@ def in_toto_mock(name, link_cmd_args):
   return link_metadata
 
 
+def _check_match_signing_key(signing_key):
+  """ Helper method to check if the signing_key has securesystemslib's
+  KEY_SCHEMA and the private part is not empty.
+  # FIXME: Add private key format check to formats
+  """
+  securesystemslib.formats.KEY_SCHEMA.check_match(signing_key)
+  if not signing_key["keyval"].get("private"):
+    raise securesystemslib.exceptions.FormatError(
+        "Signing key needs to be a private key.")
+
+
 def in_toto_run(name, material_list, product_list, link_cmd_args,
     record_streams=False, signing_key=None, gpg_keyid=None,
     gpg_use_default=False, gpg_home=None):
@@ -378,7 +390,8 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
-        securesystemslib.formats.KEY_SCHEMA.
+        securesystemslib.formats.KEY_SCHEMA or a gpg_keyid is passed and does
+        not match securesystemslib.foramts.KEYID_SCHEMA
 
   <Side Effects>
     If a key parameter is passed for signing, the newly created link metadata
@@ -388,16 +401,13 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     Newly created Metablock object containing a Link object
 
   """
-
   log.info("Running '{}'...".format(name))
 
-  # If a key is passed, it has to match the format
+  # Check key formats to fail early
   if signing_key:
-    securesystemslib.formats.KEY_SCHEMA.check_match(signing_key)
-    # FIXME: Add private key format check to formats
-    if not signing_key["keyval"].get("private"):
-      raise securesystemslib.exceptions.FormatError(
-          "Signing key needs to be a private key.")
+    _check_match_signing_key(signing_key)
+  if gpg_keyid:
+    securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
@@ -443,12 +453,17 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
   return link_metadata
 
 
-def in_toto_record_start(step_name, material_list, signing_key):
+def in_toto_record_start(step_name, material_list, signing_key=None,
+    gpg_keyid=None, gpg_use_default=False, gpg_home=None):
   """
   <Purpose>
     Starts creating link metadata for a multi-part in-toto step. I.e.
     records passed materials, creates link meta data object from it, signs it
-    with passed key and stores it to disk with UNFINISHED_FILENAME_FORMAT.
+    with passed signing_key, gpg key identified by the passed gpg_keyid
+    or the default gpg key and stores it to disk under
+    UNFINISHED_FILENAME_FORMAT.
+
+    One of signing_key, gpg_keyid or gpg_use_default has to be passed.
 
   <Arguments>
     step_name:
@@ -457,11 +472,23 @@ def in_toto_record_start(step_name, material_list, signing_key):
     material_list:
             List of file or directory paths that should be recorded as
             materials.
-    signing_key:
-            Private key to sign link metadata.
+    signing_key: (optional)
+            If not None, link metadata is signed with this key.
             Format is securesystemslib.formats.KEY_SCHEMA
+    gpg_keyid: (optional)
+            If not None, link metadata is signed with a gpg key identified
+            by the passed keyid.
+    gpg_use_default: (optional)
+            If True, link metadata is signed with default gpg key.
+    gpg_home: (optional)
+            Path to GPG keyring (if not set the default keyring is used).
+
   <Exceptions>
-    None.
+    ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
+          is passed.
+    securesystemslib.FormatError if a signing_key is passed and does not match
+        securesystemslib.formats.KEY_SCHEMA or a gpg_keyid is passed and does
+        not match securesystemslib.foramts.KEYID_SCHEMA
 
   <Side Effects>
     Writes newly created link metadata file to disk using the filename scheme
@@ -471,10 +498,18 @@ def in_toto_record_start(step_name, material_list, signing_key):
     None.
 
   """
-
-  unfinished_fn = UNFINISHED_FILENAME_FORMAT.format(step_name=step_name,
-      keyid=signing_key["keyid"])
   log.info("Start recording '{}'...".format(step_name))
+
+  # Fail if there is no signing key arg at all
+  if not signing_key and not gpg_keyid and not gpg_use_default:
+    raise ValueError("Pass either a signing key, a gpg keyid or set"
+        " gpg_use_default to True!")
+
+  # Check key formats to fail early
+  if signing_key:
+    _check_match_signing_key(signing_key)
+  if gpg_keyid:
+    securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
@@ -487,22 +522,44 @@ def in_toto_record_start(step_name, material_list, signing_key):
 
   link_metadata = Metablock(signed=link)
 
-  log.info("Signing link metadata with key '{:.8}...'...".format(
-      signing_key["keyid"]))
-  link_metadata.sign(signing_key)
+  if signing_key:
+    log.info("Signing link metadata using passed key...")
+    signature = link_metadata.sign(signing_key)
+
+  elif gpg_keyid:
+    log.info("Signing link metadata using passed GPG keyid...")
+    signature = link_metadata.sign_gpg(gpg_keyid, gpg_home=gpg_home)
+
+  else:  # (gpg_use_default)
+    log.info("Signing link metadata using default GPG key ...")
+    signature = link_metadata.sign_gpg(gpg_keyid=None, gpg_home=gpg_home)
+
+  # We need the signature's keyid to write the link to keyid infix'ed filename
+  signing_keyid = signature["keyid"]
+
+  unfinished_fn = UNFINISHED_FILENAME_FORMAT.format(step_name=step_name,
+    keyid=signing_keyid)
 
   log.info("Storing preliminary link metadata to '{}'...".format(unfinished_fn))
   link_metadata.dump(unfinished_fn)
 
 
-def in_toto_record_stop(step_name, product_list, signing_key):
+
+def in_toto_record_stop(step_name, product_list, signing_key=None,
+    gpg_keyid=None, gpg_use_default=False, gpg_home=None):
   """
   <Purpose>
     Finishes creating link metadata for a multi-part in-toto step.
-    Loads signing key and unfinished link metadata file from disk, verifies
-    that the file was signed with the key, records products, updates unfinished
-    Link object (products and signature), removes unfinished link file from and
+    Loads unfinished link metadata file from disk, verifies
+    that the file was signed with either the passed signing key, a gpg key
+    identified by the passed gpg_keyid or the default gpg key.
+
+    Then records products, updates unfinished Link object
+    (products and signature), removes unfinished link file from and
     stores new link file to disk.
+
+    One of signing_key, gpg_keyid or gpg_use_default has to be passed and it
+    needs to be the same that was used with preceding in_toto_record_start.
 
   <Arguments>
     step_name:
@@ -510,12 +567,25 @@ def in_toto_record_stop(step_name, product_list, signing_key):
             layout.
     product_list:
             List of file or directory paths that should be recorded as products.
-    signing_key:
-            Private key to sign link metadata.
+    signing_key: (optional)
+            If not None, link metadata is signed with this key.
             Format is securesystemslib.formats.KEY_SCHEMA
+    gpg_keyid: (optional)
+            If not None, link metadata is signed with a gpg key identified
+            by the passed keyid.
+    gpg_use_default: (optional)
+            If True, link metadata is signed with default gpg key.
+    gpg_home: (optional)
+            Path to GPG keyring (if not set the default keyring is used).
 
   <Exceptions>
-    None.
+    ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
+      is passed.
+    securesystemslib.FormatError if a signing_key is passed and does not match
+        securesystemslib.formats.KEY_SCHEMA or a gpg_keyid is passed and does
+        not match securesystemslib.foramts.KEYID_SCHEMA
+    LinkNotFoundError if gpg is used for signing and the corresponding
+        preliminary link file can not be found in the current working directory
 
   <Side Effects>
     Writes newly created link metadata file to disk using the filename scheme
@@ -526,29 +596,91 @@ def in_toto_record_stop(step_name, product_list, signing_key):
     None.
 
   """
-  fn = FILENAME_FORMAT.format(step_name=step_name, keyid=signing_key["keyid"])
-  unfinished_fn = UNFINISHED_FILENAME_FORMAT.format(step_name=step_name,
-      keyid=signing_key["keyid"])
   log.info("Stop recording '{}'...".format(step_name))
 
-  # Expects an a file with name UNFINISHED_FILENAME_FORMAT in the current dir
+  # Check that we have something to sign and if the formats are right
+  if not signing_key and not gpg_keyid and not gpg_use_default:
+    raise ValueError("Pass either a signing key, a gpg keyid or set"
+        " gpg_use_default to True")
+
+  if signing_key:
+    _check_match_signing_key(signing_key)
+  if gpg_keyid:
+    securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+
+  # Load preliminary link file
+  # If we have a signing key we can use the keyid to construct the name
+  if signing_key:
+    unfinished_fn = UNFINISHED_FILENAME_FORMAT.format(step_name=step_name,
+        keyid=signing_key["keyid"])
+
+  # FIXME: Currently there is no way to know the default GPG key's keyid and
+  # so we glob for preliminary link files
+  else:
+    unfinished_fn_glob = UNFINISHED_FILENAME_FORMAT_GLOB.format(
+        step_name=step_name, pattern="*")
+    unfinished_fn_list = glob.glob(unfinished_fn_glob)
+
+    if not len(unfinished_fn_list):
+      raise in_toto.exceptions.LinkNotFoundError("Could not find a preliminary"
+          " link for step '{}' in the current working directory.".format(
+          step_name))
+
+    if len(unfinished_fn_list) > 1:
+      raise in_toto.exceptions.LinkNotFoundError("Found more than one"
+          " preliminary links for step '{}' in the current working directory:"
+          " {}. We need exactly one to stop recording.".format(
+          step_name, ", ".join(unfinished_fn_list)))
+
+    unfinished_fn = unfinished_fn_list[0]
+
   log.info("Loading preliminary link metadata '{}'...".format(unfinished_fn))
   link_metadata = Metablock.load(unfinished_fn)
 
   # The file must have been signed by the same key
-  log.info("Verifying preliminary link signature...")
-  keydict = {signing_key["keyid"] : signing_key}
-  link_metadata.verify_signatures(keydict)
+  # If we have a signing_key we use it for verification as well
+  if signing_key:
+    log.info("Verifying preliminary link signature using passed signing key...")
+    keyid = signing_key["keyid"]
+    verification_key_dict = {keyid: signing_key}
 
+  elif gpg_keyid:
+    log.info("Verifying preliminary link signature using passed gpg key...")
+    gpg_pubkey = in_toto.gpg.functions.gpg_export_pubkey(gpg_keyid, gpg_home)
+    keyid = gpg_pubkey["keyid"]
+    verification_key_dict = {keyid: gpg_pubkey}
+
+  else: # must be gpg_use_default
+    # FIXME: Currently there is no way to know the default GPG key's keyid
+    # before signing. As a workaround we extract the keyid of the preliminary
+    # Link file's signature and try to export a pubkey from the gpg
+    # keyring. We do this even if a gpg_keyid was specified, because gpg
+    # accepts many different ids (mail, name, parts of an id, ...) but we
+    # need a specific format.
+    log.info("Verifying preliminary link signature using default gpg key...")
+    keyid = link_metadata.signatures[0]["keyid"]
+    gpg_pubkey = in_toto.gpg.functions.gpg_export_pubkey(keyid, gpg_home)
+    verification_key_dict = {keyid: gpg_pubkey}
+
+  link_metadata.verify_signatures(verification_key_dict)
+
+  # Record products if a product path list was passed
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))
   link_metadata.signed.products = record_artifacts_as_dict(product_list)
 
-  log.info("Updating signature with key '{:.8}...'...".format(
-      signing_key["keyid"]))
   link_metadata.signatures = []
-  link_metadata.sign(signing_key)
+  if signing_key:
+    log.info("Updating signature with key '{:.8}...'...".format(keyid))
+    link_metadata.sign(signing_key)
 
+  else: # gpg_keyid or gpg_use_default
+    # In both cases we use the keyid we got from verifying the preliminary
+    # link signature above.
+    log.info("Updating signature with gpg key '{:.8}...'...".format(keyid))
+    link_metadata.sign_gpg(keyid, gpg_home)
+
+  fn = FILENAME_FORMAT.format(step_name=step_name, keyid=keyid)
   log.info("Storing link metadata to '{}'...".format(fn))
   link_metadata.dump(fn)
 

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -64,22 +64,23 @@ class TestInTotoRecordTool(unittest.TestCase):
 
   def test_main_required_args(self):
     """Test CLI command record start/stop with required arguments. """
-    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
-        self.key_path]
-    with patch.object(sys, 'argv', args + ["start"]):
+    args = ["--step-name", "test-step", "--key", self.key_path]
+
+    with patch.object(sys, 'argv', ["in_toto_record.py", "start"] + args):
       in_toto_record_main()
-    with patch.object(sys, 'argv', args + ["stop"]):
+    with patch.object(sys, 'argv', ["in_toto_record.py", "stop"] + args):
       in_toto_record_main()
+
 
   def test_main_optional_args(self):
     """Test CLI command record start/stop with optional arguments. """
-    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
+    args = ["--step-name", "test-step", "--key",
         self.key_path]
-    with patch.object(sys, 'argv', args + ["start", "--materials",
-        self.test_artifact]):
+    with patch.object(sys, 'argv',
+        ["in_toto_record.py", "start"] + args + ["-m", self.test_artifact]):
       in_toto_record_main()
-    with patch.object(sys, 'argv', args + ["stop", "--products",
-        self.test_artifact]):
+    with patch.object(sys, 'argv',
+        ["in_toto_record.py", "stop"] +  args + ["-p", self.test_artifact]):
       in_toto_record_main()
 
   def test_main_wrong_args(self):
@@ -102,8 +103,8 @@ class TestInTotoRecordTool(unittest.TestCase):
 
   def test_main_wrong_key_exits(self):
     """Test CLI command record with wrong key exits and logs error """
-    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
-        "non-existing-key", "start"]
+    args = [ "in_toto_record.py", "start", "--step-name", "test-step", "--key",
+        "non-existing-key"]
     with patch.object(sys, 'argv',
         args), self.assertRaises(
         SystemExit):
@@ -111,13 +112,12 @@ class TestInTotoRecordTool(unittest.TestCase):
 
   def test_main_verbose(self):
     """Log level with verbose flag is lesser/equal than logging.INFO. """
-    args = [ "in_toto_record.py", "--step-name", "test-step", "--key",
-        self.key_path, "--verbose"]
+    args = ["--step-name", "test-step", "--key", self.key_path, "--verbose"]
 
     original_log_level = logging.getLogger().getEffectiveLevel()
-    with patch.object(sys, 'argv', args + ["start"]):
+    with patch.object(sys, 'argv', ["in_toto_record.py", "start"] + args):
       in_toto_record_main()
-    with patch.object(sys, 'argv', args + ["stop"]):
+    with patch.object(sys, 'argv', ["in_toto_record.py", "stop"] + args):
       in_toto_record_main()
     self.assertLessEqual(logging.getLogger().getEffectiveLevel(), logging.INFO)
     # Reset log level
@@ -125,7 +125,7 @@ class TestInTotoRecordTool(unittest.TestCase):
 
   def test_stop_missing_unfinished_link_exit(self):
     """Error exit with missing unfinished link file. """
-    args = ["in_toto_record.py", "-n", "test-step", "-k", self.key_path, "stop"]
+    args = ["in_toto_record.py", "stop", "-n", "test-step", "-k", self.key_path]
     with patch.object(sys, 'argv', args), self.assertRaises(SystemExit):
       in_toto_record_main()
 

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -28,6 +28,7 @@ import tempfile
 from mock import patch
 
 import in_toto.util
+from in_toto.models.link import UNFINISHED_FILENAME_FORMAT
 from in_toto.in_toto_record import main as in_toto_record_main
 
 WORKING_DIR = os.getcwd()
@@ -40,12 +41,23 @@ class TestInTotoRecordTool(unittest.TestCase):
   in_toto_record_start/in_toto_record_stop - calls runlib and error logs/exits
   on Exception. """
 
+
   @classmethod
   def setUpClass(self):
     """Create and change into temporary directory,
     generate key pair, dummy artifact and base arguments. """
     self.test_dir = tempfile.mkdtemp()
+
+    # Find gpg keyring
+    gpg_keyring_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
+
     os.chdir(self.test_dir)
+
+    # Copy gpg keyring to temp dir
+    self.gnupg_home = os.path.join(self.test_dir, "rsa")
+    shutil.copytree(gpg_keyring_path, self.gnupg_home)
+    self.gpg_keyid = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
 
     self.key_path = "test_key"
     in_toto.util.generate_and_write_rsa_keypair(self.key_path)
@@ -55,11 +67,13 @@ class TestInTotoRecordTool(unittest.TestCase):
     open(self.test_artifact1, "w").close()
     open(self.test_artifact2, "w").close()
 
+
   @classmethod
   def tearDownClass(self):
     """Change back to initial working dir and remove temp test directory. """
     os.chdir(WORKING_DIR)
     shutil.rmtree(self.test_dir)
+
 
   def _test_cli_sys_exit(self, cli_args, status):
     """Test helper to mock command line call and assert return value. """
@@ -96,13 +110,51 @@ class TestInTotoRecordTool(unittest.TestCase):
     self._test_cli_sys_exit(["start"] + args, 0)
     self._test_cli_sys_exit(["stop"] + args, 0)
 
+    # Start/stop sign with specified gpg keyid
+    args = ["--step-name", "test5", "--gpg", self.gpg_keyid, "--gpg-home",
+        self.gnupg_home]
+    self._test_cli_sys_exit(["start"] + args, 0)
+    self._test_cli_sys_exit(["stop"] + args, 0)
 
-  def test_no_key(self):
+    # Start/stop sign with default gpg keyid
+    # Default key signing only works on fully supported gpg versions
+    args = ["--step-name", "test5", "--gpg", "--gpg-home", self.gnupg_home]
+    if in_toto.gpg.util.is_version_fully_supported():
+      self._test_cli_sys_exit(["start"] + args, 0)
+      self._test_cli_sys_exit(["stop"] + args, 0)
+
+    else:
+      self._test_cli_sys_exit(["start"] + args, 1)
+      self._test_cli_sys_exit(["stop"] + args, 1)
+
+  def test_glob_no_unfinished_files(self):
+    """Test record stop with missing unfinished files when globbing (gpg). """
+    args = ["--step-name", "test-no-glob", "--gpg", self.gpg_keyid,
+        "--gpg-home", self.gnupg_home]
+    self._test_cli_sys_exit(["stop"] + args, 1)
+
+  def test_glob_to_many_unfinished_files(self):
+    """Test record stop with to many unfinished files when globbing (gpg). """
+    name = "test-to-many-glob"
+    fn1 = UNFINISHED_FILENAME_FORMAT.format(step_name=name, keyid="a12345678")
+    fn2 = UNFINISHED_FILENAME_FORMAT.format(step_name=name, keyid="b12345678")
+    open(fn1, "w").close()
+    open(fn2, "w").close()
+    args = ["--step-name", name, "--gpg", self.gpg_keyid,
+        "--gpg-home", self.gnupg_home]
+    self._test_cli_sys_exit(["stop"] + args, 1)
+
+  def test_wrong_key(self):
     """Test CLI command record with wrong key exits 1 """
-    args = ["--step-name", "no-key", "--key", "non-existing-key"]
+    args = ["--step-name", "wrong-key", "--key", "non-existing-key"]
     self._test_cli_sys_exit(["start"] + args, 1)
     self._test_cli_sys_exit(["stop"] + args, 1)
 
+  def test_no_key(self):
+    """Test if no key is specified, argparse error exists with 2"""
+    args = ["--step-name", "no-key"]
+    self._test_cli_sys_exit(["start"] + args, 2)
+    self._test_cli_sys_exit(["stop"] + args, 2)
 
   def test_missing_unfinished_link(self):
     """Error exit with missing unfinished link file. """

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -31,7 +31,6 @@ from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_import_rsa_key_from_file)
 from in_toto.models.link import Link
 from in_toto.in_toto_record import main as in_toto_record_main
-from in_toto.in_toto_record import in_toto_record_start, in_toto_record_stop
 
 WORKING_DIR = os.getcwd()
 
@@ -124,20 +123,11 @@ class TestInTotoRecordTool(unittest.TestCase):
     # Reset log level
     logging.getLogger().setLevel(original_log_level)
 
-  def test_in_toto_record_start_stop(self):
-    """in_toto_record_start/stop run through. """
-    in_toto_record_start("test-step", self.key, [self.test_artifact])
-    in_toto_record_stop("test-step", self.key, [self.test_artifact])
-
-  def test_in_toto_record_start_bad_key_error_exit(self):
-    """Error exit in_toto_record_start with bad key. """
-    with self.assertRaises(SystemExit):
-      in_toto_record_start("test-step", "bad-key", [self.test_artifact])
-
-  def test_in_toto_record_stop_missing_unfinished_link_exit(self):
-    """Error exit in_toto_record_stop with missing unfinished link file. """
-    with self.assertRaises(SystemExit):
-      in_toto_record_stop("test-step", self.key, [self.test_artifact])
+  def test_stop_missing_unfinished_link_exit(self):
+    """Error exit with missing unfinished link file. """
+    args = ["in_toto_record.py", "-n", "test-step", "-k", self.key_path, "stop"]
+    with patch.object(sys, 'argv', args), self.assertRaises(SystemExit):
+      in_toto_record_main()
 
 
 if __name__ == '__main__':

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -117,21 +117,21 @@ class TestInTotoRecordTool(unittest.TestCase):
     self._test_cli_sys_exit(["stop"] + args, 0)
 
     # Start/stop sign with default gpg keyid
-    # Default key signing only works on fully supported gpg versions
     args = ["--step-name", "test6", "--gpg", "--gpg-home", self.gnupg_home]
     if in_toto.gpg.util.is_version_fully_supported():
       self._test_cli_sys_exit(["start"] + args, 0)
       self._test_cli_sys_exit(["stop"] + args, 0)
 
     else:
-      # Fail (exit 1) start recording on not fully supported gpg version
+      # Signing with the default GPG key does not work on not
+      # "fully supported versions" of GPG, which makes in-toto-record start
+      # fail with exit code 1 ...
       self._test_cli_sys_exit(["start"] + args, 1)
-
-      # NOTE: Stop recording with default gpg on not fully supported gpg
-      # version actually does not fail, because we get the keyid from the
-      # preliminary link file and then pass it directly to gpg.
-      # We need to create the preliminary link file first, which requires
-      # a call to in-toto-record start, passing a gpg keyid explicitly.
+      # ... in-toto-record stop, however, uses a workaround to assess the keyid
+      # based on an existing preliminary link file even if no keyid was passed.
+      # To create that preliminary link file we call start, passing it the GPG
+      # keyid explicitly (remember, start would fail otherwise) and then call
+      # stop using the default GPG key.
       self._test_cli_sys_exit(["start", "--step-name", "test6", "--gpg",
           self.gpg_keyid, "--gpg-home", self.gnupg_home], 0)
       self._test_cli_sys_exit(["stop"] + args, 0)

--- a/test/test_in_toto_record.py
+++ b/test/test_in_toto_record.py
@@ -118,14 +118,24 @@ class TestInTotoRecordTool(unittest.TestCase):
 
     # Start/stop sign with default gpg keyid
     # Default key signing only works on fully supported gpg versions
-    args = ["--step-name", "test5", "--gpg", "--gpg-home", self.gnupg_home]
+    args = ["--step-name", "test6", "--gpg", "--gpg-home", self.gnupg_home]
     if in_toto.gpg.util.is_version_fully_supported():
       self._test_cli_sys_exit(["start"] + args, 0)
       self._test_cli_sys_exit(["stop"] + args, 0)
 
     else:
+      # Fail (exit 1) start recording on not fully supported gpg version
       self._test_cli_sys_exit(["start"] + args, 1)
-      self._test_cli_sys_exit(["stop"] + args, 1)
+
+      # NOTE: Stop recording with default gpg on not fully supported gpg
+      # version actually does not fail, because we get the keyid from the
+      # preliminary link file and then pass it directly to gpg.
+      # We need to create the preliminary link file first, which requires
+      # a call to in-toto-record start, passing a gpg keyid explicitly.
+      self._test_cli_sys_exit(["start", "--step-name", "test6", "--gpg",
+          self.gpg_keyid, "--gpg-home", self.gnupg_home], 0)
+      self._test_cli_sys_exit(["stop"] + args, 0)
+
 
   def test_glob_no_unfinished_files(self):
     """Test record stop with missing unfinished files when globbing (gpg). """

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -383,6 +383,12 @@ class TestInTotoRecordStart(unittest.TestCase):
     link.verify_signatures({self.key["keyid"] : self.key})
     os.remove(self.link_name_unfinished)
 
+  def test_no_key_arguments(self):
+    """Test record start without passing one required key argument. """
+    with self.assertRaises(ValueError):
+      in_toto_record_start(
+          self.step_name, [], signing_key=None, gpg_keyid=None,
+          gpg_use_default=False)
 
 class TestInTotoRecordStop(unittest.TestCase):
   """"Test in_toto_record_stop(step_name, key, product_list). """
@@ -471,6 +477,13 @@ class TestInTotoRecordStop(unittest.TestCase):
       open(self.link_name, "r")
     os.rename(changed_link_name, link_name)
     os.remove(self.link_name_unfinished)
+
+  def test_no_key_arguments(self):
+    """Test record stop without passing one required key argument. """
+    with self.assertRaises(ValueError):
+      in_toto_record_stop(
+          self.step_name, [], signing_key=None, gpg_keyid=None,
+          gpg_use_default=False)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -370,7 +370,7 @@ class TestInTotoRecordStart(unittest.TestCase):
   def test_create_unfinished_metadata_with_expected_material(self):
     """Test record start creates metadata with expected material. """
     in_toto_record_start(
-        self.step_name, self.key, [self.test_material])
+        self.step_name, [self.test_material], self.key)
     link = Metablock.load(self.link_name_unfinished)
     self.assertEquals(link.signed.materials.keys(), [self.test_material])
     os.remove(self.link_name_unfinished)
@@ -378,7 +378,7 @@ class TestInTotoRecordStart(unittest.TestCase):
   def test_create_unfininished_metadata_verify_signature(self):
     """Test record start creates metadata with expected signature. """
     in_toto_record_start(
-        self.step_name, self.key, [self.test_material])
+        self.step_name, [self.test_material], self.key)
     link = Metablock.load(self.link_name_unfinished)
     link.verify_signatures({self.key["keyid"] : self.key})
     os.remove(self.link_name_unfinished)
@@ -419,32 +419,32 @@ class TestInTotoRecordStop(unittest.TestCase):
 
   def test_create_metadata_with_expected_product(self):
     """Test record stop records expected product. """
-    in_toto_record_start(self.step_name, self.key, [])
-    in_toto_record_stop(self.step_name, self.key, [self.test_product])
+    in_toto_record_start(self.step_name, [], self.key)
+    in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
     self.assertEquals(link.signed.products.keys(), [self.test_product])
     os.remove(self.link_name)
 
   def test_create_metadata_with_expected_cwd(self):
     """Test record start/stop run, verify cwd. """
-    in_toto_record_start(self.step_name, self.key, [])
-    in_toto_record_stop(self.step_name, self.key, [self.test_product])
+    in_toto_record_start(self.step_name, [], self.key)
+    in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
     self.assertEquals(link.signed.environment["workdir"], os.getcwd())
     os.remove(self.link_name)
 
   def test_create_metadata_verify_signature(self):
     """Test record start creates metadata with expected signature. """
-    in_toto_record_start(self.step_name, self.key, [])
-    in_toto_record_stop(self.step_name, self.key, [])
+    in_toto_record_start(self.step_name, [], self.key)
+    in_toto_record_stop(self.step_name, [], self.key)
     link = Metablock.load(self.link_name)
     link.verify_signatures({self.key["keyid"] : self.key})
     os.remove(self.link_name)
 
   def test_replace_unfinished_metadata(self):
     """Test record stop removes unfinished file and creates link file. """
-    in_toto_record_start(self.step_name, self.key, [])
-    in_toto_record_stop(self.step_name, self.key, [])
+    in_toto_record_start(self.step_name, [], self.key)
+    in_toto_record_stop(self.step_name, [], self.key)
     with self.assertRaises(IOError):
       open(self.link_name_unfinished, "r")
     open(self.link_name, "r")
@@ -453,20 +453,20 @@ class TestInTotoRecordStop(unittest.TestCase):
   def test_missing_unfinished_file(self):
     """Test record stop exits on missing unfinished file, no link recorded. """
     with self.assertRaises(IOError):
-      in_toto_record_stop(self.step_name, self.key, [])
+      in_toto_record_stop(self.step_name, [], self.key)
     with self.assertRaises(IOError):
       open(self.link_name, "r")
 
   def test_wrong_signature_in_unfinished_metadata(self):
     """Test record stop exits on wrong signature, no link recorded. """
-    in_toto_record_start(self.step_name, self.key, [])
+    in_toto_record_start(self.step_name, [], self.key)
     link_name = UNFINISHED_FILENAME_FORMAT.format(
         step_name=self.step_name, keyid=self.key["keyid"])
     changed_link_name = UNFINISHED_FILENAME_FORMAT.format(
         step_name=self.step_name, keyid=self.key2["keyid"])
     os.rename(link_name, changed_link_name)
     with self.assertRaises(SignatureVerificationError):
-      in_toto_record_stop(self.step_name, self.key2, [])
+      in_toto_record_stop(self.step_name, [], self.key2)
     with self.assertRaises(IOError):
       open(self.link_name, "r")
     os.rename(changed_link_name, link_name)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
This PR adds gpg signing capabilities to the `in-toto-record` command line tool and its corresponding library functions.
*Note: in-toto-record can be used to create link metadata for multipart steps*

Furthermore this PR makes the following enhancements in in-toto-record:
- Declutter the command line interface code (77cac9e5b9c6346ef49fc370d51840a97a2c6b18)
- Make in-toto-record's subcommands `start` and `stop` the first arguments. Shared and arguments specific to the subcommands come afterwards. Former is realized with a shared [`argparse` parent parser](https://docs.python.org/2.7/library/argparse.html#parents) (fa227d6e6b772f9209bb4ca5c6147893366c341d)
- Remove custom cli tool help message and improve auto help message with [`argparse` metavars](https://docs.python.org/2.7/library/argparse.html#metavar) (20ddbfdc7f8fc51521039a2abb40b048c86c9f28)
- Update README (7ad6d551261b1a1f822573e831e9f2d400e69c67)
- Refactor unit tests (5ced4b8bac49372ed07f64012a54c9c2e71f7abd)

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


