### PR TITLE
Add base path cli argument to in-toto-run/in-toto-record

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -37,3 +37,12 @@ EXCLUDE_KWARGS = {
           " e.g.: environment variables or RCfiles. See"
           " ARTIFACT_EXCLUDE_PATTERNS documentation for additional info.")
   }
+
+BASE_PATH_ARGS = ["--base-path"]
+BASE_PATH_KWARGS = {
+  "dest": "base_path",
+  "required": False,
+  "metavar": "<path>",
+  "help": ("Record 'materials/products' relative to <path>. If not set,"
+          " current working directory is used as base path.")
+  }

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -24,7 +24,3 @@ class BadReturnValueError(Error):
 class LinkNotFoundError(Error):
   """Indicates that a link file was not found. """
   pass
-
-class SettingsError(Error):
-  """Indicates an invalid setting. """
-  pass

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -62,6 +62,8 @@ optional arguments:
                         set patterns, using e.g.: environment variables or
                         RCfiles. See ARTIFACT_EXCLUDE_PATTERNS documentation
                         for additional info.
+  --base-path <path>    Record 'materials/products' relative to <path>. If not
+                        set, current working directory is used as base path.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -108,7 +110,8 @@ import in_toto.util
 import in_toto.user_settings
 import in_toto.runlib
 
-from in_toto.common_args import EXCLUDE_ARGS, EXCLUDE_KWARGS
+from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
+    BASE_PATH_ARGS, BASE_PATH_KWARGS)
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -181,6 +184,8 @@ examples:
       " '--gpg-home' is not passed, the default GPG keyring is used."))
 
   parent_parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
+  parent_parser.add_argument(*BASE_PATH_ARGS, **BASE_PATH_KWARGS)
+
 
   verbosity_args = parent_parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",
@@ -243,14 +248,14 @@ examples:
       in_toto.runlib.in_toto_record_start(args.step_name, args.materials,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path)
 
     # Mutually exclusiveness is guaranteed by argparser
     else: # args.command == "stop":
       in_toto.runlib.in_toto_record_stop(args.step_name, args.products,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path)
 
   except Exception as e:
     log.error("(in-toto-record {0}) {1}: {2}"

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -58,6 +58,8 @@ optional arguments:
                         set patterns, using e.g.: environment variables or
                         RCfiles. See ARTIFACT_EXCLUDE_PATTERNS documentation
                         for additional info.
+  --base-path <path>    Record 'materials/products' relative to <path>. If not
+                        set, current working directory is used as base path.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 
@@ -98,7 +100,8 @@ import logging
 import in_toto.user_settings
 from in_toto import (util, runlib)
 
-from in_toto.common_args import EXCLUDE_ARGS, EXCLUDE_KWARGS
+from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
+    BASE_PATH_ARGS, BASE_PATH_KWARGS)
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -185,6 +188,7 @@ examples:
     " off by' step."))
 
   parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
+  parser.add_argument(*BASE_PATH_ARGS, **BASE_PATH_KWARGS)
 
   verbosity_args = parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",
@@ -240,7 +244,7 @@ examples:
 
     runlib.in_toto_run(args.step_name, args.materials, args.products,
         args.link_cmd, args.record_streams, key, gpg_keyid, gpg_use_default,
-        args.gpg_home, args.exclude_patterns)
+        args.gpg_home, args.exclude_patterns, args.base_path)
 
   except Exception as e:
     log.error("(in-toto-run) {0}: {1}".format(type(e).__name__, e))

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -98,6 +98,12 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
     self.assert_cli_sys_exit(["stop"] + args + ["--products",
         self.test_artifact1, "--exclude", "test*"], 0)
 
+    # Start/stop with base-path
+    args = ["--step-name", "test2.6", "--key", self.key_path, "--base-path",
+        self.test_dir]
+    self.assert_cli_sys_exit(["start"] + args, 0)
+    self.assert_cli_sys_exit(["stop"] + args, 0)
+
     # Start/stop with recording multiple artifacts
     args = ["--step-name", "test3", "--key", self.key_path]
     self.assert_cli_sys_exit(["start"] + args + ["--materials",
@@ -115,6 +121,7 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
     args = ["--step-name", "test6", "--gpg", "--gpg-home", self.gnupg_home]
     self.assert_cli_sys_exit(["start"] + args, 0)
     self.assert_cli_sys_exit(["stop"] + args, 0)
+
 
 
   def test_glob_no_unfinished_files(self):

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -118,6 +118,19 @@ class TestInTotoRunTool(tests.common.CliTestCase):
     self.assertFalse(link_metadata.signed.materials)
     self.assertFalse(link_metadata.signed.products)
 
+    # Test with base path
+    args3 = named_args + ["--base-path", self.test_dir] + positional_args
+    self.assert_cli_sys_exit(args3, 0)
+    link_metadata = Metablock.load(self.test_link)
+    self.assertListEqual(list(link_metadata.signed.materials.keys()),
+        [self.test_artifact])
+    self.assertListEqual(list(link_metadata.signed.products.keys()),
+        [self.test_artifact])
+
+    # Test with bogus base path
+    args4 = named_args + ["--base-path", "bogus/path"] + positional_args
+    self.assert_cli_sys_exit(args4, 1)
+
 
   def test_main_with_specified_gpg_key(self):
     """Test CLI command with specified gpg key. """


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
in-toto provides an `ARTIFACT_BASE_PATH` setting to be used as base path for any materials and products, specified via `--materials` and `--products` arguments, when recording link metadata.

This PR adds a `--base-path`, argument to `in-toto-run` and `in-toto-record` to specify the base path on the cli tool. A base path passed via argument overrides a base path specified via setting (or envvar or RCfile).

*Note:*
The base path setting was originally added to record relative artifact paths, not relative to the current working directory, e.g. to record an artifact at `/path/to/bar` as `bar`, which before was only possible when the directory, in which `in-toto-run`/`in-toto-record` was executed, was `/path/to/`.

An alternative approach that might be more intuitive is proposed in #194.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


