### PR TITLE
FIX: gpg/rsa: fix #170 signature length bug

### DIFF
--- a/in_toto/gpg/constants.py
+++ b/in_toto/gpg/constants.py
@@ -36,9 +36,6 @@ try:
   proc = process.run(GPG_VERSION_COMMAND, stdout=process.PIPE,
     stderr=process.PIPE)
 
-  # TODO: Remove debug statements after fixing in-toto/in-toto#171
-  log.debug("{0} (stdout):{1}".format(GPG_VERSION_COMMAND, proc.stdout))
-  log.debug("{0} (stderr):{1}".format(GPG_VERSION_COMMAND, proc.stderr))
 except OSError: # pragma: no cover
   GPG_COMMAND = "gpg"
   GPG_VERSION_COMMAND = GPG_COMMAND + " --version"

--- a/in_toto/gpg/functions.py
+++ b/in_toto/gpg/functions.py
@@ -91,10 +91,6 @@ def gpg_sign_object(content, keyid=None, homedir=None):
   process = in_toto.process.run(command, input=content,
     stdout=in_toto.process.PIPE, stderr=in_toto.process.PIPE)
 
-  # TODO: Remove debug statements after fixing in-toto/in-toto#171
-  log.debug("{0} (stdout):{1}".format(command, process.stdout))
-  log.debug("{0} (stderr):{1}".format(command, process.stderr))
-
   signature_data = process.stdout
   signature = in_toto.gpg.common.parse_signature_packet(signature_data)
 
@@ -233,10 +229,6 @@ def gpg_export_pubkey(keyid, homedir=None):
   command = GPG_EXPORT_PUBKEY_COMMAND.format(keyid=keyid, homearg=homearg)
   process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
     stderr=in_toto.process.PIPE)
-
-  # TODO: Remove debug statements after fixing in-toto/in-toto#171
-  log.debug("{0} (stdout):{1}".format(command, process.stdout))
-  log.debug("{0} (stderr):{1}".format(command, process.stderr))
 
   key_packet = process.stdout
   key_bundle = in_toto.gpg.common.parse_pubkey_bundle(key_packet, keyid)

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -221,10 +221,6 @@ def get_version():
   process = in_toto.process.run(command, stdout=in_toto.process.PIPE,
     stderr=in_toto.process.PIPE, universal_newlines=True)
 
-  # TODO: Remove debug statements after fixing in-toto/in-toto#171
-  log.debug("{0} (stdout):{1}".format(command, process.stdout))
-  log.debug("{0} (stderr):{1}".format(command, process.stderr))
-
   full_version_info = process.stdout
   version_string = re.search(r'(\d\.\d\.\d+)', full_version_info).group(1)
 


### PR DESCRIPTION
It appears the specification for PKCSv1.5 doesn't say how long should a
signature should be (i.e., should we zero-pad the signature or should we
use the minimum number of bits required). In this case, signatures
generated using gnupg would sometimes be 8*n bits shorter than the
public key length, which would result in signatures that fail to verify
due to missing leading zeroes (the leading zeroes existed at the bit
level however).

Zero-left-pad signature objects that do not match the length of the exponent
`n` on a gpg rsa public key object before verification.

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature:
   I don't want to add a test for this on the interest of runtime of the test-suite, but I'm open to ideas on how to test this..
- [x] Docs have been added for the bug fix or new feature:
   I left a big comment warning future in-toto developers in their pilgrimage through the innards of RFC3447 and RFC4880...


