### PR TITLE
ENH:WIP: Add substitution layer

### DIFF
--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -54,4 +54,6 @@ ANY_STRING_SCHEMA = ssl_schema.AnyString()
 LIST_OF_ANY_STRING_SCHEMA = ssl_schema.ListOf(ANY_STRING_SCHEMA)
 
 PARAMETER_DICTIONARY_KEY = ssl_schema.RegularExpression(r'[a-zA-Z0-9_-]+')
-PARAMETER_DICTIONARY_VALUE = ssl_schema.AnyString()
+PARAMETER_DICTIONARY_SCHEMA = ssl_schema.DictOf(
+    key_schema = PARAMETER_DICTIONARY_KEY,
+    value_schema = ssl_schema.AnyString())

--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -4,6 +4,7 @@
 
 <Author>
   Lukas Puehringer <lukas.puehringer@nyu.edu>
+  Santiago Torres-Arias <santiago@nyu.edu>
 
 <Started>
   November 28, 2017.
@@ -51,3 +52,6 @@ ANY_SIGNATURE_SCHEMA = ssl_schema.OneOf([ssl_formats.SIGNATURE_SCHEMA,
 
 ANY_STRING_SCHEMA = ssl_schema.AnyString()
 LIST_OF_ANY_STRING_SCHEMA = ssl_schema.ListOf(ANY_STRING_SCHEMA)
+
+PARAMETER_DICTIONARY_KEY = ssl_schema.RegularExpression(r'[a-zA-Z0-9_-]+')
+PARAMETER_DICTIONARY_VALUE = ssl_schema.AnyString()

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -312,7 +312,8 @@ def substitute_parameters(layout, parameter_dictionary):
     step.expected_products = new_product_rules
 
   for inspection in layout.inspect:
-    inspection.run = inspection.run.format(**parameter_dictionary)
+    new_run = [x.format(**parameter_dictionary) for x in inspection.run]
+    inspection.run = new_run
 
 
 def verify_layout_signatures(layout_metablock, keys_dict):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -312,8 +312,20 @@ def substitute_parameters(layout, parameter_dictionary):
     step.expected_products = new_product_rules
 
   for inspection in layout.inspect:
+
+    inspection.expected_materials = [
+        [ s.format(**parameter_dictionary) for s in m ] \
+        for m in inspection.expected_materials
+    ]
+
+    inspection.expected_products = [
+        [ s.format(**parameter_dictionary) for s in p ] \
+        for p in inspection.expected_products
+    ]
+
     new_run = [x.format(**parameter_dictionary) for x in inspection.run]
     inspection.run = new_run
+
 
 
 def verify_layout_signatures(layout_metablock, keys_dict):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -257,8 +257,12 @@ def substitute_parameters(layout, parameter_dictionary):
             A dictionary containing key-value pairs for substitution.
 
   <Exceptions>
-    securesystemslib.FormatException:
+    securesystemslib.exceptions.FormatError:
       if the parameter dictionary is malformed.
+
+    KeyError:
+      if one of the keys in the parameter dictionary are not present for
+      substitution
 
   <Side Effects>
     The layout object will have any tags replaced with the corresponding

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1533,7 +1533,7 @@ def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
 
   # If there are parameters sent to the tanslation layer, substitute them
   if substitution_parameters is not None:
-    log.info('Perorming parameter substitution...')
+    log.info('Performing parameter substitution...')
     substitute_parameters(layout, substitution_parameters)
 
   log.info("Reading link metadata files...")

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -268,35 +268,51 @@ def substitute_parameters(layout, parameter_dictionary):
 
   for step in layout.steps:
 
-    step.expected_command = [x.format(**parameter_dictionary) for x in step.expected_command]
-
     new_material_rules = []
     for rule in step.expected_materials:
-      new_rule = [x.format(**parameter_dictionary) for x in rule]
+      new_rule = []
+      for stanza in rule:
+        new_rule.append(stanza.format(**parameter_dictionary))
       new_material_rules.append(new_rule)
 
     new_product_rules = []
     for rule in step.expected_products:
-      new_rule = [x.format(**parameter_dictionary) for x in rule]
+      new_rule = []
+      for stanza in rule:
+        new_rule.append(stanza.format(**parameter_dictionary))
       new_product_rules.append(new_rule)
 
+    new_expected_command = []
+    for argv in step.expected_command:
+      new_expected_command.append(argv.format(**parameter_dictionary))
+
+    step.expected_command = new_expected_command
     step.expected_materials = new_material_rules
     step.expected_products = new_product_rules
 
   for inspection in layout.inspect:
+    
+    new_material_rules = []
+    for rule in inspection.expected_materials:
+      new_rule = []
+      for stanza in rule:
+        new_rule.append(stanza.format(**parameter_dictionary))
+      new_material_rules.append(new_rule)
 
-    inspection.expected_materials = [
-        [ s.format(**parameter_dictionary) for s in m ] \
-        for m in inspection.expected_materials
-    ]
+    new_product_rules = []
+    for rule in inspection.expected_products:
+      new_rule = []
+      for stanza in rule:
+        new_rule.append(stanza.format(**parameter_dictionary))
+      new_product_rules.append(new_rule)
 
-    inspection.expected_products = [
-        [ s.format(**parameter_dictionary) for s in p ] \
-        for p in inspection.expected_products
-    ]
+    new_run = []
+    for argv in inspection.run:
+      new_run.append(argv.format(**parameter_dictionary))
 
-    new_run = [x.format(**parameter_dictionary) for x in inspection.run]
     inspection.run = new_run
+    inspection.expected_materials = new_material_rules
+    inspection.expected_products = new_product_rules
 
 
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -50,34 +50,6 @@ import in_toto.rulelib
 log = logging.getLogger(__name__)
 
 
-def _sanitize_parameter_dictionary(parameter_dictionary):
-  """
-  <Purpose>
-    Internal dictionary that ensures that the parameter dictionary:
-      - only consists of string-based keys
-      - All values are strings
-      - None of the keys have any characters outside of the allowed character
-        set ([a-zA-Z0-9-_]).
-
-  <Arguments>
-    parameter_dictionary:
-      The dictionary to verify.
-
-  <Exceptions>
-    SchemaMismatchError if the dictionary doesn't comply with the requirements
-    described above.
-
-  <Side Effects>
-    None.
-
-  <Returns>
-    None.
-  """
-  for key in parameter_dictionary:
-    in_toto.formats.PARAMETER_DICTIONARY_KEY.check_match(key)
-    in_toto.formats.PARAMETER_DICTIONARY_VALUE.check_match(parameter_dictionary[key])
-
-
 def _raise_on_bad_retval(return_value, command=None):
   """
   <Purpose>
@@ -292,7 +264,7 @@ def substitute_parameters(layout, parameter_dictionary):
     The layout object will have any tags replaced with the corresponding
     values defined in the parameter dictionary.
   """
-  _sanitize_parameter_dictionary(parameter_dictionary)
+  in_toto.formats.PARAMETER_DICTIONARY_SCHEMA.check_match(parameter_dictionary)
 
   for step in layout.steps:
 

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -56,7 +56,16 @@ class Test_SubstituteArtifacts(unittest.TestCase):
   def setUp(self):
     self.layout = Layout.read({
         "_type": "layout",
-        "inspect": [],
+        "inspect": [{
+          "name": "do-the-thing",
+          "expected_materials": [
+            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM", 
+              "{SOURCE_STEP}"]
+          ],
+          "expected_products": [
+            ["CREATE", "{NEW_THING}"]
+          ]
+        }],
         "steps": [{
           "name": "artifacts",
           "expected_command": [],
@@ -77,6 +86,10 @@ class Test_SubstituteArtifacts(unittest.TestCase):
     self.assertEquals(self.layout.steps[0].expected_materials[0][1], "vim")
     self.assertEquals(self.layout.steps[0].expected_materials[0][5], "source_step")
     self.assertEquals(self.layout.steps[0].expected_products[0][1], "new_thing")
+    self.assertEquals(self.layout.inspect[0].expected_materials[0][1], "vim")
+    self.assertEquals(self.layout.inspect[0].expected_materials[0][5], "source_step")
+    self.assertEquals(self.layout.inspect[0].expected_products[0][1], "new_thing")
+
 
 
   def test_substitute_no_var(self):
@@ -127,8 +140,7 @@ class Test_SubstituteExpectedCommand(unittest.TestCase):
         "steps": [{
           "name": "run-command",
           "expected_command": ["{EDITOR}"],
-        }]
-      })
+        }]})
 
   def test_substitute(self):
     """Do a simple substitution on the expected_command field"""

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_verifylib.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Nov 07, 2016
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test verifylib functions.
+
+"""
+
+import os
+import shutil
+import copy
+import tempfile
+import unittest
+import glob
+from mock import patch
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+import in_toto.settings
+from in_toto.models.metadata import Metablock
+from in_toto.models.link import Link, FILENAME_FORMAT
+from in_toto.models.layout import (Step, Inspection, Layout,
+    SUBLAYOUT_LINK_DIR_FORMAT)
+from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
+    verify_modify_rule, verify_allow_rule, verify_disallow_rule,
+    verify_match_rule, verify_item_rules, verify_all_item_rules,
+    verify_command_alignment, run_all_inspections, in_toto_verify,
+    verify_sublayouts, get_summary_link, _raise_on_bad_retval,
+    load_links_for_layout, verify_link_signature_thresholds,
+    verify_threshold_constraints, substitute_parameters)
+from in_toto.exceptions import (RuleVerificationError,
+    SignatureVerificationError, LayoutExpiredError, BadReturnValueError,
+    ThresholdVerificationError)
+from in_toto.util import import_rsa_key_from_file, import_rsa_public_keys_from_files_as_dict
+import in_toto.gpg.functions
+
+import securesystemslib.exceptions
+import in_toto.exceptions
+
+
+class Test_SubstituteArtifacts(unittest.TestCase):
+  """Test parameter substitution on artifact rules. """
+
+  def setUp(self):
+    self.layout = Layout.read({
+        "_type": "layout",
+        "inspect": [],
+        "steps": [{
+          "name": "artifacts",
+          "expected_command": [],
+          "expected_materials": [
+            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM", 
+              "{SOURCE_STEP}"]
+          ],
+          "expected_products": [
+            ["CREATE", "{NEW_THING}"]
+          ]
+        }]
+    })
+
+  def test_substitute(self):
+    """Do a simple substitution on the expected_command field"""
+    substitute_parameters(self.layout, {"SOURCE_THING": "vim",
+      "SOURCE_STEP": "source_step", "NEW_THING": "new_thing"})
+    self.assertEquals(self.layout.steps[0].expected_materials[0][1], "vim")
+    self.assertEquals(self.layout.steps[0].expected_materials[0][5], "source_step")
+    self.assertEquals(self.layout.steps[0].expected_products[0][1], "new_thing")
+
+
+  def test_substitute_no_var(self):
+    """Raise an error if the parameter is not filled-in"""
+    with self.assertRaises(KeyError):
+      substitute_parameters(self.layout, {})
+
+
+class Test_SubstituteRunField(unittest.TestCase):
+  """Test substitution on the run field of the layout"""
+
+  def setUp(self):
+    """
+    Create layout with dummy inspection
+    """
+
+    # Create layout with one inspection
+    self.layout = Layout.read({
+        "_type": "layout",
+        "steps": [],
+        "inspect": [{
+          "name": "run-command",
+          "run": ["{COMMAND}"],
+        }]
+      })
+
+  def test_substitute(self):
+    """Check that the substitution is performed on the run field."""
+    substitute_parameters(self.layout, {"COMMAND": "touch"})
+    self.assertEquals(self.layout.inspect[0].run[0], "touch")
+
+
+  def test_inspection_fail_with_non_zero_retval(self):
+    """Check that the substitution raises TypeError if the key is missing"""
+
+    with self.assertRaises(KeyError):
+      substitute_parameters(self.layout, {})
+
+
+class Test_SubstituteExpectedCommand(unittest.TestCase):
+  """Test verifylib.verify_command_alignment(command, expected_command)"""
+
+  def setUp(self):
+    # Create layout with one inspection
+    self.layout = Layout.read({
+        "_type": "layout",
+        "inspect": [],
+        "steps": [{
+          "name": "run-command",
+          "expected_command": ["{EDITOR}"],
+        }]
+      })
+
+  def test_substitute(self):
+    """Do a simple substitution on the expected_command field"""
+    substitute_parameters(self.layout, {"EDITOR": "vim"})
+    self.assertEquals(self.layout.steps[0].expected_command[0], "vim")
+
+
+  def test_substitute_no_var(self):
+    """Raise an error if the parameter is not filled-in"""
+
+    with self.assertRaises(KeyError):
+      substitute_parameters(self.layout, {"NOEDITOR": "vim"})
+
+
+class Test_SubstituteOnVerify(unittest.TestCase):
+  """Test verifylib.verify_command_alignment(command, expected_command)"""
+
+  @classmethod
+  def setUpClass(self):
+    # Create layout with one inspection
+    self.layout = Layout.read({
+        "_type": "layout",
+        "inspect": [],
+        "steps": [{
+          "name": "run-command",
+          "expected_command": ["{EDITOR}"],
+        }]
+      })
+
+    # Backup original cwd
+    self.working_dir = os.getcwd()
+
+    # Find demo files
+    demo_files = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "demo_files")
+
+    # Create and change into temporary directory
+    self.test_dir = os.path.realpath(tempfile.mkdtemp())
+    os.chdir(self.test_dir)
+
+    # Copy demo files to temp dir
+    for file in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+
+    # load alice's key
+    self.alice = import_rsa_key_from_file("alice")
+    self.alice_pub_dict = import_rsa_public_keys_from_files_as_dict(
+        ["alice.pub"])
+
+  @classmethod
+  def tearDownClass(self):
+    os.chdir(self.working_dir)
+    shutil.rmtree(self.test_dir)
+
+  def test_substitute(self):
+    """Do a simple substitution on the expected_command field"""
+    signed_layout = Metablock(signed=self.layout)
+    signed_layout.sign(self.alice)
+
+    # we will catch a LinkNotFound error because we don't have (and don't need)
+    # the metadata.
+    with self.assertRaises(in_toto.exceptions.LinkNotFoundError):
+      in_toto_verify(signed_layout, self.alice_pub_dict,
+          substitution_parameters={"EDITOR":"vim"})
+
+    self.assertEquals(self.layout.steps[0].expected_command[0], "vim")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -2,19 +2,21 @@
 
 """
 <Program Name>
