### PR TITLE
Generalize step and inspection

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -32,6 +32,7 @@ from six import string_types
 
 import attr
 import shlex
+import json
 
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -221,6 +222,11 @@ class SupplyChainItem(ValidationMixin):
     self.name = kwargs.get("name")
     self.expected_materials = kwargs.get("expected_materials", [])
     self.expected_products = kwargs.get("expected_products", [])
+
+  def __repr__(self):
+    return json.dumps(attr.asdict(self),
+        indent=1, separators=(",", ": "), sort_keys=True)
+
 
 
   def _validate_expected_materials(self):

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -194,8 +194,58 @@ class Layout(Signable):
             "There is a repeated name in the steps! {}".format(inspection.name))
       names_seen.add(inspection.name)
 
+
+
 @attr.s(repr=False, init=False)
-class Step(ValidationMixin):
+class SupplyChainItem(ValidationMixin):
+  """
+  Represents an item of the supply chain, i.e. a Step or an Inspection.
+
+  <Attributes>
+    name:
+      A unique name used to identify the related link metadata
+
+    expected_materials and expected_products:
+      A list of artifact rules used to verify if the materials or products of
+      the item (found in the according link metadata file) link correctly with
+      other items of the supply chain
+
+  """
+  name = attr.ib()
+  expected_materials = attr.ib()
+  expected_products = attr.ib()
+
+
+  def __init__(self, **kwargs):
+    super(SupplyChainItem, self).__init__()
+    self.name = kwargs.get("name")
+    self.expected_materials = kwargs.get("expected_materials", [])
+    self.expected_products = kwargs.get("expected_products", [])
+
+
+  def _validate_expected_materials(self):
+    """Private method to check that material rules are correctly formed."""
+    if type(self.expected_materials) != list:
+      raise securesystemslib.exceptions.FormatError(
+          "Material rules should be a list!")
+
+    for rule in self.expected_materials:
+      in_toto.rulelib.unpack_rule(rule)
+
+
+  def _validate_expected_products(self):
+    """Private method to check that product rules are correctly formed."""
+    if type(self.expected_products) != list:
+      raise securesystemslib.exceptions.FormatError(
+          "Product rules should be a list!")
+
+    for rule in self.expected_products:
+      in_toto.rulelib.unpack_rule(rule)
+
+
+
+@attr.s(repr=False, init=False)
+class Step(SupplyChainItem):
   """
   Represents a step of the supply chain performed by a functionary.
   A step relates to a link metadata file generated when the step was
@@ -203,12 +253,10 @@ class Step(ValidationMixin):
 
   <Attributes>
     name:
-        a unique name used to identify the related link metadata
+        cf. SupplyChainItem
 
     expected_materials and expected_products:
-        a list of artifact rules used to verify if the materials or products of
-        the step (found in the according link metadata file) link correctly with
-        other steps of the supply chain
+        cf. SupplyChainItem
 
     pubkeys:
         a list of keyids of the functionaries authorized to perform the step
@@ -221,24 +269,20 @@ class Step(ValidationMixin):
 
   """
   _type = attr.ib()
-  name = attr.ib()
-  expected_materials = attr.ib()
-  expected_products = attr.ib()
   pubkeys = attr.ib()
   expected_command = attr.ib()
   threshold = attr.ib()
 
+
   def __init__(self, **kwargs):
-    super(Step, self).__init__()
+    super(Step, self).__init__(**kwargs)
     self._type = "step"
-    self.name = kwargs.get("name")
-    self.expected_materials = kwargs.get("expected_materials", [])
-    self.expected_products = kwargs.get("expected_products", [])
     self.pubkeys = kwargs.get("pubkeys", [])
     self.expected_command = kwargs.get("expected_command", [])
     self.threshold = kwargs.get("threshold", 1)
 
     self.validate()
+
 
   @staticmethod
   def read(data):
@@ -256,6 +300,7 @@ class Step(ValidationMixin):
       raise securesystemslib.exceptions.FormatError(
           "Invalid _type value for step (Should be 'step')")
 
