### PR TITLE
Add support for Python 3.4, 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
-language:
-    python
-
-python:
-    - "2.7"
+dist: trusty
+language: python
+python: 3.6
 
 env:
     - TOXENV=lint
@@ -12,8 +10,8 @@ env:
     - TOXENV=py36
 
 install:
-    - pip install tox
-    - pip install coveralls
+    - pip install -U tox
+    - pip install -U coveralls
 
 script:
     - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
     - TOXENV=py35
     - TOXENV=py36
 
+
+before_install:
+    # Workaround for https://github.com/travis-ci/travis-ci/issues/8363
+    - pyenv global system 3.5
+
 install:
     - pip install -U tox
     - pip install -U coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,13 @@ matrix:
         # hoping that tox and pyenv run the tests in the desired versions.
         # https://github.com/travis-ci/travis-ci/issues/8363#issuecomment-355090242
         - python: "2.7"
-          env: TOXENV=py27-unittest
+          env: TOXENV=py27
         - python: "3.4"
-          env: TOXENV=py34-unittest
+          env: TOXENV=py34
         - python: "3.5"
-          env: TOXENV=py35-unittest
+          env: TOXENV=py35
         - python: "3.6"
-          env: TOXENV=py36-unittest
-
-        # Use max Python version supported by both bandit and pylint
-        - python: "3.5"
-          env: TOXENV=lint
+          env: TOXENV=py36
 
 install:
     - pip install -U tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
 env:
     - TOXENV=lint
     - TOXENV=py27
+    - TOXENV=py34
+    - TOXENV=py35
+    - TOXENV=py36
 
 install:
     - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 dist: trusty
 language: python
-python: 3.6
 
-env:
-    - TOXENV=lint
-    - TOXENV=py27
-    - TOXENV=py34
-    - TOXENV=py35
-    - TOXENV=py36
+matrix:
+    include:
+        # Explicitly tell Travis which Python version to use for which
+        # tox environment, instead of using one Python version in Travis and
+        # hoping that tox and pyenv run the tests in the desired versions.
+        # https://github.com/travis-ci/travis-ci/issues/8363#issuecomment-355090242
+        - python: "2.7"
+          env: TOXENV=py27-unittest
+        - python: "3.4"
+          env: TOXENV=py34-unittest
+        - python: "3.5"
+          env: TOXENV=py35-unittest
+        - python: "3.6"
+          env: TOXENV=py36-unittest
 
-
-before_install:
-    # Workaround for https://github.com/travis-ci/travis-ci/issues/8363
-    - pyenv global system 3.5
+        # Use max Python version supported by both bandit and pylint
+        - python: "3.5"
+          env: TOXENV=lint
 
 install:
     - pip install -U tox

--- a/in_toto/gpg/common.py
+++ b/in_toto/gpg/common.py
@@ -114,6 +114,7 @@ def parse_signature_packet(data):
 
   data = in_toto.gpg.util.parse_packet_header(
       data, PACKET_TYPES['signature_packet'])
+
   ptr = 0
 
   # we get the version number, which we also expect to be v4, or we bail
@@ -188,7 +189,7 @@ def parse_signature_packet(data):
 
   # Excluded so that coverage does not vary in different test environments
   if keyid: # pragma: no cover
-    keyid = binascii.hexlify(keyid[0][1][2:])
+    keyid = binascii.hexlify(keyid[0][1][2:]).decode("ascii")
 
   else: # pragma: no cover
     keyid = ""

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -207,7 +207,8 @@ def get_version():
 
   """
   command = shlex.split(in_toto.gpg.constants.GPG_VERSION_COMMAND)
-  process = subprocess.Popen(command, stdout=subprocess.PIPE)
+  process = subprocess.Popen(command, stdout=subprocess.PIPE,
+      universal_newlines=True)
   full_version_info, junk = process.communicate()
 
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -146,7 +146,7 @@ def compute_keyid(pubkey_packet_data):
   hasher.update(b'\x99')
   hasher.update(struct.pack(">H", len(pubkey_packet_data)))
   hasher.update(bytes(pubkey_packet_data))
-  return binascii.hexlify(hasher.finalize())
+  return binascii.hexlify(hasher.finalize()).decode("ascii")
 
 
 def parse_subpackets(subpacket_octets):

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -26,7 +26,7 @@ def info(msg):
 
 def warn(msg):
   """Verbose user warning. """
-  logging.warn("WARNING: %s", msg)
+  logging.warning("WARNING: %s", msg)
 
 def error(msg):
   """Prints unexpected errors """

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -28,6 +28,7 @@
   Inspection:
       represents a hook that is run at verification
 """
