### PR TITLE
Buffer in-toto logging while testing and show on fail

### DIFF
--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -15,11 +15,15 @@
   aggregates all the constant definitions and lookup structures for signature
   handling
 """
+import logging
 
 import in_toto.gpg.rsa as rsa
 import in_toto.gpg.dsa as dsa
 
 import in_toto.process as process
+
+# Inherits from in_toto base logger (c.f. in_toto.log)
+log = logging.getLogger(__name__)
 
 # By default, we assume and test that gpg2 exists. Otherwise, we assume gpg
 # exists.
@@ -29,8 +33,12 @@ GPG_VERSION_COMMAND = GPG_COMMAND + " --version"
 FULLY_SUPPORTED_MIN_VERSION = "2.1.0"
 
 try:
-  process.run(GPG_VERSION_COMMAND, stdout=process.DEVNULL,
-    stderr=process.DEVNULL)
+  proc = process.run(GPG_VERSION_COMMAND, stdout=process.PIPE,
+    stderr=process.PIPE)
+
+  # TODO: Remove debug statements after fixing in-toto/in-toto#171
+  log.debug("{0} (stdout):{1}".format(GPG_VERSION_COMMAND, proc.stdout))
+  log.debug("{0} (stderr):{1}".format(GPG_VERSION_COMMAND, proc.stderr))
 except OSError: # pragma: no cover
   GPG_COMMAND = "gpg"
   GPG_VERSION_COMMAND = GPG_COMMAND + " --version"

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -89,7 +89,12 @@ def gpg_sign_object(content, keyid=None, homedir=None):
 
   command = GPG_SIGN_COMMAND.format(keyarg=keyarg, homearg=homearg)
   process = in_toto.process.run(command, input=content,
-    stdout=in_toto.process.PIPE, stderr=in_toto.process.DEVNULL)
+    stdout=in_toto.process.PIPE, stderr=in_toto.process.PIPE)
+
+  # TODO: Remove debug statements after fixing in-toto/in-toto#171
+  log.debug("{0} (stdout):{1}".format(command, process.stdout))
+  log.debug("{0} (stderr):{1}".format(command, process.stderr))
+
   signature_data = process.stdout
   signature = in_toto.gpg.common.parse_signature_packet(signature_data)
 
@@ -227,7 +232,12 @@ def gpg_export_pubkey(keyid, homedir=None):
 
   command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
   process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
-    stderr=in_toto.process.DEVNULL)
+    stderr=in_toto.process.PIPE)
+
+  # TODO: Remove debug statements after fixing in-toto/in-toto#171
+  log.debug("{0} (stdout):{1}".format(command, process.stdout))
+  log.debug("{0} (stderr):{1}".format(command, process.stderr))
+
   key_packet = process.stdout
   key_bundle = in_toto.gpg.common.parse_pubkey_bundle(key_packet, keyid)
 

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -17,6 +17,7 @@
 import struct
 import binascii
 import re
+import logging
 
 from distutils.version import StrictVersion # pylint: disable=no-name-in-module,import-error
 
@@ -25,6 +26,9 @@ import cryptography.hazmat.primitives.hashes as hashing
 
 import in_toto.gpg.exceptions
 import in_toto.process
+
+# Inherits from in_toto base logger (c.f. in_toto.log)
+log = logging.getLogger(__name__)
 
 def get_mpi_length(data):
   """
@@ -215,7 +219,12 @@ def get_version():
   """
   command = in_toto.gpg.constants.GPG_VERSION_COMMAND
   process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
-    stderr=in_toto.process.DEVNULL, universal_newlines=True)
+    stderr=in_toto.process.PIPE, universal_newlines=True)
+
+  # TODO: Remove debug statements after fixing in-toto/in-toto#171
+  log.debug("{0} (stdout):{1}".format(command, process.stdout))
+  log.debug("{0} (stderr):{1}".format(command, process.stderr))
+
   full_version_info = process.stdout
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,29 @@
-import in_toto
+import sys
 import logging
+import in_toto
 
-# Override in-toto logger default StreamHandler to prevent test log inundation
-in_toto.log.logger.handlers = [logging.NullHandler()]
+class CapturableStreamHandler(logging.StreamHandler):
+  """Override logging.StreamHandler's stream property to always write log
+  output to `sys.stderr` available at the time of logging.
+  """
+  @property
+  def stream(self):
+    """Always use currently available sys.stderr. """
+    return sys.stderr
+
+  @stream.setter
+  def stream(self, value):
+    """Disable setting stream. """
+    pass
+
+# Python `unittest` is configured to buffer output to `sys.stdout/sys.stderr`
+# (see `TextTestRunner` in `tests/runtests.py`) and only show it in case a test
+# fails. Python `unittest` buffers output by overriding `sys.stdout/sys.stderr`
+# before running tests, hence we need to log to that overridden `sys.stderr`,
+# which we do by using a custom StreamHandler.
+handler = CapturableStreamHandler()
+# We also use a verbose logging level and format
+formatter = logging.Formatter(in_toto.log._FORMAT_DEBUG)
+handler.setFormatter(formatter)
+in_toto.log.logger.handlers = [handler]
+in_toto.log.logger.setLevel(logging.DEBUG)

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -22,12 +22,15 @@ import unittest
 import argparse
 import shutil
 import tempfile
+import logging
 from mock import patch
 
 from in_toto.in_toto_mock import main as in_toto_mock_main
 
 import tests.common
 
+# Required to cache and restore default log level
+logger = logging.getLogger("in_toto")
 
 
 class TestInTotoMockTool(tests.common.CliTestCase):
@@ -39,6 +42,11 @@ class TestInTotoMockTool(tests.common.CliTestCase):
   def setUpClass(self):
     """Create and change into temporary directory,
     dummy artifact and base arguments. """
+
+    # Below tests override the base logger ('in_toto') log level to
+    # `logging.INFO`. We cache the original log level before running the tests
+    # to restore it afterwards.
+    self._base_log_level = logger.level
 
     self.working_dir = os.getcwd()
 
@@ -56,6 +64,9 @@ class TestInTotoMockTool(tests.common.CliTestCase):
     """Change back to initial working dir and remove temp test directory. """
     os.chdir(self.working_dir)
     shutil.rmtree(self.test_dir)
+
+    # Restore log level to what it was before running in-toto-mock
+    logger.setLevel(self._base_log_level)
 
   def tearDown(self):
     try:

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -156,7 +156,7 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
 
     # Fail with an explicit link directory, where no links are found
     args = ["--layout", self.layout_single_signed_path,
-        "--layout-keys", self.alice_path, "--link-dir", "bad-link-dir", "-v"]
+        "--layout-keys", self.alice_path, "--link-dir", "bad-link-dir"]
     self.assert_cli_sys_exit(args, 1)
 
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:
Related to #171 

**Description of the changes being introduced by the pull request**:
In  #183 we disabled all logging by replacing in_toto's base logger's `StreamHandler` with a `NullHandler` while testing. While this eliminated test log inundation, it was not helpful to troubleshoot failing tests, such as #171 .

Ideally, all logging output is buffered and only displayed in case a test fails. Python's [`unittest` framework provides such a `buffer` option, which we already use](https://github.com/in-toto/in-toto/blob/a613af932ae217724a918c91b0f8cd9f786bb6ec/tests/runtests.py#L45). It does this by overriding `sys.stdout` and `sys.stderr` before running tests.

This PR implements a  custom logging `StreamHandler` for our tests that always uses the currently available `sys.stderr` (e.g. as overridden by `unittest`) . 


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


