### PR TITLE
Fix firewall rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## in-toto v0.2.2
 
 * Add support for gpg signing subkeys.
-* Drop strict requirement on securesystemslib 0.9.
+* Drop strict requirement on securesystemslib 0.10.
 * Command line tool changes:
     - Add a --base-path parameter to in-toto record and in-toto run
     - in-toto-record now follows symbolic links
@@ -11,6 +11,7 @@
 * Adds support for sublayout namespacing (for in-toto spec 0.9 compliance)
 * Path prefix is normalized during in-toto verification:
     - Paths such as foo//bar match with foo/bar.
+* Dropped obsolete SettingsError
 
 
 ## in-toto v0.2.1

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -239,15 +239,15 @@ class TestVerifyCreateRule(unittest.TestCase):
     materials_queue = ["foo"]
     products_queue = ["foo"]
     rule = ["CREATE", "foo"]
-    with self.assertRaises(RuleVerificationError):
-      verify_create_rule(rule, materials_queue, products_queue)
+    result = verify_create_rule(rule, materials_queue, products_queue)
+    self.assertEqual(['foo'], result)
 
     # Not all (*) products newly created
     materials_queue = ["foo"]
     products_queue = ["foo", "bar"]
     rule = ["CREATE", "*"]
-    with self.assertRaises(RuleVerificationError):
-      verify_create_rule(rule, materials_queue, products_queue)
+    result = verify_create_rule(rule, materials_queue, products_queue)
+    self.assertEqual(['foo'], result)
 
   def test_pass(self):
     """"Different scenarios for passing create rule verification. """
@@ -319,7 +319,7 @@ class TestVerifyModifyRule(unittest.TestCase):
     rule = ["MODIFY", "foo"]
     m_queue, p_queue = verify_modify_rule(rule, materials_queue, products_queue,
         self.materials, self.products)
-    self.assertListEqual(m_queue, [])
+    self.assertListEqual(m_queue, ["foo"])
     self.assertListEqual(p_queue, ["bar"])
 
     # Modify all files from queue
@@ -328,7 +328,8 @@ class TestVerifyModifyRule(unittest.TestCase):
     rule = ["MODIFY", "*"]
     m_queue, p_queue = verify_modify_rule(rule, materials_queue, products_queue,
         self.materials, self.products)
-    self.assertListEqual(m_queue, p_queue, [])
+    self.assertListEqual(m_queue, ["foo"])
+    self.assertListEqual(p_queue, [])
 
     # Nothing filtered by pattern, still passes (seems strange)
     rule = ["MODIFY", "baz"]
@@ -351,29 +352,29 @@ class TestVerifyModifyRule(unittest.TestCase):
 
     # Single file not modified
     rule = ["MODIFY", "bar"]
-    with self.assertRaises(RuleVerificationError):
-      verify_modify_rule(rule, materials_queue, products_queue,
-          self.materials, self.products)
+    result = verify_modify_rule(rule, materials_queue, products_queue,
+        self.materials, self.products)
+    self.assertEquals((materials_queue, products_queue), result)
 
     # Some files not modified
     rule = ["MODIFY", "*"]
-    with self.assertRaises(RuleVerificationError):
-      verify_modify_rule(rule, materials_queue, products_queue,
+    result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
+    self.assertEquals((materials_queue, ['bar']), result)
 
     # Pattern filters bar as material but not as product
     materials_queue = ["foo", "bar"]
     products_queue = ["foo"]
-    with self.assertRaises(RuleVerificationError):
-      verify_modify_rule(rule, materials_queue, products_queue,
+    result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
+    self.assertEquals((materials_queue, []), result)
 
     # Pattern filters bar as product but not as material
     materials_queue = ["foo"]
     products_queue = ["foo", "bar"]
-    with self.assertRaises(RuleVerificationError):
-      verify_modify_rule(rule, materials_queue, products_queue,
+    result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
+    self.assertEquals((materials_queue, ['bar']), result)
 
 
 class TestVerifyAllowRule(unittest.TestCase):
@@ -668,8 +669,8 @@ class TestVerifyMatchRule(unittest.TestCase):
       "bar": {"sha256": self.sha256_bar},
     }
     queue = list(artifacts.keys())
-    with self.assertRaises(RuleVerificationError):
-      verify_match_rule(rule, queue, artifacts, self.links)
+    result = verify_match_rule(rule, queue, artifacts, self.links)
+    self.assertEquals(['bar'], result);
 
   def test_fail_path_not_in_destination_products(self):
     """["MATCH", "foo", "WITH", "PRODUCTS", "FROM", "link-1"],
@@ -680,8 +681,8 @@ class TestVerifyMatchRule(unittest.TestCase):
       "foo": {"sha256": self.sha256_foo},
     }
     queue = list(artifacts.keys())
-    with self.assertRaises(RuleVerificationError):
-      verify_match_rule(rule, queue, artifacts, self.links)
+    result = verify_match_rule(rule, queue, artifacts, self.links)
+    self.assertEquals(['foo'], result);
 
   def test_fail_hash_not_eual(self):
     """"["MATCH", "bar", "WITH", "PRODUCTS", "FROM", "link-1"],
@@ -692,8 +693,8 @@ class TestVerifyMatchRule(unittest.TestCase):
       "bar": {"sha256": "aaaaaaaaaa"},
     }
     queue = list(artifacts.keys())
-    with self.assertRaises(RuleVerificationError):
-      verify_match_rule(rule, queue, artifacts, self.links)
+    result = verify_match_rule(rule, queue, artifacts, self.links)
+    self.assertEquals(['bar'], result);
 
 
 class TestVerifyItemRules(unittest.TestCase):
@@ -937,6 +938,8 @@ class TestInTotoVerify(unittest.TestCase):
     # dump layout with failing step rule
     layout = copy.deepcopy(layout_template)
     layout.signed.steps[0].expected_products.insert(0,
+        ["DISALLOW", "*"])
+    layout.signed.steps[0].expected_products.insert(0,
         ["MODIFY", "*"])
     layout.sign(alice)
     layout.dump(self.layout_failing_step_rule_path)
@@ -945,6 +948,8 @@ class TestInTotoVerify(unittest.TestCase):
     layout = copy.deepcopy(layout_template)
     layout.signed.inspect[0].expected_materials.insert(0,
         ["MODIFY", "*"])
+    layout.signed.inspect[0].expected_materials.append(
+        ["DISALLOW", "*"])
     layout.sign(alice)
     layout.dump(self.layout_failing_inspection_rule_path)
 
@@ -1025,6 +1030,7 @@ class TestInTotoVerify(unittest.TestCase):
   def test_verify_failing_step_rules(self):
     """Test fail verification with failing step artifact rule. """
     layout = Metablock.load(self.layout_failing_step_rule_path)
+    #import pdb; pdb.set_trace()
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
     with self.assertRaises(RuleVerificationError):
       in_toto_verify(layout, layout_key_dict)
@@ -1653,6 +1659,7 @@ class TestGetSummaryLink(unittest.TestCase):
     for file in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, file), self.test_dir)
 
