### PR TITLE
Re-add missing dependency (cryptography)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 securesystemslib==0.10.8
+cryptography
 sphinx
 attrs
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     'Topic :: Software Development'
   ],
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-  install_requires=["six", "securesystemslib==0.10.8", "attrs",
-                    "python-dateutil", "iso8601"],
+  install_requires=["six", "cryptography>=2.1.3", "securesystemslib==0.10.8",
+                    "attrs", "python-dateutil", "iso8601"],
   test_suite="test.runtests",
   entry_points={
     "console_scripts": ["in-toto-run = in_toto.in_toto_run:main",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ setup(
     'Topic :: Software Development'
   ],
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
-  install_requires=["six", "cryptography>=2.1.3", "securesystemslib==0.10.8",
+  # securesystemslib 0.10.8 requires cryptography>=2.1.3, and thereby dictates
+  # the minimum version of cryptography for in-toto. The maximum version
+  # is dictated by what is available.
+  install_requires=["six", "cryptography", "securesystemslib==0.10.8",
                     "attrs", "python-dateutil", "iso8601"],
   test_suite="test.runtests",
   entry_points={


### PR DESCRIPTION
**Fixes issue #**:
Fixes comment in unrelated PR https://github.com/in-toto/in-toto/pull/169#discussion_r162169742

**Description of the changes being introduced by the pull request**:
When `securesystemslib` was factored out into a separate package, in-toto also delegated the dependency of `cryptography` to `securesystemslib.` By adding gpg support to `in-toto` `cryptography` again becomes a dependency.

This commit adds `cryptography` to `requirements.tx`t and `cryptography>=2.1.3` (same as specified by the required `securesystemslib==0.10.8`) to `setup.py`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


