### PR TITLE
Add exclude pattern cli arguments to in-toto-run/in-toto-record

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -1,0 +1,39 @@
+"""
+<Program Name>
+  common_args.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Mar 09, 2018
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides a collection of constants that can be used as `*args` or `**kwargs`
+  to argparse.ArgumentParser.add_argument() for cli tools with common
+  command line arguments.
+
+  Example Usage:
+
+  ```
+  form in_toto.common_args import EXCLUDE_ARGS, EXCLUDE_KWARGS
+  parser = argparse.ArgumentParser()
+  parser.add_argument(*EXCLUDE_KWARGS, **EXCLUDE_KWARGS)
+  ```
+
+"""
+
+EXCLUDE_ARGS = ["--exclude"]
+EXCLUDE_KWARGS = {
+  "dest": "exclude_patterns",
+  "required": False,
+  "metavar": "<pattern>",
+  "nargs": "+",
+  "help": ("Do not record 'materials/products' that match one of <pattern>."
+          " Passed exclude patterns override previously set patterns, using"
+          " e.g.: environment variables or RCfiles. See"
+          " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info.")
+  }

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -57,12 +57,11 @@ optional arguments:
                         gpg' option. If '--gpg-home' is not passed, the
                         default GPG keyring is used.
   --exclude <pattern> [<pattern> ...]
-                        Do not record 'materials/products' matched by the
-                        passed exclude patterns. Passed exclude patterns
-                        override previously set patterns, using e.g.:
-                        environment variables or RCfiles. See
-                        ARTIFACT_EXCLUDE_PATTERNS documentation for additional
-                        info.
+                        Do not record 'materials/products' that match one of
+                        <pattern>. Passed exclude patterns override previously
+                        set patterns, using e.g.: environment variables or
+                        RCfiles. See ARTIFACT_EXCLUDE_PATTERNS documentation
+                        for additional info.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -108,6 +107,8 @@ import logging
 import in_toto.util
 import in_toto.user_settings
 import in_toto.runlib
+
+from in_toto.common_args import EXCLUDE_ARGS, EXCLUDE_KWARGS
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -179,13 +180,7 @@ examples:
       "Path to GPG keyring to load GPG key identified by '--gpg' option.  If"
       " '--gpg-home' is not passed, the default GPG keyring is used."))
 
-  parent_parser.add_argument("--exclude", dest="exclude_patterns",
-      required=False, metavar="<pattern>", nargs="+", help=(
-      "Do not record 'materials/products' matched by the passed exclude"
-      " patterns. Passed exclude patterns override previously set patterns,"
-      " using e.g.: environment variables or RCfiles. See"
-      " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info."
-      ))
+  parent_parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
 
   verbosity_args = parent_parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -56,6 +56,13 @@ optional arguments:
   --gpg-home <path>     Path to GPG keyring to load GPG key identified by '--
                         gpg' option. If '--gpg-home' is not passed, the
                         default GPG keyring is used.
+  --exclude <pattern> [<pattern> ...]
+                        Do not record 'materials/products' matched by the
+                        passed exclude patterns. Passed exclude patterns
+                        override previously set patterns, using e.g.:
+                        environment variables or RCfiles. See
+                        ARTIFACT_EXCLUDE_PATTERNS documentation for additional
+                        info.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -172,6 +179,14 @@ examples:
       "Path to GPG keyring to load GPG key identified by '--gpg' option.  If"
       " '--gpg-home' is not passed, the default GPG keyring is used."))
 
+  parent_parser.add_argument("--exclude", dest="exclude_patterns",
+      required=False, metavar="<pattern>", nargs="+", help=(
+      "Do not record 'materials/products' matched by the passed exclude"
+      " patterns. Passed exclude patterns override previously set patterns,"
+      " using e.g.: environment variables or RCfiles. See"
+      " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info."
+      ))
+
   verbosity_args = parent_parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", action="store_true")
