### PR TITLE
Add layout creation convenience methods

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -362,11 +362,7 @@ class Layout(Signable):
       A list of functionary keyids.
 
     """
-    keyid_list = []
-    for keyid in list(self.keys.keys()):
-      keyid_list.append(keyid)
-
-    return keyid_list
+    return list(self.keys.keys())
 
 
   def add_functionary_key(self, key):

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -779,17 +779,12 @@ class Inspection(SupplyChainItem):
 
   """
   _type = attr.ib()
-  name = attr.ib()
   run = attr.ib()
 
 
   def __init__(self, **kwargs):
     super(Inspection, self).__init__(**kwargs)
     self._type = "inspection"
-    self.name = kwargs.get("name")
-    self.expected_materials = kwargs.get("expected_materials", [])
-    self.expected_products = kwargs.get("expected_products", [])
-
     self.run = kwargs.get("run", [])
 
     self.validate()

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -46,6 +46,7 @@ import in_toto.formats
 import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.schema
+import securesystemslib.interface
 
 
 
@@ -55,31 +56,8 @@ class Layout(Signable):
   A layout lists the sequence of steps of the software supply chain, and the
   functionaries authorized to perform these steps.
 
-  The object should be contained in a generic Metablock object, which
-  provides functionality for signing and signature verification, and reading
-  from and writing to disk.
-
-  <Attributes>
-    _type:
-        "layout"
-
-    steps:
-        a list of Step objects
-
-    inspect:
-        a list of Inspection objects
-
-    keys:
-        A dictionary of public keys used to verify the signature of link
-        metadata file related to a step. Format is
-        securesystemslib.formats.KEYDICT_SCHEMA
-
-    expires:
-        the expiration date of a layout
-
-    readme:
-        a human readable description of the software supply chain defined
-        by the layout
+  The object should be wrapped in a metablock object, to provide functionality
+  for signing and signature verification, and reading from and writing to disk.
 
   """
   _type = attr.ib()
@@ -89,7 +67,40 @@ class Layout(Signable):
   expires = attr.ib()
   readme = attr.ib()
 
+
   def __init__(self, **kwargs):
+    """
+    <Purpose>
+      Instantiate a new layout object with optional initial values.
+
+    <Optional Keyword Arguments>
+      steps:
+              A list of step objects describing the steps required to carry out
+              the software supply chain.
+
+      inspect:
+              A list of inspection objects describing any additional actions
+              carried out upon verification.
+
+      keys:
+              A dictionary of public keys whose private keys are used
+              to sign the metadata (link metadata) corresponding to the steps
+              of the supply chain. Each step can authorize one or more of the
+              here listed keys individually.
+
+      expires:
+              The expiration date of a layout.
+
+      readme:
+              A human readable description of the software supply chain defined
+              by the layout.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the instantiated layout has invalid properties, e.g. because
+              any of the assigned keyword arguments are invalid.
+
+    """
     super(Layout, self).__init__()
     self._type = "layout"
     self.steps = kwargs.get("steps", [])
@@ -97,23 +108,58 @@ class Layout(Signable):
     self.keys = kwargs.get("keys", {})
     self.readme = kwargs.get("readme", "")
 
-    # Assign a default expiration (on month) if not specified
-    self.expires = kwargs.get("expires", (datetime.today() +
-        relativedelta(months=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    # Assign a default expiration (one month) if not expiration date is passed
+    # TODO: Is one month a sensible default? In any case, we need a valid
+    # expiration date in order for the layout object to validate.
+    # (c.f. self._validate_expires)
+    self.expires = kwargs.get("expires")
+    if not self.expires:
+      self.set_relative_expiration(months=1)
 
+    # TODO: Should we validate in the constructor or allow the user to create
+    # an invalid layout and call validate explicitly?
     self.validate()
+
 
   @property
   def type_(self):
-    """Getter for protected _type attribute. Trailing underscore used by
-    convention (pep8) to avoid conflict with Python's type keyword. """
+    """
+    <Purpose>
+      Getter for protected _type attribute.
+
+      NOTE: The trailing underscore used is by convention (pep8) to avoid
+      conflicts with Python's 'type' keyword.
+
+    <Returns>
+      The type of the metadata object, i.e. "layout" (see constructor).
+
+    """
     return self._type
