### PR TITLE
Add a layout creation example document

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ The in-toto software supply chain layout consists of the following parts:
    correspond to steps carried out by a functionary as part of the software supply chain. The steps defined in the layout list the functionaries who are authorized to carry out the step (by key id). Steps require a unique name to associate them (upon verification) with link metadata that is created when a functionary carries out the step using the `in-toto` tools. Additionally, steps must have material and product rules which define the files a step is supposed to operate on. Material and product rules are described in the section below.
  - **inspections** define commands to be run during the verification process and can also list material and product rules.
 
-*Hint: Take a look at [`create_layout.py`](https://github.com/in-toto/demo/blob/master/owner_alice/create_layout.py),
-a script that creates the in-toto demo layout.*
+Take a look at the [demo layout creation example](layout-creation.md)
+for further information on how to create an in-toto layout. Or try our
+experimental [layout creation web tool](https://in-toto.engineering.nyu.edu/).
+
+
 
 #### Artifact Rules
 A software supply chain usually operates on a set of files, such as source code, executables, packages, or the like. in-toto calls these files artifacts. A material is an artifact that will be used when a step or inspection is carried out. Likewise, a product is an artifact that results from carrying out a step.

--- a/layout-creation.md
+++ b/layout-creation.md
@@ -1,9 +1,14 @@
 # Layout Creation Example
 
-The following Python snippet shows how to use in-toto to create a software
-supply chain layout like the one that is used for the in-toto demo.
-*Take a look at the [demo repo](https://github.com/in-toto/demo) for more
-information about that supply chain*.
+While it is possible to write an in-toto layout from scratch using a text
+editor and the JSON format, the preferred way is to use the in-toto model
+classes provided by the reference implementation.
+
+This document shows how to use in-toto's model classes and their convenience
+methods to create a supply chain layout like the one that is being used in the
+in-toto demo. Take a look at the [demo repo](https://github.com/in-toto/demo)
+for more details about the supply chain represented by this layout.
+
 
 
 ```python
@@ -12,16 +17,21 @@ from securesystemslib.interface import (generate_and_write_rsa_keypair,
 from in_toto.models.layout import Layout, Step, Inspection
 from in_toto.models.metadata import Metablock
 
-# Create RSA private and public keys
 
-# Alice is the project owner and her private key is used to sign the layout
+# in-toto provides functions to create RSA key pairs if you don't have them yet
+
+# In this example Alice is the project owner, whose private key is used to sign
+# the layout. The corresponding public key will be used during final product
+# verification.
 alice_path = generate_and_write_rsa_keypair("alice", password="123")
 alice_key = import_rsa_privatekey_from_file(alice_path, password="123")
 
 # Bob and Carl are both functionaries, i.e. they are authorized to carry out
-# different steps of the supply chain. Their public keys are added to the
-# supply chain layout, in order to verify the signatures of the link metadata
-# that Bob and Carl will generate when carrying out their respective tasks.
+# different steps of the supply chain. Their public keys will be added to the
+# layout, in order to verify the signatures of the link metadata that Bob and
+# Carl will generate when carrying out their respective tasks.
+# Bob and Carl will each require their private key when creating link metadata
+# for a step.
 bob_path = generate_and_write_rsa_keypair("bob", password="123")
 carl_path = generate_and_write_rsa_keypair("carl", password="123")
 
@@ -30,55 +40,104 @@ carl_path = generate_and_write_rsa_keypair("carl", password="123")
 layout = Layout()
 
 # Add functionary public keys to the layout
+# Since the functionaries public keys are embedded in the layout, they don't
+# need to be added separately for final product verification, as a consequence
+# the layout serves as functionary PKI.
 bob_pubkey = layout.add_functionary_key_from_path(bob_path + ".pub")
 carl_pubkey = layout.add_functionary_key_from_path(carl_path + ".pub")
 
-# Set expiration date so that the layout will expire in 4 months
+# Set expiration date so that the layout will expire in 4 months from now.
 layout.set_relative_expiration(months=4)
 
 
 # Create layout steps
 
-# Each step describes a task that is required to be carried out in this supply
-# chain. A step must have a unique name to associate the related link metadata
-# (i.e. the evidence that the step was carried out). Additionally, each step
-# should list rules, about the present related files before and after the step
-# was carried out. A steps pubkeys field lists the keyids of functionaries
-# authorized to perform the step.
+# Each step describes a task that is required to be carried out for a compliant
+# supply chain.
+# A step must have a unique name to associate the related link metadata
+# (i.e. the signed evidence that is created when a step is carried out).
+
+# Each step should also list rules about the related files (artifacts) present
+# before and after the step was carried out. These artifact rules allow to
+# enforce and authorize which files are used and created by a step, and to link
+# the steps of the supply chain together, i.e. to guarantee that files are not
+# tampered with in transit.
+
+# A step's pubkeys field lists the keyids of functionaries authorized to
+# perform the step.
+
+# Below step specifies the activity of cloning the source code repo.
+# Bob is authorized to carry out the step, which must create the product
+# 'demo-project/foo.py'.
+
+# When using in-toto tooling (see 'in-toto-run'), Bob will automatically
+# generate signed link metadata file, which provides the required information
+# to verify the supply chain of the final product.
+# The link metadata file must have the name "clone.<bob's keyid prefix>.link"
+
 step_clone = Step(name="clone")
-step_clone.set_expected_command_from_string(
-    "git clone https://github.com/in-toto/demo-project.git")
-step_clone.add_product_rule_from_string("CREATE demo-project/foo.py")
-step_clone.add_product_rule_from_string("DISALLOW *")
 step_clone.pubkeys = [bob_pubkey["keyid"]]
 
+# Note: In general final product verification will not fail but only warn if
+# the expected command diverges from the command that was actually used.
+
+step_clone.set_expected_command_from_string(
+    "git clone https://github.com/in-toto/demo-project.git")
+
+step_clone.add_product_rule_from_string("CREATE demo-project/foo.py")
+step_clone.add_product_rule_from_string("DISALLOW *")
+
+
+# The following step does not expect a command, since modifying the source
+# code might not be reflected by a single command. However, final product
+# verification will still require a link metadata file with the name
+# "update-version.<bob's keyid prefix>.link". In-toto also provides tooling
+# to create a link metadata file for a step that is not carried out in a
+# single command (see 'in-toto-record').
+
 step_update = Step(name="update-version")
+step_update.pubkeys = [bob_pubkey["keyid"]]
+
+# Below rules specify that the materials of this step must match the
+# products of the 'clone' step and that the product of this step can be a
+# (modified) file 'demo-project/foo.py'.
+
 step_update.add_material_rule_from_string(
     "MATCH demo-project/* WITH PRODUCTS FROM clone")
 step_update.add_material_rule_from_string("DISALLOW *")
 step_update.add_product_rule_from_string("ALLOW demo-project/foo.py")
 step_update.add_product_rule_from_string("DISALLOW *")
-step_update.pubkeys = [bob_pubkey["keyid"]]
+
+
+# Below step must be carried by Carl and expects a link file with the name
+# "package.<carl's keyid prefix>.link"
 
 step_package = Step(name="package")
+step_package.pubkeys = [carl_pubkey["keyid"]]
+
 step_package.set_expected_command_from_string(
     "tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
+
 step_package.add_material_rule_from_string(
     "MATCH demo-project/* WITH PRODUCTS FROM update-version")
 step_package.add_material_rule_from_string("DISALLOW *")
 step_package.add_product_rule_from_string("CREATE demo-project.tar.gz")
 step_package.add_product_rule_from_string("DISALLOW *")
-step_package.pubkeys = [carl_pubkey["keyid"]]
+
 
 
 # Create inspection
 
 # Inspections are commands that are executed upon in-toto final product
-# verification. In this case, we define an inspection that expands the final
-# product and verifies that the contents of the archive match with what was
+# verification. In this case, we define an inspection that untars the final
+# product, which must match the product of the last step in the supply chain,
+# ('package') and verifies that the contents of the archive match with what was
 # put into the archive.
+
 inspection = Inspection(name="untar")
+
 inspection.set_run_from_string("tar xzf demo-project.tar.gz")
+
 inspection.add_material_rule_from_string(
     "MATCH demo-project.tar.gz WITH PRODUCTS FROM package")
 inspection.add_product_rule_from_string(
@@ -92,6 +151,15 @@ layout.inspect = [inspection]
 
 # Eventually the layout gets wrapped in a generic in-toto metablock, which
 # provides functions to sign the metadata contents and write them to a file.
+# As mentioned above the layout contains the functionaries' public keys and
+# is signed by the project owner's private key.
+
+# In order to reduce the impact of a project owner key compromise, the layout
+# can and should be be signed by multiple project owners.
+
+# Project owner public keys must be provided together with the layout and the
+# link metadata files for final product verification.
+
 metablock = Metablock(signed=layout)
 metablock.sign(alice_key)
 metablock.dump("root.layout")

--- a/layout-creation.md
+++ b/layout-creation.md
@@ -1,0 +1,99 @@
+# Layout Creation Example
+
+The following Python snippet shows how to use in-toto to create a software
+supply chain layout like the one that is used for the in-toto demo.
+*Take a look at the [demo repo](https://github.com/in-toto/demo) for more
+information about that supply chain*.
+
+
+```python
+from securesystemslib.interface import (generate_and_write_rsa_keypair,
+    import_rsa_privatekey_from_file)
+from in_toto.models.layout import Layout, Step, Inspection
+from in_toto.models.metadata import Metablock
+
+# Create RSA private and public keys
+
+# Alice is the project owner and her private key is used to sign the layout
+alice_path = generate_and_write_rsa_keypair("alice", password="123")
+alice_key = import_rsa_privatekey_from_file(alice_path, password="123")
+
+# Bob and Carl are both functionaries, i.e. they are authorized to carry out
+# different steps of the supply chain. Their public keys are added to the
+# supply chain layout, in order to verify the signatures of the link metadata
+# that Bob and Carl will generate when carrying out their respective tasks.
+bob_path = generate_and_write_rsa_keypair("bob", password="123")
+carl_path = generate_and_write_rsa_keypair("carl", password="123")
+
+
+# Create an empty layout
+layout = Layout()
+
+# Add functionary public keys to the layout
+bob_pubkey = layout.add_functionary_key_from_path(bob_path + ".pub")
+carl_pubkey = layout.add_functionary_key_from_path(carl_path + ".pub")
+
+# Set expiration date so that the layout will expire in 4 months
+layout.set_relative_expiration(months=4)
+
+
+# Create layout steps
+
+# Each step describes a task that is required to be carried out in this supply
+# chain. A step must have a unique name to associate the related link metadata
+# (i.e. the evidence that the step was carried out). Additionally, each step
+# should list rules, about the present related files before and after the step
+# was carried out. A steps pubkeys field lists the keyids of functionaries
+# authorized to perform the step.
+step_clone = Step(name="clone")
+step_clone.set_expected_command_from_string(
+    "git clone https://github.com/in-toto/demo-project.git")
+step_clone.add_product_rule_from_string("CREATE demo-project/foo.py")
+step_clone.add_product_rule_from_string("DISALLOW *")
+step_clone.pubkeys = [bob_pubkey["keyid"]]
+
+step_update = Step(name="update-version")
+step_update.add_material_rule_from_string(
+    "MATCH demo-project/* WITH PRODUCTS FROM clone")
+step_update.add_material_rule_from_string("DISALLOW *")
+step_update.add_product_rule_from_string("ALLOW demo-project/foo.py")
+step_update.add_product_rule_from_string("DISALLOW *")
+step_update.pubkeys = [bob_pubkey["keyid"]]
+
+step_package = Step(name="package")
+step_package.set_expected_command_from_string(
+    "tar --exclude '.git' -zcvf demo-project.tar.gz demo-project")
+step_package.add_material_rule_from_string(
+    "MATCH demo-project/* WITH PRODUCTS FROM update-version")
+step_package.add_material_rule_from_string("DISALLOW *")
+step_package.add_product_rule_from_string("CREATE demo-project.tar.gz")
+step_package.add_product_rule_from_string("DISALLOW *")
+step_package.pubkeys = [carl_pubkey["keyid"]]
+
+
+# Create inspection
+
+# Inspections are commands that are executed upon in-toto final product
+# verification. In this case, we define an inspection that expands the final
+# product and verifies that the contents of the archive match with what was
+# put into the archive.
+inspection = Inspection(name="untar")
+inspection.set_run_from_string("tar xzf demo-project.tar.gz")
+inspection.add_material_rule_from_string(
+    "MATCH demo-project.tar.gz WITH PRODUCTS FROM package")
+inspection.add_product_rule_from_string(
+    "MATCH demo-project/foo.py WITH PRODUCTS FROM update-version")
+
+
+# Add steps and inspections to layout
+layout.steps = [step_clone, step_update, step_package]
+layout.inspect = [inspection]
+
+
+# Eventually the layout gets wrapped in a generic in-toto metablock, which
+# provides functions to sign the metadata contents and write them to a file.
+metablock = Metablock(signed=layout)
+metablock.sign(alice_key)
+metablock.dump("root.layout")
+
+```


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
Adds a markdown document that provides a Python snippet to create a demo layout like the one used in the in-toto/demo.

Also updates README to link to that document instead of the in-toto demo layout creation script and to link to the layout creation web tool.

Note that the methods used in the here added code snipped are added in the PRs #179, #180 and #181. So it would be good to merge those PRs first.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


