### PR TITLE
Adopt sublayout link namespacing

### DIFF
--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -41,6 +41,10 @@ The command returns a nonzero value if verification fails and zero otherwise.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --link-dir <path>     Path to directory where link metadata files for steps
+                        defined in the root layout should be loaded from. If
+                        not passed links are loaded from the current working
+                        directory.
   --gpg-home <path>     Path to GPG keyring to load GPG key identified by '--
                         gpg' option. If '--gpg-home' is not passed, the
                         default GPG keyring is used.
@@ -69,6 +73,13 @@ examples:
   'key_file.pub'.
 
       in-toto-verify --layout root.layout --layout-keys key_file.pub
+
+
+  Verify supply chain like above but load links corresponding to steps of
+  root.layout from 'link_dir'.
+
+      in-toto-verify --layout root.layout --layout-keys key_file.pub \
+          --link-dir link_dir
 
 
   Verify supply chain in 'root.layout', signed with GPG key '...7E0C8A17',
@@ -124,11 +135,19 @@ examples:
       {prog} --layout root.layout --layout-keys key_file.pub
 
 
+  Verify supply chain like above but load links corresponding to steps of
+  root.layout from 'link_dir'.
+
+      {prog} --layout root.layout --layout-keys key_file.pub \\
+          --link-dir link_dir
+
+
   Verify supply chain in 'root.layout', signed with GPG key '...7E0C8A17',
   whose public part can be found in the GPG keyring at '~/.gnupg'.
 
       {prog} --layout root.layout \\
       --gpg 8465A1E2E0FB2B40ADB2478E18FB3F537E0C8A17 --gpg-home ~/.gnupg
+
 
 """.format(prog=parser.prog)
 
@@ -155,6 +174,12 @@ examples:
       " Passing at least one key using '--layout-keys' and/or '--gpg' is"
       " required. For each passed key the layout must carry a valid"
       " signature."))
+
+  parser.add_argument("--link-dir", dest="link_dir", type=str,
+      metavar="<path>", default=".", help=(
+          "Path to directory where link metadata files for steps defined in"
+          " the root layout should be loaded from. If not passed links are"
+          " loaded from the current working directory."))
 
   parser.add_argument("--gpg-home", dest="gpg_home", type=str,
       metavar="<path>", help=("Path to GPG keyring to load GPG key identified"
@@ -196,7 +221,7 @@ examples:
           in_toto.util.import_gpg_public_keys_from_keyring_as_dict(
           args.gpg, gpg_home=args.gpg_home))
 
-    verifylib.in_toto_verify(layout, layout_key_dict)
+    verifylib.in_toto_verify(layout, layout_key_dict, args.link_dir)
 
   except Exception as e:
     log.error("(in-toto-verify) {0}: {1}".format(type(e).__name__, e))

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -49,6 +49,11 @@ import securesystemslib.schema
 import securesystemslib.interface
 
 
+# Link metadata for sublayouts are expected to be found in a subdirectory
+# with the following name, relative to the verification directory
+SUBLAYOUT_LINK_DIR_FORMAT = "{name}.{keyid:.8}"
+
+
 
 @attr.s(repr=False, init=False)
 class Layout(Signable):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1260,21 +1260,21 @@ def get_summary_link(layout, reduced_chain_link_dict):
     products of the overall software supply chain.
 
   """
-
   # Create empty link object
   summary_link = in_toto.models.link.Link()
 
   # Take first and last link in the order the corresponding
-  # steps appear in the layout
-  first_step_link = reduced_chain_link_dict[layout.steps[0].name]
-  last_step_link = reduced_chain_link_dict[layout.steps[-1].name]
+  # steps appear in the layout, if there are any.
+  if len(layout.steps) > 0:
+    first_step_link = reduced_chain_link_dict[layout.steps[0].name]
+    last_step_link = reduced_chain_link_dict[layout.steps[-1].name]
 
-  summary_link.materials = first_step_link.signed.materials
-  summary_link.name = first_step_link.signed.name
+    summary_link.materials = first_step_link.signed.materials
+    summary_link.name = first_step_link.signed.name
 