+    #import pdb; pdb.set_trace()
     self.demo_layout = Metablock.load("demo.layout.template")
     self.code_link = Metablock.load("package.2f89b927.link")
     self.package_link = Metablock.load("write-code.776a00e2.link")

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -347,34 +347,38 @@ class TestVerifyModifyRule(unittest.TestCase):
 
   def test_fail(self):
     """Different scenarios for failing create rule verification. """
-    materials_queue = ["foo", "bar"]
-    products_queue = ["foo", "bar"]
+    materials_queue = ["bar", "foo"]
+    products_queue = ["bar", "foo"]
 
     # Single file not modified
     rule = ["MODIFY", "bar"]
     result = verify_modify_rule(rule, materials_queue, products_queue,
         self.materials, self.products)
-    self.assertEquals((materials_queue, products_queue), result)
+    self.assertEquals((materials_queue, products_queue),
+        (sorted(result[0]), sorted(result[1])))
 
     # Some files not modified
     rule = ["MODIFY", "*"]
     result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
-    self.assertEquals((materials_queue, ['bar']), result)
+    self.assertEquals((materials_queue, ['bar']),
+        (sorted(result[0]), sorted(result[1])))
 
     # Pattern filters bar as material but not as product
-    materials_queue = ["foo", "bar"]
+    materials_queue = ["bar", "foo"]
     products_queue = ["foo"]
     result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
-    self.assertEquals((materials_queue, []), result)
+    self.assertEquals((materials_queue, []),
+        (sorted(result[0]), sorted(result[1])))
 
     # Pattern filters bar as product but not as material
     materials_queue = ["foo"]
-    products_queue = ["foo", "bar"]
+    products_queue = ["bar", "foo"]
     result = verify_modify_rule(rule, materials_queue, products_queue,
           self.materials, self.products)
-    self.assertEquals((materials_queue, ['bar']), result)
+    self.assertEquals((materials_queue, ['bar']),
+        (sorted(result[0]), sorted(result[1])))
 
 
 class TestVerifyAllowRule(unittest.TestCase):
@@ -1030,7 +1034,6 @@ class TestInTotoVerify(unittest.TestCase):
   def test_verify_failing_step_rules(self):
     """Test fail verification with failing step artifact rule. """
     layout = Metablock.load(self.layout_failing_step_rule_path)
-    #import pdb; pdb.set_trace()
     layout_key_dict = import_rsa_public_keys_from_files_as_dict([self.alice_path])
     with self.assertRaises(RuleVerificationError):
       in_toto_verify(layout, layout_key_dict)
@@ -1659,7 +1662,6 @@ class TestGetSummaryLink(unittest.TestCase):
     for file in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, file), self.test_dir)
 
-    #import pdb; pdb.set_trace()
     self.demo_layout = Metablock.load("demo.layout.template")
     self.code_link = Metablock.load("package.2f89b927.link")
     self.package_link = Metablock.load("write-code.776a00e2.link")

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -688,7 +688,7 @@ class TestVerifyMatchRule(unittest.TestCase):
     result = verify_match_rule(rule, queue, artifacts, self.links)
     self.assertEquals(['foo'], result);
 
-  def test_fail_hash_not_eual(self):
+  def test_fail_hash_not_equal(self):
     """"["MATCH", "bar", "WITH", "PRODUCTS", "FROM", "link-1"],
     source and destination bar have different hashes, fails. """
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: 

None, this issue was brought up from conversations with potential integrators

**Description of the changes being introduced by the pull request**:

The current behavior of the artifact rules throw exceptions when an element in the *filtered* queue doesn't match the target. For example, if a file `foo` is being checked for a `MODIFY` rule then a `VerificationError` will be raised if `foo` is indeed not modified. This is not how firewalls behave.

Instead, `foo` should just remain in the queue and expected to be matched by other rules later down the line. The only rule that should throw an error is a `DISALLOW` rule when artifacts are matched.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

This is still somewhat of a WIP branch, as I'd like to have some feedback from @vladimir-v-diaz and @lukpueh (if possible)

