### PR TITLE
Add appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ init:
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python -m pip install -U pip
+  # Install mock, coverage, and pytest, which are needed for unit testing.
   - pip install -r requirements-ci.txt
   - pip install -e .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 32
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: 3.5
+      PYTHON_ARCH: 32
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: 3.4
+      PYTHON_ARCH: 32
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: 2.7
+      PYTHON_ARCH: 32
+
+init:
+  - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
+
+install:
+  - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - python -m pip install -U pip
+  - pip install -e .
+
+build: false
+
+test_script:
+  - python tests/runtests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ init:
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python -m pip install -U pip
+  - pip install -r requirements-ci.txt
   - pip install -e .
 
 build: false


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

in-toto currently uses Travis CI for continuous integration under Linux.  The project should also use a CI solution for Windows.  I recommend Appveyor, the only drawback being that a free account for OSS projects is limited to one concurrent build.  Note: Appveyor recently added support for Linux, but it might be faster to use Travis (for Linux) + Appveyor (for Windows) because of Appveyor's limit on build jobs.

This pull request adds a `appveyor.yml` configuration file, which executes in-toto's unit tests under Windows for Python versions 2.7, 3.4, 3.5 and 3.6.

The project maintainers will have to create Appveyor account before they can trigger a build job with this configuration file, which hasn't been fully tested (but it should work).

Note: I tried testing in-toto in a Windows VM and most of the unit tests failures I came across were due to incompatible file path separators.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>