### PR TITLE
Add interface for subprocess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
           env: TOXENV=py36
         - python: "3.7"
           env: TOXENV=py37
+          # NOTE: temporary workaround; see https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122
+          dist: xenial
+          sudo: true
 
 install:
     - pip install -U tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ matrix:
         # https://github.com/travis-ci/travis-ci/issues/8363#issuecomment-355090242
         - python: "2.7"
           env: TOXENV=py27
-        - python: "3.4"
-          env: TOXENV=py34
         - python: "3.5"
           env: TOXENV=py35
         - python: "3.6"
           env: TOXENV=py36
+        - python: "3.7"
+          env: TOXENV=py37
 
 install:
     - pip install -U tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,15 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: 3.7
+      PYTHON_ARCH: 32
+
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
 
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: 3.4
       PYTHON_ARCH: 32
 
     - PYTHON: "C:\\Python27"

--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -16,11 +16,10 @@
   handling
 """
 
-import shlex
-import subprocess
-
 import in_toto.gpg.rsa as rsa
 import in_toto.gpg.dsa as dsa
+
+import in_toto.process as process
 
 # By default, we assume and test that gpg2 exists. Otherwise, we assume gpg
 # exists.
@@ -30,7 +29,7 @@ GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 
 try:
-  subprocess.check_call(shlex.split(GPG_VERSION_COMMAND))
+  process.check_call_no_stdout_no_stderr(GPG_VERSION_COMMAND)
 except OSError: # pragma: no cover
   GPG_COMMAND = "gpg"
   GPG_VERSION_COMMAND = GPG_COMMAND + " --version"

--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -29,7 +29,8 @@ GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 
 try:
-  process.check_call_no_stdout_no_stderr(GPG_VERSION_COMMAND)
+  process.run(GPG_VERSION_COMMAND, stdout=process.DEVNULL,
+    stderr=process.DEVNULL)
 except OSError: # pragma: no cover
   GPG_COMMAND = "gpg"
   GPG_VERSION_COMMAND = GPG_COMMAND + " --version"

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -88,8 +88,8 @@ def gpg_sign_object(content, keyid=None, homedir=None):
     homearg = "--homedir {}".format(homedir).replace("\\", "/")
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
-  process = in_toto.process.check_call_write_stdin_pipe_stdout(command,
-    content)
+  process = in_toto.process.run(command, _input=content,
+    stdout=in_toto.process.PIPE, stderr=in_toto.process.DEVNULL)
   signature_data = process.stdout
   signature = in_toto.gpg.common.parse_signature_packet(signature_data)
 
@@ -226,7 +226,9 @@ def gpg_export_pubkey(keyid, homedir=None):
     homearg = "--homedir {}".format(homedir).replace("\\", "/")
 
   command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
-  key_packet = in_toto.process.check_output_no_stdin_no_stderr(command)
+  process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
+    stderr=in_toto.process.DEVNULL)
+  key_packet = process.stdout
   key_bundle = in_toto.gpg.common.parse_pubkey_bundle(key_packet, keyid)
 
   return key_bundle

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -88,7 +88,7 @@ def gpg_sign_object(content, keyid=None, homedir=None):
     homearg = "--homedir {}".format(homedir).replace("\\", "/")
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
-  process = in_toto.process.run(command, _input=content,
+  process = in_toto.process.run(command, input=content,
     stdout=in_toto.process.PIPE, stderr=in_toto.process.DEVNULL)
   signature_data = process.stdout
   signature = in_toto.gpg.common.parse_signature_packet(signature_data)

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -15,8 +15,6 @@
   publicly-usable functions for exporting public-keys, signing data and
   verifying signatures.
 """
-import subprocess
-import shlex
 import logging
 
 import in_toto.gpg.common
@@ -25,8 +23,9 @@ import in_toto.gpg.formats
 from in_toto.gpg.constants import (GPG_EXPORT_PUBKEY_COMMAND, GPG_SIGN_COMMAND,
     SIGNATURE_HANDLERS, FULLY_SUPPORTED_MIN_VERSION)
 
-import securesystemslib.formats
+import in_toto.process
 
+import securesystemslib.formats
 
 # Inherits from in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger(__name__)
