### PR TITLE
FIX: requirements: Drop pinned version of securesystemslib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-securesystemslib==0.10.10
+securesystemslib>=0.10.10
 cryptography
 attrs
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
   # securesystemslib 0.10.9 requires cryptography>=2.1.3, and thereby dictates
   # the minimum version of cryptography for in-toto. The maximum version
   # is dictated by what is available.
-  install_requires=["six", "cryptography", "securesystemslib==0.10.10", "attrs",
+  install_requires=["six", "cryptography", "securesystemslib>=0.10.10", "attrs",
                     "python-dateutil", "iso8601"],
   test_suite="tests.runtests",
   entry_points={


### PR DESCRIPTION
Remove the `==` on securesystemslib. As we no longer require a pinned version, we can change it to `>=`. The `>=` is however required to ensure that no older, api-breaking, version are installed for whatever reason.