### PR TITLE
Remove command parse from Step/Inspection constructors

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -44,6 +44,7 @@ import in_toto.formats
 
 import securesystemslib.exceptions
 import securesystemslib.formats
+import securesystemslib.schema
 
 
 
@@ -232,17 +233,7 @@ class Step(ValidationMixin):
     self.expected_materials = kwargs.get("expected_materials", [])
     self.expected_products = kwargs.get("expected_products", [])
     self.pubkeys = kwargs.get("pubkeys", [])
-
-    # Accept expected command as string or list, if it is a string we split it
-    # using shell like syntax.
-    self.expected_command = kwargs.get("expected_command")
-    if self.expected_command:
-      if not isinstance(self.expected_command, list):
-        self.expected_command = shlex.split(self.expected_command)
-
-    else:
-      self.expected_command = []
-
+    self.expected_command = kwargs.get("expected_command", [])
     self.threshold = kwargs.get("threshold", 1)
 
     self.validate()
@@ -250,6 +241,12 @@ class Step(ValidationMixin):
   @staticmethod
   def read(data):
     return Step(**data)
+
+
+  def set_expected_command_from_string(self, command_string):
+    securesystemslib.schema.AnyString().check_match(command_string)
+    self.expected_command = shlex.split(command_string)
+
 
   def _validate_type(self):
     """Private method to ensure that the type field is set to step."""
@@ -331,20 +328,18 @@ class Inspection(ValidationMixin):
     self.expected_materials = kwargs.get("expected_materials", [])
     self.expected_products = kwargs.get("expected_products", [])
 
-    # Accept run command as string or list, if it is a string we split it
-    # using shell like syntax.
-    self.run = kwargs.get("run")
-    if self.run:
-      if not isinstance(self.run, list):
-        self.run = shlex.split(self.run)
-    else:
-      self.run = []
+    self.run = kwargs.get("run", [])
 
     self.validate()
 
   @staticmethod
   def read(data):
     return Inspection(**data)
+
+  def set_run_from_string(self, command_string):
+    securesystemslib.schema.AnyString().check_match(command_string)
+    self.run = shlex.split(command_string)
+
 
   def _validate_type(self):
     """Private method to ensure that the type field is set to inspection."""

--- a/tests/models/test_inspection.py
+++ b/tests/models/test_inspection.py
@@ -99,6 +99,13 @@ class TestInspectionValidator(unittest.TestCase):
     self.inspection._validate_run()
     self.inspection.validate()
 
+
+  def test_set_run_from_string(self):
+    """Test shelx parse command string to list. """
+    inspection = Inspection()
+    inspection.set_run_from_string("echo 'foo bar'")
+    self.assertListEqual(inspection.run, ["echo", "foo bar"])
+
 if __name__ == '__main__':
 
   unittest.main()

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -213,13 +213,5 @@ class TestLayoutValidator(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       tmp_step.validate()
 
-
-  def test_step_expected_command_shlex(self):
-    """Check that a step's `expected_command` passed as string is converted
-    to a list (using `shlex`). """
-    step = Step(**{"expected_command": "rm -rf /"})
-    self.assertTrue(isinstance(step.expected_command, list))
-    self.assertTrue(len(step.expected_command) == 3)
-
 if __name__ == "__main__":
   unittest.main()

--- a/tests/models/test_step.py
+++ b/tests/models/test_step.py
@@ -135,6 +135,11 @@ class TestStepValidator(unittest.TestCase):
     self.step._validate_expected_command()
     self.step.validate()
 
-if __name__ == '__main__':
+  def test_set_expected_command_from_string(self):
+    """Test shelx parse command string to list. """
+    step = Step()
+    step.set_expected_command_from_string("echo 'foo bar'")
+    self.assertListEqual(step.expected_command, ["echo", "foo bar"])
 
+if __name__ == "__main__":
   unittest.main()

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -87,7 +87,7 @@ class TestRunAllInspections(unittest.TestCase):
         "steps": [],
         "inspect": [{
           "name": "touch-bar",
-          "run": "touch bar",
+          "run": ["touch", "bar"],
         }]
       })
 
@@ -125,7 +125,7 @@ class TestRunAllInspections(unittest.TestCase):
         "steps": [],
         "inspect": [{
           "name": "non-zero-inspection",
-          "run": "expr 1 / 0",
+          "run": ["expr", "1", "/", "0"],
         }]
     })
     with self.assertRaises(BadReturnValueError):


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
We used to accept the command for `Step`'s `expected_command` and `Inspection`'s `run` properties as list or string and in the latter case transform it to a list using `shlex`. 

However, it is better to not magically transform the metadata in the constructors, as it is likely to break existing signatures. Instead we provide the convenient parsing functionality in separate `Step`/`Inspection` methods.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