@@ -232,13 +247,15 @@ examples:
     if args.command == "start":
       in_toto.runlib.in_toto_record_start(args.step_name, args.materials,
           signing_key=key, gpg_keyid=gpg_keyid,
-          gpg_use_default=gpg_use_default, gpg_home=args.gpg_home)
+          gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
+          exclude_patterns=args.exclude_patterns)
 
     # Mutually exclusiveness is guaranteed by argparser
     else: # args.command == "stop":
       in_toto.runlib.in_toto_record_stop(args.step_name, args.products,
           signing_key=key, gpg_keyid=gpg_keyid,
-          gpg_use_default=gpg_use_default, gpg_home=args.gpg_home)
+          gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
+          exclude_patterns=args.exclude_patterns)
 
   except Exception as e:
     log.error("(in-toto-record {0}) {1}: {2}"

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -53,11 +53,11 @@ optional arguments:
   -x, --no-command      Generate link metadata without executing a command,
                         e.g. for a 'signed off by' step.
   --exclude <pattern> [<pattern> ...]
-                        Do not record 'materials' and 'products' matched by
-                        the passed exclude patterns. Passed exclude patterns
-                        override previously set patterns, using e.g.:
-                        environment variables or RCfiles. See
-                        ARTIFACT_EXCLUDE_PATTERNS documentation for additional
+                        Do not record 'materials/products' that match one of
+                        <pattern>. Passed exclude patterns override previously
+                        set patterns, using e.g.: environment variables or
+                        RCfiles. See ARTIFACT_EXCLUDE_PATTERNS documentation
+                        for additional info.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -98,6 +98,7 @@ import logging
 import in_toto.user_settings
 from in_toto import (util, runlib)
 
+from in_toto.common_args import EXCLUDE_ARGS, EXCLUDE_KWARGS
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -183,13 +184,7 @@ examples:
     "Generate link metadata without executing a command, e.g. for a 'signed"
     " off by' step."))
 
-  parser.add_argument("--exclude", dest="exclude_patterns", required=False,
-      metavar="<pattern>", nargs="+", help=(
-      "Do not record 'materials' and 'products' matched by the passed"
-      " exclude patterns. Passed exclude patterns override previously"
-      " set patterns, using e.g.: environment variables or RCfiles. See"
-      " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info."
-      ))
+  parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
 
   verbosity_args = parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -52,6 +52,12 @@ optional arguments:
                         link metadata.
   -x, --no-command      Generate link metadata without executing a command,
                         e.g. for a 'signed off by' step.
+  --exclude <pattern> [<pattern> ...]
+                        Do not record 'materials' and 'products' matched by
+                        the passed exclude patterns. Passed exclude patterns
+                        override previously set patterns, using e.g.:
+                        environment variables or RCfiles. See
+                        ARTIFACT_EXCLUDE_PATTERNS documentation for additional
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -177,6 +183,14 @@ examples:
     "Generate link metadata without executing a command, e.g. for a 'signed"
     " off by' step."))
 
+  parser.add_argument("--exclude", dest="exclude_patterns", required=False,
+      metavar="<pattern>", nargs="+", help=(
+      "Do not record 'materials' and 'products' matched by the passed"
+      " exclude patterns. Passed exclude patterns override previously"
+      " set patterns, using e.g.: environment variables or RCfiles. See"
+      " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info."
+      ))
+
   verbosity_args = parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",
       help="Verbose execution.", action="store_true")
@@ -231,7 +245,7 @@ examples:
 
     runlib.in_toto_run(args.step_name, args.materials, args.products,
         args.link_cmd, args.record_streams, key, gpg_keyid, gpg_use_default,
-        args.gpg_home)
+        args.gpg_home, args.exclude_patterns)
 
   except Exception as e:
     log.error("(in-toto-run) {0}: {1}".format(type(e).__name__, e))

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -28,6 +28,7 @@ from mock import patch
 
 import in_toto.util
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT
+from in_toto.models.metadata import Metablock
 from in_toto.in_toto_record import main as in_toto_record_main
 
 import tests.common
@@ -89,6 +90,13 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
         self.test_artifact1], 0)
     self.assert_cli_sys_exit(["stop"] + args + ["--products",
         self.test_artifact1], 0)
+
+    # Start/stop with excluding one artifact
+    args = ["--step-name", "test2.5", "--key", self.key_path]
+    self.assert_cli_sys_exit(["start"] + args + ["--materials",
+        self.test_artifact1, "--exclude", "test*"], 0)
+    self.assert_cli_sys_exit(["stop"] + args + ["--products",
+        self.test_artifact1, "--exclude", "test*"], 0)
 
     # Start/stop with recording multiple artifacts
     args = ["--step-name", "test3", "--key", self.key_path]


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
in-toto provides an [`ARTIFACT_EXCLUDE_PATTERNS`](https://github.com/in-toto/in-toto/blob/0.2.1/README.md#settings) setting to exclude artifacts when recording link metadata.

This PR adds an `--exclude` argument to `in-toto-run` and `in-toto-record` to specify the patterns on the cli tool. Patterns passed via argument override patterns specified via setting (or envvar or RCfile).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


