### PR TITLE
Remove commented out user setting parsing

### DIFF
--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -34,7 +34,6 @@
 import sys
 import argparse
 import in_toto.util
-import in_toto.user_settings
 from in_toto import log
 
 
@@ -86,9 +85,6 @@ def main():
   <filename> and <filename>.pub (Private key and Public key respectively)
   """
   args = parse_args()
-
-  # Override defaults in settings.py with environment variables and RCfiles
-  #in_toto.user_settings.set_settings()
 
   try:
     if args.prompt:

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -35,7 +35,6 @@
 
 import sys
 import argparse
-import in_toto.user_settings
 from in_toto import (runlib, log)
 
 def in_toto_mock(name, link_cmd_args):
@@ -94,9 +93,6 @@ def main():
 
   # Turn on all the `log.info()` in the library
   log.logging.getLogger().setLevel(log.logging.INFO)
-
-  # Override defaults in settings.py with environment variables and RCfiles
-  #in_toto.user_settings.set_settings()
 
   in_toto_mock(args.name, args.link_cmd)
 

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -66,7 +66,6 @@
 """
 import sys
 import argparse
-import in_toto.user_settings
 from in_toto import log, exceptions, util
 from in_toto.models.link import FILENAME_FORMAT
 from in_toto.models.metadata import Metablock
@@ -253,9 +252,6 @@ def main():
 
   if args.verbose:
     log.logging.getLogger().setLevel(log.logging.INFO)
-
-  # Override defaults in settings.py with environment variables and RCfiles
-  #in_toto.user_settings.set_settings()
 
 
   # Additional argparse sanitization

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -40,7 +40,6 @@
 import sys
 import argparse
 
-import in_toto.user_settings
 import in_toto.log as log
 import in_toto.util
 from in_toto import verifylib
@@ -147,9 +146,6 @@ def main():
   # Turn on all the `log.info()` in the library
   if args.verbose:
     log.logging.getLogger().setLevel(log.logging.INFO)
-
-  # Override defaults in settings.py with environment variables and RCfiles
-  #in_toto.user_settings.set_settings()
 
   # For verifying at least one of --layout-keys or --gpg must be specified
   # Note: Passing both at the same time is possible.


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
We commented out unused user settings parsing in #158 , which broke the build because the linter complained about unused imports.
This PR removes the commented out calls and the imports altogether.

The parser can be re-added to the modified command line scripts, if we add user settings that are available in those scripts.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