-  summary_link.products = last_step_link.signed.products
-  summary_link.byproducts = last_step_link.signed.byproducts
-  summary_link.command = last_step_link.signed.command
+    summary_link.products = last_step_link.signed.products
+    summary_link.byproducts = last_step_link.signed.byproducts
+    summary_link.command = last_step_link.signed.command
 
   return Metablock(signed=summary_link)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 import in_toto
 import logging
 
- # Override in-toto logger default StreamHandler to prevent test log inundation
+# Override in-toto logger default StreamHandler to prevent test log inundation
 in_toto.log.logger.handlers = [logging.NullHandler()]

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -389,7 +389,7 @@ class TestLayoutValidator(unittest.TestCase):
         name=name, pubkeys=[functionary_key["keyid"]]))
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
-      in_toto.verifylib.load_links_for_layout(self.layout)
+      in_toto.verifylib.load_links_for_layout(self.layout, ".")
 
     # Clean up
     os.remove(link_path)

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -140,6 +140,20 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
     self.assert_cli_sys_exit(args, 1)
 
 
+  def test_main_link_dir(self):
+    """Test in-toto-verify CLI tool with explicit link dir. """
+
+    # Use current working directory explicitly to load links
+    args = ["--layout", self.layout_single_signed_path,
+        "--layout-keys", self.alice_path, "--link-dir", "."]
+    self.assert_cli_sys_exit(args, 0)
+
+    # Fail with an explicit link directory, where no links are found
+    args = ["--layout", self.layout_single_signed_path,
+        "--layout-keys", self.alice_path, "--link-dir", "bad-link-dir", "-v"]
+    self.assert_cli_sys_exit(args, 1)
+
+
 
 class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
   """ Tests in-toto-verify like TestInTotoVerifyTool but with

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -1328,7 +1328,7 @@ class TestVerifySublayouts(unittest.TestCase):
     self.super_layout.steps.append(sub_layout_step)
 
     # Load the super layout links (i.e. the sublayout)
-    self.super_layout_links = load_links_for_layout(self.super_layout)
+    self.super_layout_links = load_links_for_layout(self.super_layout, ".")
 
   @classmethod
   def tearDownClass(self):

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -890,6 +890,8 @@ class TestInTotoVerify(unittest.TestCase):
     self.layout_failing_step_rule_path = "failing-step-rule.layout"
     self.layout_failing_inspection_rule_path = "failing-inspection-rule.layout"
     self.layout_failing_inspection_retval = "failing-inspection-retval.layout"
+    self.layout_no_steps_no_inspections = "no_steps_no_inspections.layout"
+
 
     # Import layout signing keys
     alice = import_rsa_key_from_file("alice")
@@ -941,6 +943,10 @@ class TestInTotoVerify(unittest.TestCase):
     layout.sign(alice)
     layout.dump(self.layout_failing_inspection_retval)
 
+    # dump empty layout
+    layout = Metablock(signed=Layout())
+    layout.sign(alice)
+    layout.dump(self.layout_no_steps_no_inspections)
     self.alice = alice
 
   @classmethod
@@ -959,6 +965,13 @@ class TestInTotoVerify(unittest.TestCase):
     """Test pass verification of double-signed layout. """
     layout = Metablock.load(self.layout_double_signed_path)
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path, self.bob_path])
+    in_toto_verify(layout, layout_key_dict)
+
+  def test_verify_passing_empty_layout(self):
+    """Test pass verification of layout without steps or inspections. """
+    layout = Metablock.load(self.layout_no_steps_no_inspections)
+    layout_key_dict = import_rsa_public_keys_from_files_as_dict(
+        [self.alice_path])
     in_toto_verify(layout, layout_key_dict)
 
   def test_verify_failing_wrong_key(self):


### PR DESCRIPTION
**Fixes issue #**:
#130 

**Description of the changes being introduced by the pull request**:
This PR adopts the part in the specification that suggests that links corresponding to the steps of a sublayout are to be loaded from a subdirectory namespaced using the name of the step in the superlayout for which the sublayout serves as link and the sublayout's signing key keyid prefix.

In that course `verifylib.in_toto_verify` and the corresponding cli tool `in-toto-verify` get a new argument that can also be used to tell the verification routine to load links from a different place than the current working directory (default). For sublayouts this path is generated automatically as described above.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


