### PR TITLE
FIX: gpg: s/pgp+SHA1/pgp+SHA2/

### DIFF
--- a/in_toto/gpg/formats.py
+++ b/in_toto/gpg/formats.py
@@ -58,6 +58,9 @@ import securesystemslib.schema as ssl_schema
 import securesystemslib.formats as ssl_formats
 
 
+GPG_HASH_ALGORITHM_STRING = "pgp+SHA2"
+GPG_PUBKEY_METHOD_STRING = "pgp+rsa-pkcsv1.5"
+
 RSA_PUBKEYVAL_SCHEMA = ssl_schema.Object(
   object_name = "RSA_PUBKEYVAL_SCHEMA",
   e = ssl_schema.AnyString(),
@@ -68,8 +71,8 @@ RSA_PUBKEYVAL_SCHEMA = ssl_schema.Object(
 RSA_PUBKEY_SCHEMA = ssl_schema.Object(
   object_name = "RSA_PUBKEY_SCHEMA",
   type = ssl_schema.String("rsa"),
-  method = ssl_schema.String("pgp+rsa-pkcsv1.5"),
-  hashes = ssl_schema.ListOf(ssl_schema.String("pgp+SHA1")),
+  method = ssl_schema.String(GPG_PUBKEY_METHOD_STRING),
+  hashes = ssl_schema.ListOf(ssl_schema.String(GPG_HASH_ALGORITHM_STRING)),
   keyid = ssl_formats.KEYID_SCHEMA,
   keyval = ssl_schema.Object(
       public = RSA_PUBKEYVAL_SCHEMA,
@@ -91,7 +94,7 @@ DSA_PUBKEY_SCHEMA = ssl_schema.Object(
   object_name = "DSA_PUBKEY_SCHEMA",
   type = ssl_schema.String("dsa"),
   method = ssl_schema.String("pgp+dsa-fips-180-2"),
-  hashes = ssl_schema.ListOf(ssl_schema.String("pgp+SHA1")),
+  hashes = ssl_schema.ListOf(ssl_schema.String(GPG_HASH_ALGORITHM_STRING)),
   keyid = ssl_formats.KEYID_SCHEMA,
   keyval = ssl_schema.Object(
       public = DSA_PUBKEYVAL_SCHEMA,

--- a/in_toto/gpg/formats.py
+++ b/in_toto/gpg/formats.py
@@ -30,7 +30,7 @@
 
   >>> rsa_pubkey = {
       'type': 'rsa',
-      'hashes': ['pgp+SHA1'],
+      'hashes': ['pgp+SHA2'],
       'keyid': '8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17',
       'keyval': {
         'public': {

--- a/in_toto/gpg/formats.py
+++ b/in_toto/gpg/formats.py
@@ -59,7 +59,8 @@ import securesystemslib.formats as ssl_formats
 
 
 GPG_HASH_ALGORITHM_STRING = "pgp+SHA2"
-GPG_PUBKEY_METHOD_STRING = "pgp+rsa-pkcsv1.5"
+PGP_RSA_PUBKEY_METHOD_STRING = "pgp+rsa-pkcsv1.5"
+PGP_DSA_PUBKEY_METHOD_STRING = "pgp+dsa-fips-180-2"
 
 RSA_PUBKEYVAL_SCHEMA = ssl_schema.Object(
   object_name = "RSA_PUBKEYVAL_SCHEMA",
@@ -71,7 +72,7 @@ RSA_PUBKEYVAL_SCHEMA = ssl_schema.Object(
 RSA_PUBKEY_SCHEMA = ssl_schema.Object(
   object_name = "RSA_PUBKEY_SCHEMA",
   type = ssl_schema.String("rsa"),
-  method = ssl_schema.String(GPG_PUBKEY_METHOD_STRING),
+  method = ssl_schema.String(PGP_RSA_PUBKEY_METHOD_STRING),
   hashes = ssl_schema.ListOf(ssl_schema.String(GPG_HASH_ALGORITHM_STRING)),
   keyid = ssl_formats.KEYID_SCHEMA,
   keyval = ssl_schema.Object(
@@ -93,7 +94,7 @@ DSA_PUBKEYVAL_SCHEMA = ssl_schema.Object(
 DSA_PUBKEY_SCHEMA = ssl_schema.Object(
   object_name = "DSA_PUBKEY_SCHEMA",
   type = ssl_schema.String("dsa"),
-  method = ssl_schema.String("pgp+dsa-fips-180-2"),
+  method = ssl_schema.String(PGP_DSA_PUBKEY_METHOD_STRING),
   hashes = ssl_schema.ListOf(ssl_schema.String(GPG_HASH_ALGORITHM_STRING)),
   keyid = ssl_formats.KEYID_SCHEMA,
   keyval = ssl_schema.Object(

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -23,6 +23,8 @@ import in_toto.gpg.common
 from in_toto.gpg.constants import (GPG_EXPORT_PUBKEY_COMMAND, GPG_SIGN_COMMAND,
     SIGNATURE_HANDLERS)
 
+from in_toto.gpg.formats import GPG_HASH_ALGORITHM_STRING
+
 import securesystemslib.formats
 
 
@@ -172,7 +174,7 @@ def gpg_export_pubkey(keyid, homedir=None):
   return {
     "method": keyinfo['method'],
     "type": keyinfo['type'],
-    "hashes": ["pgp+SHA1"],
+    "hashes": [GPG_HASH_ALGORITHM_STRING],
     "keyid": keyinfo['keyid'],
     "keyval" : {
       "private": "",

--- a/tests/demo_files_gpg/demo.layout.template
+++ b/tests/demo_files_gpg/demo.layout.template
@@ -34,7 +34,7 @@
     "keys": {
         "7b3abb26b97b655ab9296bd15b0bd02e1c768c43": {
             "hashes": [
-                "pgp+SHA1"
+                "pgp+SHA2"
             ],
             "keyid": "7b3abb26b97b655ab9296bd15b0bd02e1c768c43",
             "keyval": {
@@ -49,7 +49,7 @@
         },
         "8288ef560ed3795f9df2c0db56193089b285da58": {
             "hashes": [
-                "pgp+SHA1"
+                "pgp+SHA2"
             ],
             "keyid": "8288ef560ed3795f9df2c0db56193089b285da58",
             "keyval": {


### PR DESCRIPTION
The code used to identify the pgp-compliant algorithms as PGP+sha1. In reality,
we are using sha256 as the hash algorithm. Change the default string to
pgp+SHA2 to properly document what are the methods used for hashing.

In addition, the string has been moved to a constant within gpg.formats.py so
it can be easily replaced in the future.