+
   def _validate_threshold(self):
     """Private method to check that the threshold field is set to an int."""
     if type(self.threshold) != int:
@@ -263,23 +308,6 @@ class Step(ValidationMixin):
           "Invalid threshold '{}', value must be an int."
           .format(self.threshold))
 
-  def _validate_expected_materials(self):
-    """Private method to check that material rules are correctly formed."""
-    if type(self.expected_materials) != list:
-      raise securesystemslib.exceptions.FormatError(
-          "Material rules should be a list!")
-
-    for rule in self.expected_materials:
-      in_toto.rulelib.unpack_rule(rule)
-
-  def _validate_expected_products(self):
-    """Private method to check that product rules are correctly formed."""
-    if type(self.expected_products) != list:
-      raise securesystemslib.exceptions.FormatError(
-          "Product rules should be a list!")
-
-    for rule in self.expected_products:
-      in_toto.rulelib.unpack_rule(rule)
 
   def _validate_pubkeys(self):
     """Private method to check that the pubkeys is a list of keyids."""
@@ -290,6 +318,7 @@ class Step(ValidationMixin):
     for keyid in self.pubkeys:
       securesystemslib.formats.KEYID_SCHEMA.check_match(keyid)
 
+
   def _validate_expected_command(self):
     """Private method to check that the expected_command is proper."""
     if type(self.expected_command) != list:
@@ -299,18 +328,16 @@ class Step(ValidationMixin):
 
 
 @attr.s(repr=False, init=False)
-class Inspection(ValidationMixin):
+class Inspection(SupplyChainItem):
   """
   Represents an inspection which performs a command during layout verification.
 
   <Attributes>
     name:
-        a unique name used to identify related link metadata
-        link metadata for Inspections are just created and used on the fly
-        and not stored to disk
+        c.f. SupplyChainItem
 
     expected_materials and expected_products:
-        cf. Step Attributes
+        cf. SupplyChainItem
 
     run:
         the command to execute during layout verification
@@ -318,13 +345,11 @@ class Inspection(ValidationMixin):
   """
   _type = attr.ib()
   name = attr.ib()
-  expected_materials = attr.ib()
-  expected_products = attr.ib()
   run = attr.ib()
 
-  def __init__(self, **kwargs):
-    super(Inspection, self).__init__()
 
+  def __init__(self, **kwargs):
+    super(Inspection, self).__init__(**kwargs)
     self._type = "inspection"
     self.name = kwargs.get("name")
     self.expected_materials = kwargs.get("expected_materials", [])
@@ -333,6 +358,7 @@ class Inspection(ValidationMixin):
     self.run = kwargs.get("run", [])
 
     self.validate()
+
 
   @staticmethod
   def read(data):
@@ -349,23 +375,6 @@ class Inspection(ValidationMixin):
       raise securesystemslib.exceptions.FormatError(
           "The _type field must be set to 'inspection'!")
 
-  def _validate_expected_materials(self):
-    """Private method to check that the material rules are correct."""
-    if type(self.expected_materials) != list:
-      raise securesystemslib.exceptions.FormatError(
-          "The material rules should be a list!")
-
-    for rule in self.expected_materials:
-      in_toto.rulelib.unpack_rule(rule)
-
-  def _validate_expected_products(self):
-    """Private method to check that the product rules are correct."""
-    if type(self.expected_products) != list:
-      raise securesystemslib.exceptions.FormatError(
-          "The product rules should be a list!")
-
-    for rule in self.expected_products:
-      in_toto.rulelib.unpack_rule(rule)
 
   def _validate_run(self):
     """Private method to check that the expected command is correct."""

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -228,6 +228,17 @@ class SupplyChainItem(ValidationMixin):
         indent=1, separators=(",", ": "), sort_keys=True)
 
 