@@ -89,10 +88,9 @@ def gpg_sign_object(content, keyid=None, homedir=None):
     homearg = "--homedir {}".format(homedir).replace("\\", "/")
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
-  process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE,
-      stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-  signature_data, junk = process.communicate(content)
-
+  process = in_toto.process.check_call_write_stdin_pipe_stdout(command,
+    content)
+  signature_data = process.stdout
   signature = in_toto.gpg.common.parse_signature_packet(signature_data)
 
   # On GPG < 2.1 we cannot derive the full keyid from the signature data.
@@ -228,10 +226,7 @@ def gpg_export_pubkey(keyid, homedir=None):
     homearg = "--homedir {}".format(homedir).replace("\\", "/")
 
   command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
-  process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE,
-      stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-  key_packet, _ = process.communicate()
-
+  key_packet = in_toto.process.check_output_no_stdin_no_stderr(command)
   key_bundle = in_toto.gpg.common.parse_pubkey_bundle(key_packet, keyid)
 
   return key_bundle

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -16,8 +16,6 @@
 """
 import struct
 import binascii
-import subprocess
-import shlex
 import re
 
 from distutils.version import StrictVersion # pylint: disable=no-name-in-module,import-error
@@ -26,7 +24,7 @@ import cryptography.hazmat.backends as backends
 import cryptography.hazmat.primitives.hashes as hashing
 
 import in_toto.gpg.exceptions
-
+import in_toto.process
 
 def get_mpi_length(data):
   """
@@ -215,10 +213,9 @@ def get_version():
     Version number string, e.g. "2.1.22"
 
   """
-  command = shlex.split(in_toto.gpg.constants.GPG_VERSION_COMMAND)
-  process = subprocess.Popen(command, stdout=subprocess.PIPE,
-      universal_newlines=True)
-  full_version_info, junk = process.communicate()
+  command = in_toto.gpg.constants.GPG_VERSION_COMMAND
+  full_version_info = in_toto.process.check_output_no_stdin_no_stderr(command,
+                        universal_newlines=True)
 
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)
 

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -214,9 +214,9 @@ def get_version():
 
   """
   command = in_toto.gpg.constants.GPG_VERSION_COMMAND
-  full_version_info = in_toto.process.check_output_no_stdin_no_stderr(command,
-                        universal_newlines=True)
-
+  process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
+    stderr=in_toto.process.DEVNULL, universal_newlines=True)
+  full_version_info = process.stdout
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)
 
   return version_string

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -27,7 +27,7 @@ import shlex
 import six
 
 if six.PY2:
-  import subprocess32 as subprocess # pragma: no cover
+  import subprocess32 as subprocess # pragma: no cover pylint: disable=import-error
 else: # pragma: no cover
   import subprocess
 

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -1,11 +1,9 @@
-import os
 import logging
 import shlex
-import sys
 
 import six
 