+
 
   @staticmethod
   def read(data):
-    """Static method to instantiate a Layout and containing Step and Inspection
-    objects from a dictionary, e.g.:
-    {"steps": [<step data>, ...], "inspect": [<inspection data>, ...]} """
+    """
+    <Purpose>
+      Static method to instantiate a layout object from a Python dictionary,
+      e.g.: by parsing its JSON representation. The method expects any
+      contained steps and inspections to be Python dictionaries as well, and
+      tries to instantiate the corresponding objects using the step's and
+      inspection's read methods respectively.
+
+    <Arguments>
+      data:
+              A dictionary containing layout metadata.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If any of the layout's properties is invalid.
+
+    <Returns>
+      The newly created layout object, optionally containing newly instantiated
+      step and inspection objects.
+
+    """
     steps = []
 
     for step_data in data.get("steps"):
@@ -128,11 +174,375 @@ class Layout(Signable):
     return Layout(**data)
 
 
+  def set_relative_expiration(self, days=0, months=0, years=0):
+    """
+    <Purpose>
+      Set the layout's expiration date in one or more of "days", "months" or
+      "years" from today. If no argument is passed, it defaults to today.
+
+    <Arguments>
+      days:
+              Days from today.
+
+      months:
+              Months from today.
+
+      years:
+              Years from today.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If any of days, months or years is passed and is not an
+              integer.
+
+    """
+    securesystemslib.schema.Integer().check_match(days)
+    securesystemslib.schema.Integer().check_match(months)
+    securesystemslib.schema.Integer().check_match(years)
+
+    self.expires = (datetime.today() + relativedelta(
+        days=days, months=months, years=years)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+  def get_step_name_list(self):
+    """
+    <Purpose>
+      Return list of step names in the order in which they are listed in the
+      layout.
+
+    <Returns>
+      A list of step names.
+
+    """
+    step_names = []
+    for step in self.steps:
+      step_names.append(step.name)
+
+    return step_names
+
+
+  def get_step_by_name(self, step_name):
+    """
+    <Purpose>
+      Return the first step in the layout's list of steps identified by the
+      passed step name.
+
+      NOTE: Step names must be unique within a layout, which is enforced by
+      they Layout's validate method. However, if validate has not been called,
+      there may be multiple steps with the same name. In that case only
+      the first step with the passed name is returned.
+
+    <Arguments>
+      step_name:
+              A step name.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed step name is not a string.
+
+    <Returns>
+      A step object.
+
+    """
+    securesystemslib.schema.AnyString().check_match(step_name)
+
+    for step in self.steps: # pragma: no branch
+      if step.name == step_name:
+        return step
+
+
+  def remove_step_by_name(self, step_name):
+    """
+    <Purpose>
+      Remove all steps from the layout's list of steps identified by the
+      passed step name.
+
+      NOTE: Step names must be unique within a layout, which is enforced by
+      they layout's validate method. However, if validate has not been called,
+      there might be multiple steps with the same name. The method removes
+      all steps with the passed name.
+
+    <Arguments>
+      step_name:
+              A step name.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed step name is not a string.
+
+    """
+    securesystemslib.schema.AnyString().check_match(step_name)
+
+    for step in self.steps:
+      if step.name == step_name:
+        self.steps.remove(step)
+
+
+  def get_inspection_name_list(self):
+    """
+    <Purpose>
+      Return list of inspection names in the order in which they are listed in
+      the layout.
+
+    <Returns>
+      A list of the inspection names.
+
+    """
+    inspection_names = []
+    for inspection in self.inspect:
+      inspection_names.append(inspection.name)
+
+    return inspection_names
+
+
+  def get_inspection_by_name(self, inspection_name):
+    """
+    <Purpose>
+      Return the first inspection in the layout's list of inspections
+      identified by the passed inspection name.
+
+      NOTE: Inspection names must be unique within a layout, which is enforced
+      by they layout's validate method. However, if validate has not been
+      called, there may be multiple inspections with the same name. In that
+      case only the first inspection with the passed name is returned.
+
+    <Arguments>
+      inspection_name:
+              An inspection name.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed inspection name is not a string.
+
+    <Returns>
+      An inspection object.
+
+    """
+    securesystemslib.schema.AnyString().check_match(inspection_name)
+
+    for inspection in self.inspect: # pragma: no branch
+      if inspection.name == inspection_name:
+        return inspection
+
+
+  def remove_inspection_by_name(self, inspection_name):
+    """
+    <Purpose>
+      Remove all inspections from the layout's list of inspections identified
+      by the passed inspection name.
+
+      NOTE: Inspection names must be unique within a layout, which is enforced
+      by they layout's validate method. However, if validate has not been
+      called, there may be multiple inspections with the same name. The
+      method removes all inspections with the passed name.
+
+    <Arguments>
+      inspection_name:
+              An inspection name.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed inspection name is not a string.
+
+    """
+    securesystemslib.schema.AnyString().check_match(inspection_name)
+
+    for inspection in self.inspect:
+      if inspection.name == inspection_name:
+        self.inspect.remove(inspection)
+
+
+  def get_functionary_key_id_list(self):
+    """
+    <Purpose>
+      Return a list of the functionary keyids from the layout's keys
+      dictionary.
+
+    <Returns>
+      A list of functionary keyids.
+
+    """
+    keyid_list = []
+    for keyid in list(self.keys.keys()):
+      keyid_list.append(keyid)
+
+    return keyid_list
+
+
+  def add_functionary_key(self, key):
+    """
+    <Purpose>
+      Add the passed functionary public key to the layout's dictionary of keys.
+
+    <Arguments>
+      key:
+              A functionary public key conformant with
+              in_toto.formats.ANY_PUBKEY_SCHEMA.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed key does not match
+              in_toto.formats.ANY_PUBKEY_SCHEMA.
+
+    <Returns>
+      The added functionary public key.
+
+    """
+    in_toto.formats.ANY_PUBKEY_SCHEMA.check_match(key)
+    keyid = key["keyid"]
+    self.keys[keyid] = key
+    return key
+
+
+  def add_functionary_key_from_path(self, key_path):
+    """
+    <Purpose>
+      Load a functionary public key in RSA PEM format from the passed path
+      and add it to the layout's dictionary of keys.
+
+    <Arguments>
+      key_path:
+              A path, conformant with securesystemslib.formats.PATH_SCHEMA,
+              to a functionary public key.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed key path does not match
+              securesystemslib.formats.PATH_SCHEMA.
+
+      securesystemslib.exceptions.Error
+              If the key at the passed path cannot be imported as public key.
+
+    <Returns>
+      The added functionary public key.
+
+    """
+    securesystemslib.formats.PATH_SCHEMA.check_match(key_path)
+    key = securesystemslib.interface.import_rsa_publickey_from_file(key_path)
+
+    return self.add_functionary_key(key)
+
+
+
+  def add_functionary_key_from_gpg_keyid(self, gpg_keyid, gpg_home=None):
+    """
+    <Purpose>
+      Load a functionary public key from the GPG keychain, located at the
+      passed GPG home path, identified by the passed GPG keyid, and add it to
+      the layout's dictionary of keys.
+
+    <Arguments>
+      gpg_keyid:
+              A GPG keyid.
+
+      gpg_home:
+              A path to the GPG keychain to load the key from. If not passed
+              the default GPG keychain is used.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If the passed gpg keyid does not match
+              securesystemslib.formats.KEYID_SCHEMA.
+
+              If the gpg home path is passed and does not match
+              securesystemslib.formats.PATH_SCHEMA.
+
+              If the key loaded from the GPG keychain does not match
+              in_toto.formats.ANY_PUBKEY_SCHEMA.
+
+    <Returns>
+      The added functionary public key.
+
+    """
+    securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+    if gpg_home: # pragma: no branch
+      securesystemslib.formats.PATH_SCHEMA.check_match(gpg_home)
+
+    key = in_toto.gpg.functions.gpg_export_pubkey(gpg_keyid,
+        homedir=gpg_home)
+    return self.add_functionary_key(key)
+
+
+  def add_functionary_keys_from_paths(self, key_path_list):
+    """
+    <Purpose>
+      Load the functionary public keys in RSA PEM format from the passed list
+      of paths and add them to the layout's dictionary of keys.
+
+    <Arguments>
+      key_path_list:
+              A list of paths, conformant with
+              securesystemslib.formats.PATH_SCHEMA, to functionary public keys.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If any of the passed key paths does not match
+              securesystemslib.formats.PATH_SCHEMA.
+
+      securesystemslib.exceptions.Error
+              If any of the keys at the passed paths cannot be imported as
+              public key.
+
+    <Returns>
+      A dictionary of the added functionary public keys with the key's keyids
+      as dictionary keys and the keys as values.
+
+    """
+    securesystemslib.formats.PATHS_SCHEMA.check_match(key_path_list)
+    key_dict = {}
+    for key_path in key_path_list:
+      key = self.add_functionary_key_from_path(key_path)
+      key_dict[key["keyid"]] = key
+
+    return key_dict
+
+
+  def add_functionary_keys_from_gpg_keyids(self, gpg_keyid_list, gpg_home=None):
+    """
+    <Purpose>
+      Load functionary public keys from the GPG keychain, located at the
+      passed GPG home path, identified by the passed GPG keyids, and add it to
+      the layout's dictionary of keys.
+
+    <Arguments>
+      gpg_keyid_list:
+              A list of GPG keyids.
+
+      gpg_home:
+              A path to the GPG keychain to load the keys from. If not passed
+              the default GPG keychain is used.
+
+    <Exceptions>
+      securesystemslib.exceptions.FormatError
+              If any of the passed gpg keyids does not match
+              securesystemslib.formats.KEYID_SCHEMA.
+
+              If gpg home is passed and does not match
+              securesystemslib.formats.PATH_SCHEMA.
+
+              If any of the keys loaded from the GPG keychain does not
+              match in_toto.formats.ANY_PUBKEY_SCHEMA.
+
+    <Returns>
+      A dictionary of the added functionary public keys with the key's keyids
+      as dictionary keys and the keys as values.
+
+    """
+    securesystemslib.formats.KEYIDS_SCHEMA.check_match(gpg_keyid_list)
+    key_dict = {}
+    for gpg_keyid in gpg_keyid_list:
+      key = self.add_functionary_key_from_gpg_keyid(gpg_keyid, gpg_home)
+      key_dict[key["keyid"]] = key
+
+    return key_dict
+
+
   def _validate_type(self):
     """Private method to check that the type string is set to layout."""
     if self._type != "layout":
       raise securesystemslib.exceptions.FormatError(
           "Invalid _type value for layout (Should be 'layout')")
+
 
   def _validate_expires(self):
     """Private method to verify if the expiration field has the right format
@@ -147,6 +557,7 @@ class Layout(Signable):
       raise securesystemslib.exceptions.FormatError(
           "Malformed date string in layout. Exception: {}".format(e))
 
+
   def _validate_readme(self):
     """Private method to check that the readme field is a string."""
     if not isinstance(self.readme, string_types):
@@ -154,18 +565,19 @@ class Layout(Signable):
           "Invalid readme '{}', value must be a string."
           .format(self.readme))
 
+
   def _validate_keys(self):
     """Private method to ensure that the keys contained are right."""
     in_toto.formats.ANY_PUBKEY_DICT_SCHEMA.check_match(self.keys)
 
+
   def _validate_steps_and_inspections(self):
     """Private method to verify that the list of steps and inspections are
     correctly formed."""
-
     names_seen = set()
     if type(self.steps) != list:
       raise securesystemslib.exceptions.FormatError(
-          "the steps section should be a list!")
+          "The steps section should be a list!")
 
     for step in self.steps:
       if not isinstance(step, Step):
@@ -176,7 +588,8 @@ class Layout(Signable):
 
       if step.name in names_seen:
         raise securesystemslib.exceptions.FormatError(
-            "There is a repeated name in the steps! {}".format(step.name))
+            "There is already a step with name '{}'. Step names must be"
+            " unique within a layout.".format(step.name))
       names_seen.add(step.name)
 
     if type(self.inspect) != list:
@@ -192,7 +605,8 @@ class Layout(Signable):
 
       if inspection.name in names_seen:
         raise securesystemslib.exceptions.FormatError(
-            "There is a repeated name in the steps! {}".format(inspection.name))
+            "There is already an inspection with name '{}'. Inspection names"
+            " must be unique within a layout.".format(inspection.name))
       names_seen.add(inspection.name)
 
 

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -641,12 +641,20 @@ class SupplyChainItem(ValidationMixin):
   def add_material_rule_from_string(self, rule_string):
     securesystemslib.schema.AnyString().check_match(rule_string)
     rule_list = shlex.split(rule_string)
+
+    # Raises format error if the parsed rule_string is not a valid rule
+    in_toto.rulelib.unpack_rule(rule_list)
+
     self.expected_materials.append(rule_list)
 
 
   def add_product_rule_from_string(self, rule_string):
     securesystemslib.schema.AnyString().check_match(rule_string)
     rule_list = shlex.split(rule_string)
+
+    # Raises format error if the parsed rule_string is not a valid rule
+    in_toto.rulelib.unpack_rule(rule_list)
+
     self.expected_products.append(rule_list)
 
 

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -19,7 +19,9 @@
 
 import os
 import unittest
-import datetime
+import tempfile
+import shutil
+
 from in_toto.models.layout import Layout, Step, Inspection
 from in_toto.models.metadata import Metablock
 import in_toto.models.link
@@ -27,17 +29,188 @@ import in_toto.exceptions
 import in_toto.verifylib
 import securesystemslib.exceptions
 
+
+class TestLayoutMethods(unittest.TestCase):
+  """Test Layout methods. """
+
+  @classmethod
+  def setUpClass(self):
+    """Create temporary test directory and copy gpg keychain, and rsa keys from
+    demo files. """
+    self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
+    self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
+    self.test_dir = os.path.realpath(tempfile.mkdtemp())
+
+    # Create directory to run the tests without having everything blow up
+    self.working_dir = os.getcwd()
+
+    # Copy GPG keyring to temp test dir
+    tests_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+
+    self.gnupg_home = os.path.join(self.test_dir, "rsa")
+    shutil.copytree(
+        os.path.join(tests_dir, "gpg_keyrings", "rsa"),
+        self.gnupg_home)
+
+    # Copy keys to temp test dir
+    key_names = ["bob", "bob.pub", "carl.pub"]
+    for name in key_names:
+      shutil.copy(
+        os.path.join(tests_dir, "demo_files", name),
+        os.path.join(self.test_dir, name))
+
+    self.key_path = os.path.join(self.test_dir, "bob")
+    self.pubkey_path1 = os.path.join(self.test_dir, "bob.pub")
+    self.pubkey_path2 = os.path.join(self.test_dir, "carl.pub")
+
+    os.chdir(self.test_dir)
+
+
+
+  @classmethod
+  def tearDownClass(self):
+    """Change back to initial working dir and remove temp test directory. """
+    os.chdir(self.working_dir)
+    shutil.rmtree(self.test_dir)
+
+
+  def test_set_relative_expiration(self):
+    """Test adding expiration date relative from today. """
+    layout = Layout()
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.set_relative_expiration(days=None, months=0, years=0)
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.set_relative_expiration(days=0, months="", years=0)
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.set_relative_expiration(days=0, months=0, years=[])
+
+    layout.set_relative_expiration(days=1)
+    layout._validate_expires()
+    layout.set_relative_expiration(months=2)
+    layout._validate_expires()
+    layout.set_relative_expiration(years=3)
+    layout._validate_expires()
+    layout.set_relative_expiration(days=3, months=2, years=1)
+    layout._validate_expires()
+
+
+  def test_get_step_name_list(self):
+    """Test getting list of step names. """
+    names = ["a", "b", "c"]
+    layout = Layout(steps=[Step(name=name) for name in names])
+    self.assertListEqual(layout.get_step_name_list(), names)
+
+
+  def test_get_step_by_name(self):
+    """Test getting step by name. """
+    names = ["a", "b", "c"]
+    layout = Layout(steps=[Step(name=name) for name in names])
+    self.assertEqual(layout.get_step_by_name("b").name, "b")
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.get_step_by_name(None)
+
+
+  def test_remove_step_by_name(self):
+    """Test removing step by name. """
+    names = ["a", "b", "c"]
+    layout = Layout(steps=[Step(name=name) for name in names])
+    layout.remove_step_by_name("b")
+    self.assertEqual(len(layout.steps), 2)
+    self.assertTrue("b" not in layout.get_step_name_list())
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.get_step_by_name([])
+
+
+  def test_get_inspection_name_list(self):
+    """Test getting list of inspection names. """
+    names = ["a", "b", "c"]
+    layout = Layout(inspect=[Inspection(name=name) for name in names])
+    self.assertListEqual(layout.get_inspection_name_list(), names)
+
+
+  def test_get_inspection_by_name(self):
+    """Test getting inspection by name. """
+    names = ["a", "b", "c"]
+    layout = Layout(inspect=[Inspection(name=name) for name in names])
+    self.assertEqual(layout.get_inspection_by_name("b").name, "b")
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.get_inspection_by_name(1)
+
+
+  def test_remove_inspection_by_name(self):
+    """Test removing inspection by name. """
+    names = ["a", "b", "c"]
+    layout = Layout(inspect=[Inspection(name=name) for name in names])
+    layout.remove_inspection_by_name("b")
+    self.assertEqual(len(layout.inspect), 2)
+    self.assertTrue("b" not in layout.get_inspection_name_list())
+
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.remove_inspection_by_name(False)
+
+
+  def test_functionary_keys(self):
+    """Test adding and listing functionary keys (securesystemslib and gpg). """
+    layout = Layout()
+    self.assertEqual(len(layout.get_functionary_key_id_list()), 0)
+
+    layout.add_functionary_keys_from_paths([self.pubkey_path1,
+        self.pubkey_path2])
+
+    layout.add_functionary_keys_from_gpg_keyids([self.gpg_keyid1,
+        self.gpg_keyid2], gpg_home=self.gnupg_home)
+
+    layout._validate_keys()
+
+    self.assertEqual(len(layout.get_functionary_key_id_list()), 4)
+
+    # Must be a valid key object
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_key("abcd")
+
+    # Must be pubkey and not private key
+    with self.assertRaises(securesystemslib.exceptions.Error):
+      layout.add_functionary_key_from_path(self.key_path)
+
+    # Must be a valid path
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_key_from_path(123)
+
+    # Must be a valid keyid
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_key_from_gpg_keyid("abcdefg")
+
+    # Must be a list of paths
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_keys_from_paths("abcd")
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_keys_from_paths([1])
+
+    # Must be a list of keyids
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_keys_from_gpg_keyids(None)
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      layout.add_functionary_keys_from_gpg_keyids(["abcdefg"])
+
+
+
 class TestLayoutValidator(unittest.TestCase):
   """Test in_toto.models.layout.Layout validators. """
+
 
   def setUp(self):
     """Populate a base layout that we can use."""
     self.layout = Layout()
     self.layout.expires = '2016-11-18T16:44:55Z'
 
+
   def test_wrong_type(self):
     """Test that the type field is validated properly."""
-
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       self.layout._type = "wrong"
       self.layout._validate_type()
@@ -45,6 +218,7 @@ class TestLayoutValidator(unittest.TestCase):
 
     self.layout._type = "layout"
     self.layout._validate_type()
+
 
   def test_validate_readme_field(self):
     """Tests the readme field data type validator. """
@@ -54,6 +228,7 @@ class TestLayoutValidator(unittest.TestCase):
 
     self.layout.readme = "This is a test supply chain"
     self.layout._validate_readme()
+
 
   def test_wrong_expires(self):
     """Test the expires field is properly populated."""
@@ -83,6 +258,7 @@ class TestLayoutValidator(unittest.TestCase):
     self.layout.expires = '2016-11-18T16:44:55Z'
     self.layout._validate_expires()
     self.layout.validate()
+
 
   def test_wrong_key_dictionary(self):
     """Test that the keys dictionary is properly populated."""
@@ -115,6 +291,7 @@ class TestLayoutValidator(unittest.TestCase):
     self.layout._validate_keys()
     self.layout.validate()
 
+
   def test_wrong_steps_list(self):
     """Check that the validate method checks the steps' correctness."""
     self.layout.steps = "not-a-step"
@@ -136,6 +313,7 @@ class TestLayoutValidator(unittest.TestCase):
     test_step.threshold = 1
     self.layout.steps = [test_step]
     self.layout.validate()
+
 
   def test_wrong_inspect_list(self):
     """Check that the validate method checks the inspections' correctness."""
@@ -159,6 +337,7 @@ class TestLayoutValidator(unittest.TestCase):
     self.layout.inspect = [test_inspection]
     self.layout.validate()
 
+
   def test_repeated_step_names(self):
     """Check that only unique names exist in the steps and inspect lists"""
 
@@ -174,6 +353,7 @@ class TestLayoutValidator(unittest.TestCase):
     self.layout.step = [Step(name="name"), Step(name="othername")]
     self.layout.inspect = [Inspection(name="thirdname")]
     self.layout.validate()
+
 
   def test_import_step_metadata_wrong_type(self):
     functionary_key = securesystemslib.keys.generate_rsa_key()

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -121,9 +121,14 @@ class TestLayoutMethods(unittest.TestCase):
     """Test removing step by name. """
     names = ["a", "b", "c"]
     layout = Layout(steps=[Step(name=name) for name in names])
-    layout.remove_step_by_name("b")
-    self.assertEqual(len(layout.steps), 2)
-    self.assertTrue("b" not in layout.get_step_name_list())
+
+    self.assertEqual(len(layout.steps), 3)
+    self.assertTrue("b" in layout.get_step_name_list())
+    # Items are only removed if they exist
+    for _ in range(2):
+      layout.remove_step_by_name("b")
+      self.assertEqual(len(layout.steps), 2)
+      self.assertTrue("b" not in layout.get_step_name_list())
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       layout.get_step_by_name([])
@@ -150,9 +155,15 @@ class TestLayoutMethods(unittest.TestCase):
     """Test removing inspection by name. """
     names = ["a", "b", "c"]
     layout = Layout(inspect=[Inspection(name=name) for name in names])
-    layout.remove_inspection_by_name("b")
-    self.assertEqual(len(layout.inspect), 2)
-    self.assertTrue("b" not in layout.get_inspection_name_list())
+
+    self.assertEqual(len(layout.inspect), 3)
+    self.assertTrue("b" in layout.get_inspection_name_list())
+    # Items are only removed if they exist
+    for _ in range(2):
+      layout.remove_inspection_by_name("b")
+      self.assertEqual(len(layout.inspect), 2)
+      self.assertTrue("b" not in layout.get_inspection_name_list())
+
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       layout.remove_inspection_by_name(False)

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -95,6 +95,10 @@ class TestLayoutMethods(unittest.TestCase):
     layout.set_relative_expiration(days=3, months=2, years=1)
     layout._validate_expires()
 
+    # It's possible to add an expiration date in the past
+    layout.set_relative_expiration(days=-3, months=-2, years=-1)
+    layout._validate_expires()
+
 
   def test_get_step_name_list(self):
     """Test getting list of step names. """


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
Adds methods to the layout class to ease layout creation.

Here is a list of the newly added methods:
- set_relative_expiration
- get_step_name_list
- get_step_by_name
- remove_step_by_name
- get_inspection_name_list
- get_inspection_by_name
- remove_inspection_by_name
- get_functionary_key_id_list
- add_functionary_key
- add_functionary_key_from_path
- add_functionary_key_from_gpg_keyid
- add_functionary_keys_from_paths
- add_functionary_keys_from_gpg_keyids

Additionally refines and fixes various docstrings, comments, exceptions messages and spacings in the the layout class.

Please merge #180 and #179 first. I'd like to give the docstrings, comments in the parts of the layout module affected by those PRs another pass here.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


