### PR TITLE
Add normalize_line_endings argument to in_toto_run/record

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -60,7 +60,8 @@ else: # pragma: no cover
   import subprocess
 
 
-def _hash_artifact(filepath, hash_algorithms=None):
+def _hash_artifact(filepath, hash_algorithms=None,
+      normalize_line_endings=False):
   """Internal helper that takes a filename and hashes the respective file's
   contents using the passed hash_algorithms and returns a hashdict conformant
   with securesystemslib.formats.HASHDICT_SCHEMA. """
@@ -71,7 +72,8 @@ def _hash_artifact(filepath, hash_algorithms=None):
   hash_dict = {}
 
   for algorithm in hash_algorithms:
-    digest_object = securesystemslib.hash.digest_filename(filepath, algorithm, normalize_line_endings=True)
+    digest_object = securesystemslib.hash.digest_filename(filepath, algorithm,
+        normalize_line_endings=normalize_line_endings)
     hash_dict.update({algorithm: digest_object.hexdigest()})
 
   securesystemslib.formats.HASHDICT_SCHEMA.check_match(hash_dict)
@@ -94,7 +96,7 @@ def _apply_exclude_patterns(names, exclude_filter):
 
 
 def record_artifacts_as_dict(artifacts, exclude_patterns=None,
-    base_path=None, follow_symlink_dirs=False):
+    base_path=None, follow_symlink_dirs=False, normalize_line_endings=False):
   """
   <Purpose>
     Hashes each file in the passed path list. If the path list contains
@@ -154,6 +156,11 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             linked files are always recorded, independently of this parameter.
             NOTE: Beware of infinite recursions that can occur if a symlink
             points to a parent directory or itself.
+
+    normalize_line_endings: (optional)
+            If True, replaces windows and mac line endings with unix line
+            endings before hashing the content of the passed files, for
+            cross-platform support.
 
   <Exceptions>
     in_toto.exceptions.ValueError,
@@ -221,7 +228,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
       artifact = artifact.replace('\\', '/')
 
       # Path was already normalized above
-      artifacts_dict[artifact] = _hash_artifact(artifact)
+      artifacts_dict[artifact] = _hash_artifact(artifact,
+          normalize_line_endings=normalize_line_endings)
 
     elif os.path.isdir(artifact):
       for root, dirs, files in os.walk(artifact,
@@ -269,7 +277,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           # FIXME: this is necessary to provide consisency between windows filepaths and
           # *nix filepaths. A better solution may be in order though...
           normalized_filepath = filepath.replace("\\", "/")
-          artifacts_dict[normalized_filepath] = _hash_artifact(filepath)
+          artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
+              normalize_line_endings=normalize_line_endings)
 
     # Path is no file and no directory
     else:
@@ -381,7 +390,8 @@ def _check_match_signing_key(signing_key):
 def in_toto_run(name, material_list, product_list, link_cmd_args,
     record_streams=False, signing_key=None, gpg_keyid=None,
     gpg_use_default=False, gpg_home=None, exclude_patterns=None,
-    base_path=None, compact_json=False, record_environment=False):
+    base_path=None, compact_json=False, record_environment=False,
+    normalize_line_endings=False):
   """
   <Purpose>
     Calls functions in this module to run the command passed as link_cmd_args
@@ -440,6 +450,10 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     record_environment: (optional)
             if values such as workdir should be recorded  on the environment
             dictionary (false by default)
+    normalize_line_endings: (optional)
+            If True, replaces windows and mac line endings with unix line
+            endings before hashing materials and products, for cross-platform
+            support.
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
@@ -476,7 +490,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
@@ -490,7 +504,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   products_dict = record_artifacts_as_dict(product_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
 
   log.info("Creating link metadata...")
   environment = {}
@@ -528,7 +542,8 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
 def in_toto_record_start(step_name, material_list, signing_key=None,
     gpg_keyid=None, gpg_use_default=False, gpg_home=None,
-    exclude_patterns=None, base_path=None, record_environment=False):
+    exclude_patterns=None, base_path=None, record_environment=False,
+    normalize_line_endings=False):
   """
   <Purpose>
     Starts creating link metadata for a multi-part in-toto step. I.e.
@@ -567,6 +582,9 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
     record_environment: (optional)
             if values such as workdir should be recorded  on the environment
             dictionary (false by default)
+    normalize_line_endings: (optional)
+            If True, replaces windows and mac line endings with unix line
+            endings before hashing materials, for cross-platform support.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
@@ -611,7 +629,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
 
   log.info("Creating preliminary link metadata...")
   environment = {}
@@ -649,7 +667,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
 def in_toto_record_stop(step_name, product_list, signing_key=None,
     gpg_keyid=None, gpg_use_default=False, gpg_home=None,
-    exclude_patterns=None, base_path=None):
+    exclude_patterns=None, base_path=None, normalize_line_endings=False):
   """
   <Purpose>
     Finishes creating link metadata for a multi-part in-toto step.
@@ -688,6 +706,9 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
             current working directory.
             NOTE: The base_path part of the recorded products is not included
             in the resulting preliminary link's product section.
