### PR TITLE
Follow symbolic links when recording artifacts

### DIFF
--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -63,13 +63,15 @@ optional arguments (start subcommand only):
   -m <path> [<path> ...], --materials <path> [<path> ...]
                         Paths to files or directories, whose paths and hashes
                         are stored in the resulting link metadata's material
-                        section when running the 'start' subcommand.
+                        section when running the 'start' subcommand. Symlinks
+                        are followed.
 
 optional arguments (stop subcommand only):
   -p <path> [<path> ...], --products <path> [<path> ...]
                         Paths to files or directories, whose paths and hashes
                         are stored in the resulting link metadata's product
-                        section when running the 'stop' subcommand.
+                        section when running the 'stop' subcommand. Symlinks
+                        are followed.
 
 required named arguments:
   -n <name>, --step-name <name>
@@ -196,13 +198,13 @@ examples:
       nargs='+', metavar="<path>", help=(
       "Paths to files or directories, whose paths and hashes are stored in the"
       " resulting link metadata's material section when running the 'start'"
-      " subcommand."))
+      " subcommand. Symlinks are followed."))
 
   subparser_stop.add_argument("-p", "--products", type=str, required=False,
       nargs='+', metavar="<path>", help=(
       "Paths to files or directories, whose paths and hashes are stored in the"
       " resulting link metadata's product section when running the 'stop'"
-      " subcommand."))
+      " subcommand. Symlinks are followed."))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -39,11 +39,11 @@ optional arguments:
   -m <path> [<path> ...], --materials <path> [<path> ...]
                         Paths to files or directories, whose paths and hashes
                         are stored in the resulting link metadata before the
-                        command is executed.
+                        command is executed. Symlinks are followed.
   -p <path> [<path> ...], --products <path> [<path> ...]
                         Paths to files or directories, whose paths and hashes
                         are stored in the resulting link metadata after the
-                        command is executed.
+                        command is executed. Symlinks are followed.
   --gpg-home <path>     Path to GPG keyring to load GPG key identified by '--
                         gpg' option. If '--gpg-home' is not passed, the
                         default GPG keyring is used.