-if sys.version_info[0] < 3:
+if six.PY2:
   import subprocess32 as subprocess # pragma: no cover
 else: # pragma: no cover
   import subprocess

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -1,0 +1,214 @@
+import os
+import logging
+import shlex
+import sys
+
+import six
+
+if os.name == 'posix' and sys.version_info[0] < 3:
+  import subprocess32 as subprocess # pragma: no cover
+else: # pragma: no cover
+  import subprocess
+
+import in_toto.formats as formats
+
+from in_toto.settings import SUBPROCESS_TIMEOUT
+
+
+# Inherits from in_toto base logger (c.f. in_toto.log)
+log = logging.getLogger(__name__)
+
+
+def shlex_split(cmd):
+  """
+  <Purpose>
+    Splits a string specifying a command and its argument into a list of
+    substrings, if necessary.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (str | list)
+
+  <Exceptions>
+    securesystemslib.exceptions.FormatError:
+            If the cmd as list does not match
+            in_toto.formats.LIST_OF_ANY_STRING_SCHEMA.
+
+  <Side Effects>
+    None.
+
+  <Returns>
+    A list of strings matching in_toto.formats.LIST_OF_ANY_STRING_SCHEMA.
+
+  """
+  if isinstance(cmd, six.string_types):
+    cmd = shlex.split(cmd)
+  else:
+    formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
+  return cmd
+
+
+# TODO: Properly duplicate standard streams (issue #11)
+def run_pipe_stdout_pipe_stderr(cmd):
+  """
+  <Purpose>
+    Run the specified command, WITHOUT writing to standard input, and WITHOUT
+    writing to standard output and error.  Note that we do NOT check whether
+    the command returned a non-zero code.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str)
+
+  <Exceptions>
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds.
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A subprocess.CompletedProcess instance.
+
+  """
+  cmd = shlex_split(cmd)
+  return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    universal_newlines=True, timeout=SUBPROCESS_TIMEOUT)
+
+
+def run_no_stdout_no_stderr(cmd):
+  """
+  <Purpose>
+    Run the specified command, WITHOUT writing to standard input, output, and
+    error.  Note that we do NOT check whether the command returned a non-zero
+    code.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str)
+
+  <Exceptions>
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds.
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A subprocess.CompletedProcess instance.
+
+  """
+  cmd = shlex_split(cmd)
+  return subprocess.run(cmd, stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL, timeout=SUBPROCESS_TIMEOUT)
+
+
+def check_call_no_stdout_no_stderr(cmd):
+  """
+  <Purpose>
+    Run the specified command, WITHOUT writing to standard input, output, and
+    error.  However, note that we DO check whether the command returned a
+    non-zero code.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str)
+
+  <Exceptions>
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds.
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A subprocess.CompletedProcess instance.
+
+  """
+  cmd = shlex_split(cmd)
+  return subprocess.check_call(cmd, stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL, timeout=SUBPROCESS_TIMEOUT)
+
+
+def check_call_write_stdin_pipe_stdout(cmd, content, universal_newlines=False):
+  """
+  <Purpose>
+    Run the specified command, WITH writing the given input to standard input,
+    WITH writing to standard output, and WITHOUT writing to standard error.
+    Note that we DO check whether the command returned a non-zero code.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str)
+
+    content:
+            The content to write to the process stdin. (bytes if
+            universal_newlines=False, otherwise str)
+
+    universal_newlines:
+            If False, then the given input must be encoded as bytes; otherwise,
+            as a string.
+
+  <Exceptions>
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds.
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A subprocess.CompletedProcess instance.
+
+  """
+  cmd = shlex_split(cmd)
+  return subprocess.run(cmd, input=content, stdout=subprocess.PIPE,
+      stderr=subprocess.DEVNULL, timeout=SUBPROCESS_TIMEOUT,
+      universal_newlines=universal_newlines, check=True)
+
+
+def check_output_no_stdin_no_stderr(cmd, universal_newlines=False):
+  """
+  <Purpose>
+    Run the specified command, WITHOUT writing to standard input, output, and
+    error. However, we DO extract the output of the command. Also, note that we
+    DO check whether the command returned a non-zero code.
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str)
+
+    universal_newlines:
+            If False, then the output is encoded as bytes; otherwise, as a
+            string.
+
+  <Exceptions>
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds.
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A subprocess.CompletedProcess instance.
+
+  """
+  cmd = shlex_split(cmd)
+  return subprocess.check_output(cmd, stderr=subprocess.DEVNULL,
+    timeout=SUBPROCESS_TIMEOUT, universal_newlines=universal_newlines)
+
+

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -1,3 +1,26 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  process.py
+
+<Author>
+  Trishank Karthik Kuppusamy <trishank.kuppusamy@datadoghq.com>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  September 25, 2018
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provide a common interface for Python's subprocess module to:
+
+  - require the Py3 subprocess backport `subprocess32` on Python2,
+  - in-toto namespace subprocess constants (DEVNULL, PIPE) and
+  - provide a custom `subprocess.run` wrapper
+
+"""
 import logging
 import shlex
 

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -5,7 +5,7 @@ import sys
 
 import six
 
-if os.name == 'posix' and sys.version_info[0] < 3:
+if sys.version_info[0] < 3:
   import subprocess32 as subprocess # pragma: no cover
 else: # pragma: no cover
   import subprocess

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -300,11 +300,14 @@ def execute_link(link_cmd_args, record_streams):
     - The return value of the executed command.
   """
   if record_streams:
-    process = in_toto.process.run_pipe_stdout_pipe_stderr(link_cmd_args)
+    process = in_toto.process.run(link_cmd_args, check=False,
+      stdout=in_toto.process.PIPE, stderr=in_toto.process.PIPE,
+      universal_newlines=True)
     stdout_str, stderr_str = process.stdout, process.stderr
 
   else:
-    process = in_toto.process.run_no_stdout_no_stderr(link_cmd_args)
+    process = in_toto.process.run(link_cmd_args, check=False,
+      stdout=in_toto.process.DEVNULL, stderr=in_toto.process.DEVNULL)
     stdout_str = stderr_str = ""
 
   return {

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -24,15 +24,15 @@
     - Return Metablock containing a Link object which can be can be signed
       and stored to disk
 """
-import sys
-import os
 import glob
 import logging
+import os
 
 from pathspec import PathSpec
 
 import in_toto.settings
 import in_toto.exceptions
+import in_toto.process
 from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
     FILENAME_FORMAT_SHORT, UNFINISHED_FILENAME_FORMAT_GLOB)
 
@@ -45,19 +45,6 @@ from in_toto.models.metadata import Metablock
 
 # Inherits from in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger(__name__)
-
-
-# POSIX users (Linux, BSD, etc.) are strongly encouraged to
-# install and use the much more recent subprocess32
-if os.name == 'posix' and sys.version_info[0] < 3: # pragma: no cover
-  try:
-    import subprocess32 as subprocess
-  except ImportError:
-    log.warning("POSIX users (Linux, BSD, etc.) are strongly encouraged to"
-        " install and use the much more recent subprocess32")
-    import subprocess
-else: # pragma: no cover
-  import subprocess
 
 
 def _hash_artifact(filepath, hash_algorithms=None):
@@ -312,22 +299,18 @@ def execute_link(link_cmd_args, record_streams):
       Note: If record_streams is False, the dict values are empty strings.
     - The return value of the executed command.
   """
-  # TODO: Properly duplicate standard streams (issue #11)
   if record_streams:
-    process = subprocess.Popen(link_cmd_args, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, universal_newlines=True)
-
-    stdout_str, stderr_str = process.communicate()
-    return_value = process.returncode
+    process = in_toto.process.run_pipe_stdout_pipe_stderr(link_cmd_args)
+    stdout_str, stderr_str = process.stdout, process.stderr
 
   else:
-    return_value = subprocess.call(link_cmd_args)
+    process = in_toto.process.run_no_stdout_no_stderr(link_cmd_args)
     stdout_str = stderr_str = ""
 
   return {
       "stdout": stdout_str,
       "stderr": stderr_str,
-      "return-value": return_value
+      "return-value": process.returncode
     }
 
 

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -43,4 +43,4 @@ ARTIFACT_BASE_PATH = None
 
 # If the process does not terminate after timeout seconds, a
 # subprocess.TimeoutExpired exception will be raised.
-SUBPROCESS_TIMEOUT = 5
+SUBPROCESS_TIMEOUT = 3

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -40,3 +40,7 @@ ARTIFACT_EXCLUDE_PATTERNS = ["*.link*", ".git", "*.pyc", "*~"]
 # If not set the current working directory is used as base path
 # FIXME: Do we want different base paths for materials and products?
 ARTIFACT_BASE_PATH = None
+
+# If the process does not terminate after timeout seconds, a
+# subprocess.TimeoutExpired exception will be raised.
+SUBPROCESS_TIMEOUT = 5

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,1 +1,0 @@
-subprocess32

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-dateutil
 iso8601
 six
 pathspec
-subprocess32
+subprocess32; python_version < '3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dateutil
 iso8601
 six
 pathspec
+subprocess32

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests",
       "debian"]),
   install_requires=["six", "securesystemslib[crypto,pynacl]>=0.11.2", "attrs",
-                    "python-dateutil", "iso8601", "pathspec"],
+                    "python-dateutil", "iso8601", "pathspec", "subprocess32"],
   test_suite="tests.runtests",
   entry_points={
     "console_scripts": ["in-toto-run = in_toto.in_toto_run:main",

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,9 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests",
       "debian"]),
   install_requires=["six", "securesystemslib[crypto,pynacl]>=0.11.3", "attrs",
-                    "python-dateutil", "iso8601", "pathspec", "subprocess32"],
+                    "python-dateutil", "iso8601", "pathspec",
+                    "subprocess32; python_version < '3'"],
   test_suite="tests.runtests",
   entry_points={
     "console_scripts": ["in-toto-run = in_toto.in_toto_run:main",

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -32,10 +32,10 @@ def check_usable_gpg():
     # good idea to import anything from the module to be tested here, as
     # it messes up the module cache when running the tests, eventually leading
     # to unexpected code coverage results
-    subprocess.check_call(['gpg', '--version'], stdout=subprocess.DEVNULL)
-  # sadly, this will through either a WindowsError or a FileNotFound error
-  # so we need to catch a generic exception
-  except Exception as e:
+    with open(os.devnull, "w") as dev_null_fp:
+      subprocess.check_call(['gpg', '--version'], stdout=dev_null_fp)
+
+  except (WindowsError, FileNotFound) as e:
     os.environ["TEST_SKIP_GPG"] = "1"
 
 # set the test prerrequisites (so far, we only check if gpg is installed)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -28,7 +28,11 @@ def check_usable_gpg():
       require gpg to be installed
   """
   try:
-    subprocess.check_call(['gpg', '--version'])
+    # NOTE: We do have a custom in-toto process module but IIRC it is not a
+    # good idea to import anything from the module to be tested here, as
+    # it messes up the module cache when running the tests, eventually leading
+    # to unexpected code coverage results
+    subprocess.check_call(['gpg', '--version'], stdout=subprocess.DEVNULL)
   # sadly, this will through either a WindowsError or a FileNotFound error
   # so we need to catch a generic exception
   except Exception as e:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""
+<Program Name>
+  test_process.py
+
+<Author>
+  Lukas Puehringer <lukas.puehringer@nyu.edu>
+
+<Started>
+  Oct 4, 2018
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test subprocess interface.
+
+"""
+import os
+import tempfile
+import unittest
+import in_toto.process
+
+
+class Test_Process(unittest.TestCase):
+  """Test subprocess interface. """
+
+  def test_input_vs_stdin(self):
+    """Test that stdin kwarg is only used if input kwarg is not supplied. """
+
+    # Create a temporary file, passed as `stdin` argument
+    fd, path = tempfile.mkstemp(text=True)
+    os.write(fd, b"use stdin kwarg")
+    os.close(fd)
+
+    stdin_file = open(path)
+    cmd = \
+        "python -c \"import sys; assert(sys.stdin.read() == '{}')\""
+
+    # input is used in favor of stdin
+    in_toto.process.run(cmd.format("use input kwarg"),
+        input=b"use input kwarg",
+        stdin=stdin_file)
+
+    # stdin is only used if input is not supplied
+    in_toto.process.run(cmd.format("use stdin kwarg"), stdin=stdin_file)
+
+    # Clean up
+    stdin_file.close()
+    os.remove(path)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-# To run an individual testenvironment run e.g. tox -e py34
+# To run an individual test environment run e.g. tox -e py27
 [tox]
 envlist = py{27,35,36,37}
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 # To run an individual testenvironment run e.g. tox -e py34
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,35,36,37}
 
 [testenv]
 deps =


### PR DESCRIPTION
Takes over #227 and addresses most of the comments discussed there.

**Fixes issue #**:
#219

**Description of the changes being introduced by the pull request**:
  Provide a common interface for Python's `subprocess` module to:

  - require the Py3 subprocess backport `subprocess32` on Python2 in a single place,
  - in-toto namespace subprocess constants (DEVNULL, PIPE) and
  - provide a custom `subprocess.run` wrapper

See commit messages for more details.

**THIS PR ALSO CHANGES SUPPORTED PYTHON VERSIONS**
Drops Python 3.4 support and adds Python 3.7. Former is for easy use of `subprocess.run` which was added in Python 3.5.
If we realize that we need 3.4, we would have to find an alternative for `subprocess.run` or provide a custom  implementation of it, which should not be hard because it is only a [tiny wrapper](https://github.com/python/cpython/blob/3.5/Lib/subprocess.py#L378-L399) around `subprocess.Popen`. However we would also need to adopt [`subprocess.CompletedProcess`](https://github.com/python/cpython/blob/3.5/Lib/subprocess.py#L319-L349) and [`subprocess.CalledProcessError`](https://github.com/python/cpython/blob/3.5/Lib/subprocess.py#L60-L85), which are new in Python 3.5 and required by `subprocess.run`.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