+from six import string_types
 
 import attr
 import shlex
@@ -144,7 +145,7 @@ class Layout(Signable):
 
   def _validate_readme(self):
     """Private method to check that the readme field is a string."""
-    if not isinstance(self.readme, basestring):
+    if not isinstance(self.readme, string_types):
       raise securesystemslib.exceptions.FormatError(
           "Invalid readme '{}', value must be a string."
           .format(self.readme))

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -127,7 +127,7 @@ class Link(Signable):
           "Invalid Link: field `materials` must be of type dict, got: {}"
           .format(type(self.materials)))
 
-    for material in self.materials.values():
+    for material in list(self.materials.values()):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(material)
 
 
@@ -138,7 +138,7 @@ class Link(Signable):
           "Invalid Link: field `products` must be of type dict, got: {}"
           .format(type(self.products)))
 
-    for product in self.products.values():
+    for product in list(self.products.values()):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(product)
 
 

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -73,8 +73,8 @@ class Metablock(object):
       None.
 
     """
-    with open(filename, "wt") as fp:
-      fp.write("{}".format(self))
+    with open(filename, "wb") as fp:
+      fp.write("{}".format(self).encode("utf-8"))
 
 
   @staticmethod

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -43,7 +43,7 @@ from in_toto.models.metadata import Metablock
 
 # POSIX users (Linux, BSD, etc.) are strongly encouraged to
 # install and use the much more recent subprocess32
-if os.name == 'posix' and sys.version_info[0] < 3:
+if os.name == 'posix' and sys.version_info[0] < 3: # pragma: no cover
   try:
     import subprocess32 as subprocess
   except ImportError:

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -21,12 +21,14 @@
 
 """
 import os
-import ConfigParser
 import six
 import in_toto.log
 import in_toto.settings
 
-
+try:
+  import configparser
+except ImportError:
+  import ConfigParser as configparser
 
 USER_PATH = os.path.expanduser("~")
 
@@ -163,7 +165,7 @@ def get_rc():
   """
   rc_dict = {}
 
-  config = ConfigParser.ConfigParser()
+  config = configparser.ConfigParser()
   # Reset `optionxform`'s default case conversion to enable case-sensitivity
   config.optionxform = str
   config.read(RC_PATHS)

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -22,6 +22,7 @@
 """
 import os
 import ConfigParser
+import six
 import in_toto.log
 import in_toto.settings
 
