### PR TITLE
Get `gpg` commands as functions, not constants, of the user environment

### DIFF
--- a/in_toto/gpg/common.py
+++ b/in_toto/gpg/common.py
@@ -130,17 +130,18 @@ def parse_pubkey_payload(data):
 def parse_pubkey_bundle(data, keyid):
   """
   <Purpose>
-    Parse the public key data received by GPG_EXPORT_PUBKEY_COMMAND and
-    construct a public key dictionary, containing a master key and optional
-    subkeys, where either the master key or the subkeys are identified by
-    the passed keyid.
+    Parse the public key data received by functions.gpg_export_pubkey_command()
+    and construct a public key dictionary, containing a master key and optional
+    subkeys, where either the master key or the subkeys are identified by the
+    passed keyid.
 
     NOTE: If the keyid matches one of the subkeys, a warning is issued to
     notify the user about potential privilege escalation.
 
   <Arguments>
     data:
-          Public key data as written to stdout by GPG_EXPORT_PUBKEY_COMMAND.
+          Public key data as written to stdout by
+          functions.gpg_export_pubkey_command().
 
   <Exceptions>
     ValueError:

--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -17,25 +17,9 @@
 """
 import in_toto.gpg.rsa as rsa
 import in_toto.gpg.dsa as dsa
-import in_toto.user_settings as settings
 
 # The key used to get user-specified GPG executable from the environment.
 GPG_EXECUTABLE_KEY = "GPG_EXECUTABLE"
-
-# First, try getting the GPG executable from the RC file.
-GPG_EXECUTABLE = settings.get_rc().get(GPG_EXECUTABLE_KEY)
-
-# Second, otherwise, try getting it from environment variables.
-if not GPG_EXECUTABLE:
-  GPG_EXECUTABLE = settings.get_env().get(GPG_EXECUTABLE_KEY)
-
-# Third, otherwise, fix it to an expected binary.
-if not GPG_EXECUTABLE:
-  GPG_EXECUTABLE = "gpg2"
-
-GPG_SIGN_COMMAND = GPG_EXECUTABLE + " --detach-sign --digest-algo SHA256 {keyarg} {homearg}"
-GPG_EXPORT_PUBKEY_COMMAND = GPG_EXECUTABLE + " {homearg} --export {keyid}"
-GPG_VERSION_COMMAND = GPG_EXECUTABLE + " --version"
 
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -43,12 +43,12 @@ def gpg_executable():
   else:
     gpg_exec = settings.get_env().get(GPG_EXECUTABLE_KEY)
 
-  # Third, otherwise, fix it to an expected binary.
-  if gpg_exec:
-    log.debug('gpg_executable: ' + gpg_exec)
-  else:
-    gpg_exec = "gpg2"
-    log.debug('gpg_executable: ' + gpg_exec)
+    # Third, otherwise, fix it to an expected binary.
+    if gpg_exec:
+      log.debug('gpg_executable: ' + gpg_exec)
+    else:
+      gpg_exec = "gpg2"
+      log.debug('gpg_executable: ' + gpg_exec)
 
   # Return executable.
   return gpg_exec

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -22,8 +22,9 @@ import logging
 import in_toto.gpg.common
 import in_toto.gpg.exceptions
 import in_toto.gpg.formats
-from in_toto.gpg.constants import (GPG_EXPORT_PUBKEY_COMMAND, GPG_SIGN_COMMAND,
-    SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION)
+from in_toto.gpg.constants import (GPG_EXECUTABLE_KEY, SIGNATURE_HANDLERS,
+                                   FULLY_SUPPORTED_MIN_VERSION)
+import in_toto.user_settings as settings
 
 import securesystemslib.formats
 
@@ -32,13 +33,47 @@ import securesystemslib.formats
 log = logging.getLogger(__name__)
 
 
+def gpg_executable():
+  # First, try getting the GPG executable from the RC file.
+  gpg_exec = settings.get_rc().get(GPG_EXECUTABLE_KEY)
+
+  # Second, otherwise, try getting it from environment variables.
+  if gpg_exec:
+    log.debug('gpg_executable: ' + gpg_exec)
+  else:
+    gpg_exec = settings.get_env().get(GPG_EXECUTABLE_KEY)
+
+  # Third, otherwise, fix it to an expected binary.
+  if gpg_exec:
+    log.debug('gpg_executable: ' + gpg_exec)
+  else:
+    gpg_exec = "gpg2"
+    log.debug('gpg_executable: ' + gpg_exec)
+
+  # Return executable.
+  return gpg_exec
+
+
+def gpg_sign_command():
+  return gpg_executable() + \
+         " --detach-sign --digest-algo SHA256 {keyarg} {homearg}"
+
+
+def gpg_export_pubkey_command():
+  return gpg_executable() + " {homearg} --export {keyid}"
+
+
+def gpg_version_command():
+  return gpg_executable() + " --version"
+
+
 def gpg_sign_object(content, keyid=None, homedir=None):
   """
   <Purpose>
     Calls the gpg2 command line utility to sign the passed content with the key
     identified by the passed keyid from the gpg keyring at the passed homedir.
 
-    The executed base command is defined in constants.GPG_SIGN_COMMAND.
+    The executed base command is defined in gpg_sign_command().
 
     NOTE: On not fully supported versions of GPG, i.e. versions below
     in_toto.gpg.constants.FULLY_SUPPORTED_MIN_VERSION the returned signature
@@ -88,7 +123,7 @@ def gpg_sign_object(content, keyid=None, homedir=None):
   if homedir:
     homearg = "--homedir {}".format(homedir)
 
-  command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
+  command = gpg_sign_command().format(keyarg=keyarg, homearg=homearg)
   process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE,
       stdin=subprocess.PIPE, stderr=subprocess.PIPE)
   signature_data, junk = process.communicate(content)
@@ -192,8 +227,7 @@ def gpg_export_pubkey(keyid, homedir=None):
     Note: The identified key is exported including the corresponding master
     key and all subkeys.
 
-    The executed base command is defined in
-    constants.GPG_EXPORT_PUBKEY_COMMAND.
+    The executed base command is defined in gpg_export_pubkey_command().
 
   <Arguments>
     keyid:
@@ -227,7 +261,7 @@ def gpg_export_pubkey(keyid, homedir=None):
   if homedir:
     homearg = "--homedir {}".format(homedir)
 
-  command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
+  command = gpg_export_pubkey_command().format(keyid=keyid, homearg=homearg)
   process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE,
       stdin=subprocess.PIPE, stderr=subprocess.PIPE)
   key_packet, junk = process.communicate()

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -209,13 +209,13 @@ def get_version():
     Uses `gpg2 --version` to get the version info of the installed gpg2
     and extracts and returns the version number.
 
-    The executed base command is defined in constants.GPG_VERSION_COMMAND.
+    The executed base command is defined in functions.gpg_version_command().
 
   <Returns>
     Version number string, e.g. "2.1.22"
 
   """
-  command = shlex.split(in_toto.gpg.constants.GPG_VERSION_COMMAND)
+  command = shlex.split(in_toto.gpg.functions.gpg_version_command())
   process = subprocess.Popen(command, stdout=subprocess.PIPE,
       universal_newlines=True)
   full_version_info, junk = process.communicate()


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Get `gpg` commands as functions, not constants, of the user environment.

Cc: @ofek @SantiagoTorres 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