+    normalize_line_endings: (optional)
+            If True, replaces windows and mac line endings with unix line
+            endings before hashing products, for cross-platform support.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
@@ -792,7 +813,7 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
 
   link_metadata.signed.products = record_artifacts_as_dict(product_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
 
   link_metadata.signatures = []
   if signing_key:

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -466,9 +466,8 @@ class TestInTotoRun(unittest.TestCase):
 
       # Check that all three hashes in materials and products are equal
       for artifact_dict in [link.materials, link.products]:
-        self.assertTrue(artifact_dict[paths[0]] ==
-            artifact_dict[paths[1]] ==
-            artifact_dict[paths[2]])
+        hash_dicts = list(artifact_dict.values())
+        self.assertTrue(hash_dicts[1:] == hash_dicts[:-1])
 
     # Clean up
     finally:
@@ -662,9 +661,8 @@ class TestInTotoRecordStop(unittest.TestCase):
 
       # Check that all three hashes in materials and products are equal
       for artifact_dict in [link.materials, link.products]:
-        self.assertTrue(artifact_dict[paths[0]] ==
-            artifact_dict[paths[1]] ==
-            artifact_dict[paths[2]])
+        hash_dicts = list(artifact_dict.values())
+        self.assertTrue(hash_dicts[1:] == hash_dicts[:-1])
 
     # Clean up
     finally:

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -33,7 +33,8 @@ from in_toto.runlib import (in_toto_run, in_toto_record_start,
     _hash_artifact)
 from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_import_rsa_key_from_file)
-from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT)
+from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
+    FILENAME_FORMAT_SHORT)
 
 import securesystemslib.formats
 import securesystemslib.exceptions
@@ -447,6 +448,34 @@ class TestInTotoRun(unittest.TestCase):
     self.assertEquals(link.signed.environment["workdir"], 
         os.getcwd().replace("\\", "/"))
 
+  def test_normalize_line_endings(self):
+    """Test cross-platform line ending normalization. """
+    paths = []
+    try:
+      # Create three artifacts with same content but different line endings
+      for line_ending in [b"\n", b"\r", b"\r\n"]:
+        fd, path = tempfile.mkstemp()
+        paths.append(path)
+        os.write(fd, b"hello" + line_ending + b"toto")
+        os.close(fd)
+
+      # Call in_toto_run and record artifacts as materials and products
+      # with line ending normalization on
+      link = in_toto_run(self.step_name, paths, paths, ["python", "--version"],
+          normalize_line_endings=True).signed
+
+      # Check that all three hashes in materials and products are equal
+      for artifact_dict in [link.materials, link.products]:
+        self.assertTrue(artifact_dict[paths[0]] ==
+            artifact_dict[paths[1]] ==
+            artifact_dict[paths[2]])
+
+    # Clean up
+    finally:
+      for path in paths:
+        os.remove(path)
+
+
   def test_in_toto_bad_signing_key_format(self):
     """Fail run, passed key is not properly formatted. """
     with self.assertRaises(securesystemslib.exceptions.FormatError):
@@ -458,6 +487,7 @@ class TestInTotoRun(unittest.TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       in_toto_run(self.step_name, None, None,
           ["python", "--version"], True, self.key_pub)
+
 
 class TestInTotoRecordStart(unittest.TestCase):
   """"Test in_toto_record_start(step_name, key, material_list). """
@@ -610,6 +640,37 @@ class TestInTotoRecordStop(unittest.TestCase):
       in_toto_record_stop(
           self.step_name, [], signing_key=None, gpg_keyid=None,
           gpg_use_default=False)
+
+  def test_normalize_line_endings(self):
+    """Test cross-platform line ending normalization. """
+    paths = []
+    try:
+      # Create three artifacts with same content but different line endings
+      for line_ending in [b"\n", b"\r", b"\r\n"]:
+        fd, path = tempfile.mkstemp()
+        paths.append(path)
+        os.write(fd, b"hello" + line_ending + b"toto")
+        os.close(fd)
+
+      # Call in_toto_record start and stop and record artifacts as
+      # materials and products with line ending normalization on
+      in_toto_record_start(self.step_name, paths, self.key,
+          normalize_line_endings=True)
+      in_toto_record_stop(self.step_name, paths, self.key,
+          normalize_line_endings=True)
+      link = Metablock.load(self.link_name).signed
+
+      # Check that all three hashes in materials and products are equal
+      for artifact_dict in [link.materials, link.products]:
+        self.assertTrue(artifact_dict[paths[0]] ==
+            artifact_dict[paths[1]] ==
+            artifact_dict[paths[2]])
+
+    # Clean up
+    finally:
+      for path in paths:
+        os.remove(path)
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:

**Description of the changes being introduced by the pull request**:

Add optional boolean `normalize_line_endings` argument to `in_toto_run`, `in_toto_record_start` and `in_toto_record_stop` in `in_toto.runlib`.
If `True`, replaces windows and mac line endings with unix line endings before hashing the content of the passed files, for cross-platform support. Default is `False`.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