@@ -104,7 +105,7 @@ def get_env():
   """
   env_dict = {}
 
-  for name, value in os.environ.iteritems():
+  for name, value in six.iteritems(os.environ):
     if (name.startswith(ENV_PREFIX) and
         len(name) > len(ENV_PREFIX)):
       stripped_name = name[len(ENV_PREFIX):]

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -27,7 +27,7 @@ import in_toto.settings
 
 try:
   import configparser
-except ImportError:
+except ImportError: # pragam: no cover
   import ConfigParser as configparser
 
 USER_PATH = os.path.expanduser("~")

--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -52,10 +52,10 @@ def generate_and_write_rsa_keypair(filepath, bits=DEFAULT_RSA_KEY_BITS,
   else:
     private_pem = private
 
-  with open(filepath + ".pub", "w") as fo_public:
+  with open(filepath + ".pub", "wb") as fo_public:
     fo_public.write(public.encode("utf-8"))
 
-  with open(filepath, "w") as fo_private:
+  with open(filepath, "wb") as fo_private:
     fo_private.write(private_pem.encode("utf-8"))
 
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -902,8 +902,8 @@ def verify_item_rules(source_name, source_type, rules, links):
   source_materials = links[source_name].signed.materials
   source_products = links[source_name].signed.products
 
-  source_materials_queue = source_materials.keys()
-  source_products_queue = source_products.keys()
+  source_materials_queue = list(source_materials.keys())
+  source_products_queue = list(source_products.keys())
 
   # Create generic source artifacts list and queue depending on the source type
   if source_type == "materials":
@@ -1069,7 +1069,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
           " by enough functionaries!".format(step.name))
 
     # Take a reference link (e.g. the first in the step_link_dict)
-    reference_keyid = key_link_dict.keys()[0]
+    reference_keyid = list(key_link_dict.keys())[0]
     reference_link = key_link_dict[reference_keyid]
 
     # Iterate over all links to compare their properties with a reference_link
@@ -1127,7 +1127,7 @@ def reduce_chain_links(chain_link_dict):
     # Extract the key_link_dict for this step from the passed chain_link_dict
     # take one exemplary link (e.g. the first in the step_link_dict)
     # form the reduced_chain_link_dict to return
-    reduced_chain_link_dict[step_name] = key_link_dict.values()[0]
+    reduced_chain_link_dict[step_name] = list(key_link_dict.values())[0]
 
   return reduced_chain_link_dict
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx
 attrs
 python-dateutil
 iso8601
+six

--- a/test/models/test_artifact_rules.py
+++ b/test/models/test_artifact_rules.py
@@ -60,31 +60,31 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     """Test generic rule proper unpacking. """
     rule = ["CREATE", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 2)
+    self.assertEquals(len(list(rule_data.keys())), 2)
     self.assertEquals(rule_data["type"], "create")
     self.assertEquals(rule_data["pattern"], "foo")
 
     rule = ["DELETE", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 2)
+    self.assertEquals(len(list(rule_data.keys())), 2)
     self.assertEquals(rule_data["type"], "delete")
     self.assertEquals(rule_data["pattern"], "foo")
 
     rule = ["MODIFY", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 2)
+    self.assertEquals(len(list(rule_data.keys())), 2)
     self.assertEquals(rule_data["type"], "modify")
     self.assertEquals(rule_data["pattern"], "foo")
 
     rule = ["ALLOW", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 2)
+    self.assertEquals(len(list(rule_data.keys())), 2)
     self.assertEquals(rule_data["type"], "allow")
     self.assertEquals(rule_data["pattern"], "foo")
 
     rule = ["DISALLOW", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 2)
+    self.assertEquals(len(list(rule_data.keys())), 2)
     self.assertEquals(rule_data["type"], "disallow")
     self.assertEquals(rule_data["pattern"], "foo")
 
@@ -95,7 +95,7 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "IN", "source-path", "WITH",
         "PRODUCTS", "IN", "dest-path", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 6)
+    self.assertEquals(len(list(rule_data.keys())), 6)
     self.assertEquals(rule_data["type"], "match")
     self.assertEquals(rule_data["pattern"], "foo")
     self.assertEquals(rule_data["source_prefix"], "source-path")
@@ -106,7 +106,7 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "IN", "source-path", "WITH",
         "MATERIALS", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 6)
+    self.assertEquals(len(list(rule_data.keys())), 6)
     self.assertEquals(rule_data["type"], "match")
     self.assertEquals(rule_data["pattern"], "foo")
     self.assertEquals(rule_data["source_prefix"], "source-path")
@@ -117,7 +117,7 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "WITH",
         "PRODUCTS", "IN", "dest-path", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 6)
+    self.assertEquals(len(list(rule_data.keys())), 6)
     self.assertEquals(rule_data["type"], "match")
     self.assertEquals(rule_data["pattern"], "foo")
     self.assertEquals(rule_data["source_prefix"], "")
@@ -128,7 +128,7 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "WITH",
         "PRODUCTS", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(rule_data.keys()), 6)
+    self.assertEquals(len(list(rule_data.keys())), 6)
     self.assertEquals(rule_data["type"], "match")
     self.assertEquals(rule_data["pattern"], "foo")
     self.assertEquals(rule_data["source_prefix"], "")

--- a/test/test_in_toto_sign.py
+++ b/test/test_in_toto_sign.py
@@ -292,7 +292,7 @@ class TestInTotoSignTool(unittest.TestCase):
         ], 2)
 
     # Valid JSON but not valid Link or Layout
-    open("tmp.json", "w").write(json.dumps({}))
+    open("tmp.json", "wb").write(json.dumps({}).encode("utf-8"))
     self._test_cli_sys_exit([
         "-f", "tmp.json",
         "-k", "key-not-used",

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -142,7 +142,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     for setting in ["path/does/not/exist", 12345, True]:
       in_toto.settings.ARTIFACT_BASE_PATH = setting
       with self.assertRaises(in_toto.exceptions.SettingsError):
-        print setting
         record_artifacts_as_dict(["."])
 
   def test_base_path_is_child_dir(self):
@@ -231,7 +230,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     for setting in ["not a list of settings", 12345, True]:
       in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = setting
       with self.assertRaises(in_toto.exceptions.SettingsError):
-        print setting
         record_artifacts_as_dict(["."])
 
 

--- a/test/test_runlib.py
+++ b/test/test_runlib.py
@@ -17,6 +17,7 @@
   Test runlib functions.
 
 """