+  def add_material_rule_from_string(self, rule_string):
+    securesystemslib.schema.AnyString().check_match(rule_string)
+    rule_list = shlex.split(rule_string)
+    self.expected_materials.append(rule_list)
+
+
+  def add_product_rule_from_string(self, rule_string):
+    securesystemslib.schema.AnyString().check_match(rule_string)
+    rule_list = shlex.split(rule_string)
+    self.expected_products.append(rule_list)
+
 
   def _validate_expected_materials(self):
     """Private method to check that material rules are correctly formed."""

--- a/tests/models/test_inspection.py
+++ b/tests/models/test_inspection.py
@@ -41,49 +41,6 @@ class TestInspectionValidator(unittest.TestCase):
     self.inspection._type = "inspection"
     self.inspection._validate_type()
 
-  def test_wrong_expected_materials(self):
-    """Test that the material rule validators catch malformed ones."""
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.expected_materials = [["NONFOO"]]
-      self.inspection._validate_expected_materials()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.expected_materials = "PFF"
-      self.inspection._validate_expected_materials()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    # for more thorough tests, check the test_rulelib.py module
-    self.inspection.expected_materials = [["CREATE", "foo"]]
-    self.inspection._validate_expected_materials()
-    self.inspection.validate()
-
-  def test_wrong_expected_products(self):
-    """Test that the product rule validators catch malformed values."""
-
-    self.inspection.expected_products = [["NONFOO"]]
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection._validate_expected_products()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    self.inspection.expected_products = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection._validate_expected_products()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.inspection.validate()
-
-    # for more thorough tests, check the test_rulelib.py module
-    self.inspection.expected_products = [["CREATE", "foo"]]
-    self.inspection._validate_expected_products()
-    self.inspection.validate()
 
   def test_wrong_run(self):
     """Test that the run validators catch malformed values."""
@@ -106,6 +63,6 @@ class TestInspectionValidator(unittest.TestCase):
     inspection.set_run_from_string("echo 'foo bar'")
     self.assertListEqual(inspection.run, ["echo", "foo bar"])
 
-if __name__ == '__main__':
 
+if __name__ == "__main__":
   unittest.main()

--- a/tests/models/test_step.py
+++ b/tests/models/test_step.py
@@ -26,9 +26,11 @@ import securesystemslib.exceptions
 class TestStepValidator(unittest.TestCase):
   """Test verifylib.verify_delete_rule(rule, artifact_queue) """
 
+
   def setUp(self):
     """Populate a base layout that we can use."""
     self.step = Step(name="this-step")
+
 
   def test_wrong_type(self):
     """Test the type field within Validate()."""
@@ -42,6 +44,7 @@ class TestStepValidator(unittest.TestCase):
 
     self.step._type = "step"
     self.step._validate_type()
+
 
   def test_wrong_threshold(self):
     """Test that the threshold value is correctly checked."""
@@ -58,49 +61,6 @@ class TestStepValidator(unittest.TestCase):
     self.step._validate_threshold()
     self.step.validate()
 
-  def test_wrong_expected_materials(self):
-    """Test that the material rule validators catch malformed ones."""
-
-    self.step.expected_materials = [["NONFOO"]]
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_expected_materials()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    self.step.expected_materials = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_expected_materials()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    # for more thorough tests, check the test_rulelib.py module
-    self.step.expected_materials = [["CREATE", "foo"]]
-    self.step._validate_expected_materials()
-    self.step.validate()
-
-  def test_wrong_expected_products(self):
-    """Test that the product rule validators catch malformed ones."""
-
-    self.step.expected_products = [["NONFOO"]]
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_expected_products()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    self.step.expected_products = "PFF"
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step._validate_expected_products()
-
-    with self.assertRaises(securesystemslib.exceptions.FormatError):
-      self.step.validate()
-
-    # for more thorough tests, check the test_rulelib.py module
-    self.step.expected_products = [["CREATE", "foo"]]
-    self.step._validate_expected_products()
-    self.step.validate()
 
   def test_wrong_pubkeys(self):
     # FIXME: generating keys for each test are expensive processes, maybe we