@@ -142,12 +142,14 @@ examples:
   parser.add_argument("-m", "--materials", type=str, required=False,
       nargs='+', metavar="<path>", help=(
       "Paths to files or directories, whose paths and hashes are stored in the"
-      " resulting link metadata before the command is executed."))
+      " resulting link metadata before the command is executed. Symlinks are"
+      " followed."))
 
   parser.add_argument("-p", "--products", type=str, required=False,
       nargs='+', metavar="<path>", help=(
       "Paths to files or directories, whose paths and hashes are stored in the"
-      " resulting link metadata after the command is executed."))
+      " resulting link metadata after the command is executed. Symlinks are"
+      " followed."))
 
   named_args.add_argument("-k", "--key", type=str, metavar="<path>", help=(
       "Path to a PEM formatted private key file used to sign the resulting"

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -130,10 +130,13 @@ def record_artifacts_as_dict(artifacts, follow_symlink_dirs=False):
             A list of file or directory paths used as materials or products for
             the link command.
 
-            Follow symbolic links if the linked dir exists (default is False).
     follow_symlink_dirs: (optional)
+            Follow symlinked dirs if the linked dir exists (default is False).
+            The recorded path contains the symlink name, not the resolved name.
             NOTE: This parameter toggles following linked directories only,
             linked files are always recorded, independently of this parameter.
+            NOTE: Beware of infinite recursions that can occur if a symlink
+            points to a parent directory or itself.
 
   <Exceptions>
     in_toto.exceptions.SettingsError

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -87,7 +87,7 @@ def _apply_exclude_patterns(names, exclude_patterns):
   return names
 
 
-def record_artifacts_as_dict(artifacts, follow_links=False):
+def record_artifacts_as_dict(artifacts, follow_symlink_dirs=False):
   """
   <Purpose>
     Hashes each file in the passed path list. If the path list contains
@@ -130,8 +130,8 @@ def record_artifacts_as_dict(artifacts, follow_links=False):
             A list of file or directory paths used as materials or products for
             the link command.
 
-    follow_links: (optional)
             Follow symbolic links if the linked dir exists (default is False).
+    follow_symlink_dirs: (optional)
             NOTE: This parameter toggles following linked directories only,
             linked files are always recorded, independently of this parameter.
 
@@ -184,7 +184,8 @@ def record_artifacts_as_dict(artifacts, follow_links=False):
       artifacts_dict[artifact] = _hash_artifact(artifact)
 
     elif os.path.isdir(artifact):
-      for root, dirs, files in os.walk(artifact, followlinks=follow_links):
+      for root, dirs, files in os.walk(artifact,
+          followlinks=follow_symlink_dirs):
         # Create a list of normalized dirpaths
         dirpaths = []
         for dirname in dirs:
@@ -403,7 +404,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
-  materials_dict = record_artifacts_as_dict(material_list, follow_links=True)
+  materials_dict = record_artifacts_as_dict(material_list, follow_symlink_dirs=True)
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
@@ -413,7 +414,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))
-  products_dict = record_artifacts_as_dict(product_list, follow_links=True)
+  products_dict = record_artifacts_as_dict(product_list, follow_symlink_dirs=True)
 
   log.info("Creating link metadata...")
   link = in_toto.models.link.Link(name=name,
@@ -505,7 +506,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
-  materials_dict = record_artifacts_as_dict(material_list, follow_links=True)
+  materials_dict = record_artifacts_as_dict(material_list, follow_symlink_dirs=True)
 
   log.info("Creating preliminary link metadata...")
   link = in_toto.models.link.Link(name=step_name,
@@ -660,7 +661,7 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))
   link_metadata.signed.products = record_artifacts_as_dict(
-      product_list, follow_links=True)
+      product_list, follow_symlink_dirs=True)
 
   link_metadata.signatures = []
   if signing_key:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -87,7 +87,7 @@ def _apply_exclude_patterns(names, exclude_patterns):
   return names
 
 
-def record_artifacts_as_dict(artifacts):
+def record_artifacts_as_dict(artifacts, follow_links=False):
   """
   <Purpose>
     Hashes each file in the passed path list. If the path list contains
@@ -129,6 +129,11 @@ def record_artifacts_as_dict(artifacts):
     artifacts:
             A list of file or directory paths used as materials or products for
             the link command.
+
+    follow_links: (optional)
+            Follow symbolic links if the linked dir exists (default is False).
+            NOTE: This parameter toggles following linked directories only,
+            linked files are always recorded, independently of this parameter.
 
   <Exceptions>
     in_toto.exceptions.SettingsError
@@ -179,8 +184,7 @@ def record_artifacts_as_dict(artifacts):
       artifacts_dict[artifact] = _hash_artifact(artifact)
 
     elif os.path.isdir(artifact):
-      for root, dirs, files in os.walk(artifact):
-
+      for root, dirs, files in os.walk(artifact, followlinks=follow_links):
         # Create a list of normalized dirpaths
         dirpaths = []
         for dirname in dirs:
@@ -208,6 +212,7 @@ def record_artifacts_as_dict(artifacts):
           # result in an error later when trying to read the file
           if os.path.isfile(norm_filepath):
             filepaths.append(norm_filepath)
+
           else:
             log.info("File '{}' appears to be a broken symlink. Skipping..."
                 .format(norm_filepath))

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -403,7 +403,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
-  materials_dict = record_artifacts_as_dict(material_list)
+  materials_dict = record_artifacts_as_dict(material_list, follow_links=True)
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
@@ -413,7 +413,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))
-  products_dict = record_artifacts_as_dict(product_list)
+  products_dict = record_artifacts_as_dict(product_list, follow_links=True)
 
   log.info("Creating link metadata...")
   link = in_toto.models.link.Link(name=name,
@@ -505,7 +505,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
   if material_list:
     log.info("Recording materials '{}'...".format(", ".join(material_list)))
-  materials_dict = record_artifacts_as_dict(material_list)
+  materials_dict = record_artifacts_as_dict(material_list, follow_links=True)
 
   log.info("Creating preliminary link metadata...")
   link = in_toto.models.link.Link(name=step_name,
@@ -659,7 +659,8 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
   # Record products if a product path list was passed
   if product_list:
     log.info("Recording products '{}'...".format(", ".join(product_list)))
-  link_metadata.signed.products = record_artifacts_as_dict(product_list)
+  link_metadata.signed.products = record_artifacts_as_dict(
+      product_list, follow_links=True)
 
   link_metadata.signatures = []
   if signing_key:

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -142,7 +142,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     for setting in ["path/does/not/exist", 12345, True]:
       in_toto.settings.ARTIFACT_BASE_PATH = setting
       with self.assertRaises(in_toto.exceptions.SettingsError):
-        record_artifacts_as_dict(["."] )
+        record_artifacts_as_dict(["."])
 
   def test_base_path_is_child_dir(self):
     """Test path of recorded artifacts and cd back with child as base."""

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -112,19 +112,17 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     self.test_dir = os.path.realpath(tempfile.mkdtemp())
     os.chdir(self.test_dir)
 
-    open("foo", "w").write("foo")
-    open("bar", "w").write("bar")
-
+    # Create files on 3 levels
     os.mkdir("subdir")
     os.mkdir("subdir/subsubdir")
-    open("subdir/foosub1", "w").write("foosub")
-    open("subdir/foosub2", "w").write("foosub")
-    open("subdir/subsubdir/foosubsub", "w").write("foosubsub")
 
-    # Add dead symlinks on each level, they should be excluded
-    os.symlink("this/file/does/not/exist", "deadlink")
-    os.symlink("this/file/does/not/exist", "subdir/deadlink")
-    os.symlink("this/file/does/not/exist", "subdir/subsubdir/deadlink")
+    self.full_file_path_list = ["foo", "bar", "subdir/foosub1",
+        "subdir/foosub2", "subdir/subsubdir/foosubsub"]
+
+    for path in self.full_file_path_list:
+      with open(path, "w") as fp:
+        fp.write(path)
+
 
   @classmethod
   def tearDownClass(self):
@@ -144,7 +142,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     for setting in ["path/does/not/exist", 12345, True]:
       in_toto.settings.ARTIFACT_BASE_PATH = setting
       with self.assertRaises(in_toto.exceptions.SettingsError):
-        record_artifacts_as_dict(["."])
+        record_artifacts_as_dict(["."] )
 
   def test_base_path_is_child_dir(self):
     """Test path of recorded artifacts and cd back with child as base."""
@@ -181,8 +179,98 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
-      sorted(["foo", "bar", "subdir/foosub1", "subdir/foosub2",
-          "subdir/subsubdir/foosubsub"]))
+      sorted(self.full_file_path_list))
+
+
+  def test_record_symlinked_files(self):
+    """Symlinked files are always recorded. """
+    # Symlinked **files** are always recorded ...
+    link_pairs = [
+      ("foo", "foo_link"),
+      ("subdir/foosub1", "subdir/foosub2_link"),
+      ("subdir/subsubdir/foosubsub", "subdir/subsubdir/foosubsub_link")
+    ]
+
+    # Create links
+    for pair in link_pairs:
+      # We only use the basename of the file (source) as it is on the same
+      # level as the link (target)
+      os.symlink(os.path.basename(pair[0]), pair[1])
+
+    # Record files and linked files
+    # follow_links does not make a difference as it only concerns linked dirs
+    for follow_links in [True, False]:
+      artifacts_dict = record_artifacts_as_dict(["."], follow_links)
+
+      # Test that everything was recorded ...
+      self.assertListEqual(sorted(list(artifacts_dict.keys())),
+          sorted(self.full_file_path_list + [pair[1] for pair in link_pairs]))
+
+      # ... and the hashes of each link/file pair match
+      for pair in link_pairs:
+        self.assertDictEqual(artifacts_dict[pair[0]], artifacts_dict[pair[1]])
+
+    for pair in link_pairs:
+      os.unlink(pair[1])
+
+
+  def test_record_without_dead_symlinks(self):
+    """Dead symlinks are never recorded. """
+
+    # Dead symlinks are never recorded ...
+    links = [
+      "foo_link",
+      "subdir/foosub2_link",
+      "subdir/subsubdir/foosubsub_link"
+    ]
+
+    # Create dead links
+    for link in links:
+      os.symlink("does/not/exist", link)
+
+    # Record files without dead links
+    # follow_links does not make a difference as it only concerns linked dirs
+    for follow_links in [True, False]:
+      artifacts_dict = record_artifacts_as_dict(["."], follow_links)
+
+      # Test only the files were recorded ...
+      self.assertListEqual(sorted(list(artifacts_dict.keys())),
+          sorted(self.full_file_path_list))
+
+    for link in links:
+      os.unlink(link)
+
+
+  def test_record_follow_symlinked_directories(self):
+    """Record files in symlinked dirs if follow_links is True. """
+
+    # Link to subdir
+    os.symlink("subdir", "subdir_link")
+
+    link_pairs = [
+      ("subdir/foosub1", "subdir_link/foosub1"),
+      ("subdir/foosub2", "subdir_link/foosub2"),
+      ("subdir/subsubdir/foosubsub", "subdir_link/subsubdir/foosubsub"),
+    ]
+
+    # Record with follow_links TRUE
+    artifacts_dict = record_artifacts_as_dict(["."], follow_links=True)
+    # Test that all files were recorded including files in linked subdir ...
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
+        sorted(self.full_file_path_list + [pair[1] for pair in link_pairs]))
+
+    # ... and the hashes of each link/file pair match
+    for pair in link_pairs:
+      self.assertDictEqual(artifacts_dict[pair[0]], artifacts_dict[pair[1]])
+
+
+    # Record with follow_links FALSE (default)
+    artifacts_dict = record_artifacts_as_dict(["."])
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
+        sorted(self.full_file_path_list))
+
+    os.unlink("subdir_link")
+
 
   def test_record_files_and_subdirs(self):
     """Explicitly record files and subdirs. """

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -198,9 +198,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       os.symlink(os.path.basename(pair[0]), pair[1])
 
     # Record files and linked files