+import six
 
 import os
 import unittest
@@ -148,7 +149,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Test path of recorded artifacts and cd back with child as base."""
     in_toto.settings.ARTIFACT_BASE_PATH = "subdir"
     artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
         sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
     self.assertEquals(os.getcwd(), self.test_dir)
 
@@ -157,7 +158,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     in_toto.settings.ARTIFACT_BASE_PATH = ".."
     os.chdir("subdir/subsubdir")
     artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
         sorted(["foosub1", "foosub2", "subsubdir/foosubsub"]))
     self.assertEquals(os.getcwd(),
         os.path.join(self.test_dir, "subdir/subsubdir"))
@@ -175,10 +176,10 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Traverse dir and subdirs. Record three files. """
     artifacts_dict = record_artifacts_as_dict(["."])
 
-    for key, val in artifacts_dict.iteritems():
+    for key, val in six.iteritems(artifacts_dict):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
       sorted(["foo", "bar", "subdir/foosub1", "subdir/foosub2",
           "subdir/subsubdir/foosubsub"]))
 
@@ -186,10 +187,10 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Explicitly record files and subdirs. """
     artifacts_dict = record_artifacts_as_dict(["foo", "subdir"])
 
-    for key, val in artifacts_dict.iteritems():
+    for key, val in six.iteritems(artifacts_dict):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
       sorted(["foo", "subdir/foosub1", "subdir/foosub2",
           "subdir/subsubdir/foosubsub"]))
 
@@ -199,19 +200,19 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     artifacts_dict = record_artifacts_as_dict(["."])
 
     securesystemslib.formats.HASHDICT_SCHEMA.check_match(artifacts_dict["bar"])
-    self.assertListEqual(artifacts_dict.keys(), ["bar"])
+    self.assertListEqual(list(artifacts_dict.keys()), ["bar"])
 
   def test_exclude_subdir(self):
     """Traverse dot. Exclude subdir (and subsubdir). """
     in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = ["*subdir"]
     artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()), sorted(["bar", "foo"]))
+    self.assertListEqual(sorted(list(artifacts_dict.keys())), sorted(["bar", "foo"]))
 
   def test_exclude_files_in_subdir(self):
     """Traverse dot. Exclude files in subdir but not subsubdir. """
     in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = ["*foosub?"]
     artifacts_dict = record_artifacts_as_dict(["."])
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
       sorted(["bar", "foo", "subdir/subsubdir/foosubsub"]))
 
   def test_exclude_subsubdir(self):
@@ -219,10 +220,10 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = ["*subsubdir"]
     artifacts_dict = record_artifacts_as_dict(["."])
 
-    for key, val in artifacts_dict.iteritems():
+    for key, val in six.iteritems(artifacts_dict):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
-    self.assertListEqual(sorted(artifacts_dict.keys()),
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
         sorted(["foo", "bar", "subdir/foosub1", "subdir/foosub2"]))
 
   def test_bad_artifact_exclude_patterns_setting(self):
@@ -312,8 +313,8 @@ class TestInTotoRun(unittest.TestCase):
     """Successfully run, verify properly recorded artifacts. """
     link = in_toto_run(self.step_name, [self.test_artifact],
         [self.test_artifact], ["echo", "test"])
-    self.assertEqual(link.signed.materials.keys(),
-        link.signed.products.keys(), [self.test_artifact])
+    self.assertEqual(list(link.signed.materials.keys()),
+        list(link.signed.products.keys()), [self.test_artifact])
 
   def test_in_toto_run_verify_workdir(self):
     """Successfully run, verify cwd. """
@@ -370,7 +371,7 @@ class TestInTotoRecordStart(unittest.TestCase):
     in_toto_record_start(
         self.step_name, [self.test_material], self.key)
     link = Metablock.load(self.link_name_unfinished)
-    self.assertEquals(link.signed.materials.keys(), [self.test_material])
+    self.assertEquals(list(link.signed.materials.keys()), [self.test_material])
     os.remove(self.link_name_unfinished)
 
   def test_create_unfininished_metadata_verify_signature(self):
@@ -426,7 +427,7 @@ class TestInTotoRecordStop(unittest.TestCase):
     in_toto_record_start(self.step_name, [], self.key)
     in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
-    self.assertEquals(link.signed.products.keys(), [self.test_product])
+    self.assertEquals(list(link.signed.products.keys()), [self.test_product])
     os.remove(self.link_name)
 
   def test_create_metadata_with_expected_cwd(self):

--- a/test/test_user_settings.py
+++ b/test/test_user_settings.py
@@ -15,6 +15,7 @@
   Test in_toto/user_settings.py
 
 """
