### PR TITLE
Add metablock validators

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -136,6 +136,8 @@ class Layout(Signable):
     """Private method to verify if the expiration field has the right format
     and can be parsed."""
     try:
+      # We do both 'parse' and 'check_match' because the format check does not
+      # detect bogus dates (e.g. Jan 35th) and parse can do more formats.
       parse(self.expires)
       securesystemslib.formats.ISO8601_DATETIME_SCHEMA.check_match(
           self.expires)

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -28,7 +28,7 @@ import in_toto.verifylib
 import securesystemslib.exceptions
 
 class TestLayoutValidator(unittest.TestCase):
-  """Test verifylib.verify_delete_rule(rule, artifact_queue) """
+  """Test in_toto.models.layout.Layout validators. """
 
   def setUp(self):
     """Populate a base layout that we can use."""
@@ -185,8 +185,8 @@ class TestLayoutValidator(unittest.TestCase):
 
     link_path = os.path.abspath(link_name)
     link = in_toto.models.link.Link(name=name)
-    link._type = "wrong-type"
     metadata = Metablock(signed=link)
+    metadata.signed._type = "wrong-type"
     metadata.dump(link_path)
 
     # Add the single step to the test layout and try to read the failing link

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  test_metadata.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Jan 24, 2018
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test in_toto.models.metadata.Metablock class methods.
+
+"""
+
+import os
+import unittest
+
+import in_toto.util
+from in_toto.models.metadata import Metablock
+from in_toto.models.layout import Layout
+from in_toto.models.link import Link
+from securesystemslib.exceptions import FormatError
+
+class TestMetablockValidator(unittest.TestCase):
+  """Test in_toto.models.metadata.Metablock validators. """
+
+  def test_validate_signed(self):
+    """Test validate Metablock's 'signed' property. """
+    # Valid Layout Metablock
+    metablock = Metablock(signed=Layout())
+    metablock._validate_signed()
+
+    # Valid Link Metablock
+    Metablock(signed=Link())
+    metablock._validate_signed()
+
+
+    # Fail instantiation with empty or invalid signed property
+    # Metablock is validated on instantiation
+    with self.assertRaises(FormatError):
+      Metablock()
+    with self.assertRaises(FormatError):
+      Metablock(signed="not-a-layout-or-link")
+
+
+    # Fail with invalid signed property
+    metablock = Metablock(signed=Layout())
+    metablock.signed._type = "bogus type"
+    with self.assertRaises(FormatError):
+      metablock._validate_signed()
+
+
+  def test_validate_signatures(self):
+    """Test validate Metablock's 'signatures' property. """
+    # An empty signature list is okay
+    metablock = Metablock(signed=Layout())
+    metablock._validate_signatures()
+
+    # Fail with signatures property not a list
+    metablock.signatures = "not-a-signatures-list"
+    with self.assertRaises(FormatError):
+      metablock._validate_signatures()
+
+    # Fail with invalid signature
+    metablock.signatures = []
+    metablock.signatures.append("not-a-signature")
+    with self.assertRaises(FormatError):
+      metablock._validate_signatures()
+
+    # Load signed demo link
+    demo_link_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+        "..", "demo_files", "write-code.776a00e2.link")
+
+    metablock = Metablock.load(demo_link_path)
+
+    # Verify that there is a signature and that it is valid
+    self.assertTrue(len(metablock.signatures) > 0)
+    metablock._validate_signatures()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
Add `_validate*` methods (using `ValidationMixin`) to `Metablock` class, to validate that the `signed` property contains a valid `Link` or `Layout` object and the `signatures` property is a list and only contains valid signatures.
Validation is performed at the end of `Metablock`s constructor.

*unrelated*: This PR also adds an comment to an existing layout validator.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