@@ -121,6 +81,7 @@ class TestStepValidator(unittest.TestCase):
     self.step._validate_pubkeys()
     self.step.validate()
 
+
   def test_wrong_expected_command(self):
     """Test that the expected command validator catches malformed ones."""
 
@@ -135,11 +96,13 @@ class TestStepValidator(unittest.TestCase):
     self.step._validate_expected_command()
     self.step.validate()
 
+
   def test_set_expected_command_from_string(self):
     """Test shelx parse command string to list. """
     step = Step()
     step.set_expected_command_from_string("echo 'foo bar'")
     self.assertListEqual(step.expected_command, ["echo", "foo bar"])
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/models/test_supply_chain_item.py
+++ b/tests/models/test_supply_chain_item.py
@@ -79,5 +79,16 @@ class TestSupplyChainItem(unittest.TestCase):
     json.loads(repr(SupplyChainItem()))
 
 
+  def test_add_rule_from_string(self):
+    """Test that add_rule_from string methods set property correctly. """
+    item = SupplyChainItem()
+    item.add_material_rule_from_string("CREATE foo")
+    self.assertListEqual(item.expected_materials[-1], ["CREATE", "foo"])
+    item.add_product_rule_from_string("ALLOW bar")
+    self.assertListEqual(item.expected_products[-1], ["ALLOW", "bar"])
+
+    item.validate()
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/models/test_supply_chain_item.py
+++ b/tests/models/test_supply_chain_item.py
@@ -74,5 +74,10 @@ class TestSupplyChainItem(unittest.TestCase):
     item.validate()
 
 
+  def test_repr(self):
+    """Test repr returns a JSON parseable string. """
+    json.loads(repr(SupplyChainItem()))
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/tests/models/test_supply_chain_item.py
+++ b/tests/models/test_supply_chain_item.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  test_supply_chain_item.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Jan 25, 2018
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test SupplyChainItem class methods.
+  SupplyChainItem is a super class for Steps and Inspections.
+
+"""
+import json
+import unittest
+from in_toto.models.layout import SupplyChainItem
+import securesystemslib.exceptions
+
+class TestSupplyChainItem(unittest.TestCase):
+  """Test models.SupplyChainItem. """
+
+
+  def test_wrong_expected_materials(self):
+    """Test that the material rule validators catch malformed ones."""
+    item = SupplyChainItem()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.expected_materials = [["NONFOO"]]
+      item._validate_expected_materials()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.validate()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.expected_materials = "PFF"
+      item._validate_expected_materials()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.validate()
+
+    # for more thorough tests, check the test_rulelib.py module
+    item.expected_materials = [["CREATE", "foo"]]
+    item._validate_expected_materials()
+    item.validate()
+
+
+  def test_wrong_expected_products(self):
+    """Test that the product rule validators catch malformed values."""
+    item = SupplyChainItem()
+
+    item.expected_products = [["NONFOO"]]
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item._validate_expected_products()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.validate()
+
+    item.expected_products = "PFF"
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item._validate_expected_products()
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      item.validate()
+
+    # for more thorough tests, check the test_rulelib.py module
+    item.expected_products = [["CREATE", "foo"]]
+    item._validate_expected_products()
+    item.validate()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:
Closes #16 

**Description of the changes being introduced by the pull request**:
The `Step` and `Inspection` class both carry `expected_materials` and `expected_products` and already are treated similarly during final product verification, in terms of rule verification. Additionally both items have a name that is used to associate link metadata with the corresponding item.

This PR adds a superclass `SupplyChainItem` (suggestions for a better name are welcome) in order to reduce code redundancy.

This PR also overrides `SupplyChainItem`'s `__repr__` method to return a JSON formatted String like for `Metablock`, `Layout` and `Link`.

This PR also adds convenience methods to parse artifact rules from a string into a list and add it to a supply chain item's `expected_materials` or `expected_products` property.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