+import six
 
 import os
 import sys
@@ -55,7 +56,7 @@ class TestUserSettings(unittest.TestCase):
 
     # Other unittests might depend on defaults:
     # Restore monkey patched settings ...
-    for key, val in self.settings_backup.iteritems():
+    for key, val in six.iteritems(self.settings_backup):
       setattr(in_toto.settings, key, val)
 
     # ... and delete test environment variables

--- a/test/test_verifylib.py
+++ b/test/test_verifylib.py
@@ -110,8 +110,8 @@ class TestRunAllInspections(unittest.TestCase):
 
     run_all_inspections(self.layout)
     link = Metablock.load("touch-bar.link")
-    self.assertListEqual(link.signed.materials.keys(), ["foo"])
-    self.assertListEqual(sorted(link.signed.products.keys()), sorted(["foo", "bar"]))
+    self.assertListEqual(list(link.signed.materials.keys()), ["foo"])
+    self.assertListEqual(sorted(list(link.signed.products.keys())), sorted(["foo", "bar"]))
 
     in_toto.settings.ARTIFACT_BASE_PATH = None
     shutil.rmtree(ignore_dir)
@@ -482,7 +482,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foo": {"sha256": self.sha256_foo},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["bar"])
 
@@ -496,7 +496,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foo": {"sha256": self.sha256_foo},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["foo"])
 
@@ -510,7 +510,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "dist/foo": {"sha256": self.sha256_foo},
       "dist/bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["dist/bar"])
 
@@ -523,7 +523,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "dist/bar": {"sha256": self.sha256_bar},
       "dist/foo": {"sha256": self.sha256_foo}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["dist/foo"])
 
@@ -536,7 +536,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foo": {"sha256": self.sha256_foo},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["bar"])
 
@@ -549,7 +549,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "bar": {"sha256": self.sha256_bar},
       "foo": {"sha256": self.sha256_foo}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["foo"])
 
@@ -563,7 +563,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foobar": {"sha256": self.sha256_foobar},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["bar"])
 
@@ -577,7 +577,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "barfoo": {"sha256": self.sha256_barfoo},
       "foo": {"sha256": self.sha256_foo}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["foo"])
 
@@ -591,7 +591,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "dist/foobar": {"sha256": self.sha256_foobar},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["bar"])
 
@@ -605,7 +605,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "dist/barfoo": {"sha256": self.sha256_barfoo},
       "foo": {"sha256": self.sha256_foo}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["foo"])
 
@@ -619,7 +619,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foobar": {"sha256": self.sha256_foobar},
       "bar": {"sha256": self.sha256_bar}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["bar"])
 
@@ -633,7 +633,7 @@ class TestVerifyMatchRule(unittest.TestCase):
       "barfoo": {"sha256": self.sha256_barfoo},
       "foo": {"sha256": self.sha256_foo}
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     self.assertListEqual(
         verify_match_rule(rule, queue, artifacts, self.links), ["foo"])
 
@@ -643,7 +643,7 @@ class TestVerifyMatchRule(unittest.TestCase):
 
     rule = ["MATCH", "bar", "WITH", "MATERIALS", "FROM", "link-null"]
     artifacts = {}
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     with self.assertRaises(RuleVerficationError):
       verify_match_rule(rule, queue, artifacts, self.links)
 