-  test_verifylib.py
+  test_param_substitution.py
 
 <Author>
-  Lukas Puehringer <lukas.puehringer@nyu.edu>
+  Santiago Torres-Arias <santiago@nyu.edu>
 
 <Started>
-  Nov 07, 2016
+  May 15, 2018
 
 <Copyright>
   See LICENSE for licensing information.
 
 <Purpose>
-  Test verifylib functions.
+  Test the parameter substitution functions within verifylib. These tests were
+  placed in a separate module to ease refactoring in case the substitution
+  layer is to be removed.
 
 """
 
@@ -43,7 +45,7 @@ from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
 from in_toto.exceptions import (RuleVerificationError,
     SignatureVerificationError, LayoutExpiredError, BadReturnValueError,
     ThresholdVerificationError)
-from in_toto.util import import_rsa_key_from_file, import_rsa_public_keys_from_files_as_dict
+from in_toto.util import import_rsa_key_from_file, import_public_keys_from_files_as_dict
 import in_toto.gpg.functions
 
 import securesystemslib.exceptions
@@ -187,7 +189,7 @@ class Test_SubstituteOnVerify(unittest.TestCase):
 
     # load alice's key
     self.alice = import_rsa_key_from_file("alice")
-    self.alice_pub_dict = import_rsa_public_keys_from_files_as_dict(
+    self.alice_pub_dict = import_public_keys_from_files_as_dict(
         ["alice.pub"])
 
   @classmethod


### PR DESCRIPTION
**Fixes issue #**:

None

**Description of the changes being introduced by the pull request**:

This pull request adds the substitution layer code for our current integrators.
Note that this solution is just a stepping stone into a more robust,
full-fledged solution for a version 0.3.0 of in-toto

    Integrators and package managers that are performing in-toto verification 
need a way to signal some contextual information about the artifacts that 
are being verified (e.g., what's the name of the actual package that was 
received!). The simplest way to provide this functionality is by adding a 
simple replacement layer. Thus, a package manager that wants to verify can call: 
 
   `in_toto_verify(metadata_path, root_layout_keys, param_substitutions=...) `
     
This PR enables this functionality on the root layout, so that artifact 
names or commands to run can be provided to in-toto before execution. 
The parameter dictionary is a simple non-nested {key:value} set of strings 
that can be passed to perform substitution on python-like formatted strings 
within the layout. The tokens to replace are to be defined by the project 
owner when creating the layout. 


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature