### PR TITLE
Update securesystemslib v0.10.9 and add Python 3 classifiers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-securesystemslib==0.10.8
+securesystemslib==0.10.9
 cryptography
 sphinx
 attrs

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,12 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  # securesystemslib 0.10.8 requires cryptography>=2.1.3, and thereby dictates
-  # the minimum version of cryptography for in-toto. The maximum version
-  # is dictated by what is available.
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests",
       "debian"]),
-  install_requires=["six", "cryptography", "securesystemslib==0.10.8", "attrs",
+  # securesystemslib 0.10.9 requires cryptography>=2.1.3, and thereby dictates
+  # the minimum version of cryptography for in-toto. The maximum version
+  # is dictated by what is available.
+  install_requires=["six", "cryptography", "securesystemslib==0.10.9", "attrs",
                     "python-dateutil", "iso8601"],
   test_suite="tests.runtests",
   entry_points={

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,10 @@ setup(
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
- Update to [securesystemslib v0.10.9](https://github.com/secure-systems-lab/securesystemslib/releases/tag/v0.10.9)
- Add Programming Language classifiers for the now supported Python 3 versions to `setup.py`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