@@ -655,7 +655,7 @@ class TestVerifyMatchRule(unittest.TestCase):
     artifacts = {
       "bar": {"sha256": self.sha256_bar},
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     with self.assertRaises(RuleVerficationError):
       verify_match_rule(rule, queue, artifacts, self.links)
 
@@ -667,7 +667,7 @@ class TestVerifyMatchRule(unittest.TestCase):
     artifacts = {
       "foo": {"sha256": self.sha256_foo},
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     with self.assertRaises(RuleVerficationError):
       verify_match_rule(rule, queue, artifacts, self.links)
 
@@ -679,7 +679,7 @@ class TestVerifyMatchRule(unittest.TestCase):
     artifacts = {
       "bar": {"sha256": "aaaaaaaaaa"},
     }
-    queue = artifacts.keys()
+    queue = list(artifacts.keys())
     with self.assertRaises(RuleVerficationError):
       verify_match_rule(rule, queue, artifacts, self.links)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,32 +3,21 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-# To run an individual testenvironment run e.g. tox -e py34-unittest
+# To run an individual testenvironment run e.g. tox -e py34
 [tox]
-envlist = py{27,34,35,36}-unittest, lint
+envlist = py{27,34,35,36}
 
-
-# Use factors for conditional dependencies and commands depending on whether
-# we run a "*-unittest" environment or the "lint" environment
 [testenv]
 deps =
-    unittest: -rrequirements.txt
-    unittest: -rrequirements-ci.txt
-
-    lint: pylint
-    lint: bandit
-
+    -rrequirements.txt
+    -rrequirements-ci.txt
+    pylint
+    bandit
 
 commands =
-    # Integrating tox with setup.py test is as p of Oct 2016 discouraged
-    # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
-    unittest: coverage run test/runtests.py
-    unittest: coverage report -m --fail-under 99
-
-
     # Run pylint, using secure system lab's pylintrc configuration file
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
-    lint: pylint in_toto
+    pylint in_toto
 
     # Run bandit, a security linter from OpenStack Security
     # Note: We exclude tests that fail on importing or using the subprocess or
@@ -38,9 +27,9 @@ commands =
     # https://docs.openstack.org/bandit/latest/blacklists/blacklist_imports.html#b404-import-subprocess
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
-    lint: bandit -r in_toto --skip B404,B603
+    bandit -r in_toto --skip B404,B603
 
-basepython =
-    # Use max Python version supported by both bandit and pylint for lint env
-    # NOTE: py{VERSION}-unittest automatically uses VERSION as basepython
-    lint: python3.5
+    # Integrating tox with setup.py test is as p of Oct 2016 discouraged
+    # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
+    coverage run test/runtests.py
+    coverage report -m --fail-under 99

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py27
+envlist = lint, py27, py34, py35, py36
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-
+# To run an individual testenvironment run e.g. tox -e py34-unittest
 [tox]
 envlist = py{27,34,35,36}-unittest, lint
 
@@ -20,7 +20,7 @@ deps =
 
 
 commands =
-    # Integrating tox with setup.py test is as of Oct 2016 discouraged
+    # Integrating tox with setup.py test is as p of Oct 2016 discouraged
     # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
     unittest: coverage run test/runtests.py
     unittest: coverage report -m --fail-under 99
@@ -39,3 +39,8 @@ commands =
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
     lint: bandit -r in_toto --skip B404,B603
+
+basepython =
+    # Use max Python version supported by both bandit and pylint for lint env
+    # NOTE: py{VERSION}-unittest automatically uses VERSION as basepython
+    lint: python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -3,18 +3,32 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-[tox]
-envlist = lint, py27, py34, py35, py36
 
-[testenv:lint]
+[tox]
+envlist = py{27,34,35,36}-unittest, lint
+
+
+# Use factors for conditional dependencies and commands depending on whether
+# we run a "*-unittest" environment or the "lint" environment
+[testenv]
 deps =
-    pylint
-    bandit
+    unittest: -rrequirements.txt
+    unittest: -rrequirements-ci.txt
+
+    lint: pylint
+    lint: bandit
+
 
 commands =
+    # Integrating tox with setup.py test is as of Oct 2016 discouraged
+    # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
+    unittest: coverage run test/runtests.py
+    unittest: coverage report -m --fail-under 99
+
+
     # Run pylint, using secure system lab's pylintrc configuration file
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
-    pylint in_toto
+    lint: pylint in_toto
 
     # Run bandit, a security linter from OpenStack Security
     # Note: We exclude tests that fail on importing or using the subprocess or
@@ -24,15 +38,4 @@ commands =
     # https://docs.openstack.org/bandit/latest/blacklists/blacklist_imports.html#b404-import-subprocess
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
-    bandit -r in_toto --skip B404,B603
-
-[testenv:py27]
-deps =
-    -rrequirements.txt
-    -rrequirements-ci.txt
-
-commands =
-    # Integrating tox with setup.py test is as of Oct 2016 discouraged
-    # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
-    coverage run test/runtests.py
-    coverage report -m --fail-under 99
+    lint: bandit -r in_toto --skip B404,B603


### PR DESCRIPTION
**Fixes issue #**:
Closes #23 

**Description of the changes being introduced by the pull request**:
Add support for Python 3.4, 3.5 and 3.6 (in addition to Python 2.7 support).

Commits whose titles start with `Py2/3` contain all the changes for cross compatibility. The remaining commits update Travis and tox configs to run linters and unittests on all versions and fix coverage issues.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