-    # follow_links does not make a difference as it only concerns linked dirs
-    for follow_links in [True, False]:
-      artifacts_dict = record_artifacts_as_dict(["."], follow_links)
+    # follow_symlink_dirs does not make a difference as it only concerns linked dirs
+    for follow_symlink_dirs in [True, False]:
+      artifacts_dict = record_artifacts_as_dict(["."], follow_symlink_dirs)
 
       # Test that everything was recorded ...
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
@@ -229,9 +229,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       os.symlink("does/not/exist", link)
 
     # Record files without dead links
-    # follow_links does not make a difference as it only concerns linked dirs
-    for follow_links in [True, False]:
-      artifacts_dict = record_artifacts_as_dict(["."], follow_links)
+    # follow_symlink_dirs does not make a difference as it only concerns linked dirs
+    for follow_symlink_dirs in [True, False]:
+      artifacts_dict = record_artifacts_as_dict(["."], follow_symlink_dirs)
 
       # Test only the files were recorded ...
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
@@ -242,7 +242,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_record_follow_symlinked_directories(self):
-    """Record files in symlinked dirs if follow_links is True. """
+    """Record files in symlinked dirs if follow_symlink_dirs is True. """
 
     # Link to subdir
     os.symlink("subdir", "subdir_link")
@@ -253,8 +253,8 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       ("subdir/subsubdir/foosubsub", "subdir_link/subsubdir/foosubsub"),
     ]
 
-    # Record with follow_links TRUE
-    artifacts_dict = record_artifacts_as_dict(["."], follow_links=True)
+    # Record with follow_symlink_dirs TRUE
+    artifacts_dict = record_artifacts_as_dict(["."], follow_symlink_dirs=True)
     # Test that all files were recorded including files in linked subdir ...
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
         sorted(self.full_file_path_list + [pair[1] for pair in link_pairs]))
@@ -264,7 +264,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       self.assertDictEqual(artifacts_dict[pair[0]], artifacts_dict[pair[1]])
 
 
-    # Record with follow_links FALSE (default)
+    # Record with follow_symlink_dirs FALSE (default)
     artifacts_dict = record_artifacts_as_dict(["."])
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
         sorted(self.full_file_path_list))


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
This PR adds an optional parameter to the artifact record function to toggle following symbolic links to directories.

Furthermore the PR modifies the calling `runlib` functions, used with `in-toto-run` and `in-toto-record`,  to call with `follow_links=True` .

*UPDATE:*
This change also affects in-toto's final product verification, where, when running inspections, we record artifacts (now following symlinks) in the directory, where the verification is executed.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


