### PR TITLE
Allow user-specified GPG executables (using patch from @SantiagoTorres)

### DIFF
--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -17,10 +17,25 @@
 """
 import in_toto.gpg.rsa as rsa
 import in_toto.gpg.dsa as dsa
+import in_toto.user_settings as settings
 
-GPG_SIGN_COMMAND = "gpg2 --detach-sign --digest-algo SHA256 {keyarg} {homearg}"
-GPG_EXPORT_PUBKEY_COMMAND = "gpg2 {homearg} --export {keyid}"
-GPG_VERSION_COMMAND = "gpg2 --version"
+# The key used to get user-specified GPG executable from the environment.
+GPG_EXECUTABLE_KEY = "GPG_EXECUTABLE"
+
+# First, try getting the GPG executable from the RC file.
+GPG_EXECUTABLE = settings.get_rc().get(GPG_EXECUTABLE_KEY)
+
+# Second, otherwise, try getting it from environment variables.
+if not GPG_EXECUTABLE:
+  GPG_EXECUTABLE = settings.get_env().get(GPG_EXECUTABLE_KEY)
+
+# Third, otherwise, fix it to an expected binary.
+if not GPG_EXECUTABLE:
+  GPG_EXECUTABLE = "gpg2"
+
+GPG_SIGN_COMMAND = GPG_EXECUTABLE + " --detach-sign --digest-algo SHA256 {keyarg} {homearg}"
+GPG_EXPORT_PUBKEY_COMMAND = GPG_EXECUTABLE + " {homearg} --export {keyid}"
+GPG_VERSION_COMMAND = GPG_EXECUTABLE + " --version"
 
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,13 @@ commands =
     # https://docs.openstack.org/bandit/latest/blacklists/blacklist_imports.html#b404-import-subprocess
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
     # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
-    bandit -r in_toto --skip B404,B603 -x in_toto/util.py
+    bandit -r in_toto --skip B404,B603,B303 -x in_toto/util.py
     # Note: We exclude tests that fail on specifying the default value of a variable resembling a password
     # for in_toto/util.py as it is a false positive. We actually never use hardcoded passwords.
     # https://docs.openstack.org/bandit/latest/plugins/b107_hardcoded_password_funcdef.html
-    bandit in_toto/util.py --skip B107,B404,B603
+    # Furthermore, for GPG we are *required* to use SHA1 as the hash function to compute
+    # keyids, so B303 is added
+    bandit in_toto/util.py --skip B107,B404,B603,B303
 
     # Integrating tox with setup.py test is as p of Oct 2016 discouraged
     # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command


### PR DESCRIPTION
**Fixes issue #**:

N/A.

**Description of the changes being introduced by the pull request**:

Allow users to specify GPG executable used by in-toto. The previous assumption of `gpg2` existing may not always work for Windows or macOS users.

Cc: @ofek @SantiagoTorres 

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


