### PR TITLE
Remove unnecessary pass in custom exception classes

### DIFF
--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -2,29 +2,22 @@ from securesystemslib.exceptions import Error
 
 class SignatureVerificationError(Error):
   """Indicates a signature verification Error. """
-  pass
 
 class LayoutExpiredError(Error):
   """Indicates that the layout expired. """
-  pass
 
 class RuleVerificationError(Error):
   """Indicates that artifact rule verification failed. """
-  pass
 
 class ThresholdVerificationError(Error):
   """Indicates that signature threshold verification failed. """
-  pass
 
 class BadReturnValueError(Error):
   """Indicates that a ran command exited with non-int or non-zero return
   value. """
-  pass
 
 class LinkNotFoundError(Error):
   """Indicates that a link file was not found. """
-  pass
 
 class UnsupportedKeyTypeError(Error):
   """Indicates that the specified key type is not yet supported. """
-  pass


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
Python stubs with a docstring and no body do not require `pass`. Moreover, since pylint 2.2 (released on 2018-11-25) an unnecessary pass is flagged. See [`unnecessary-pass` in pylint changelog](http://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-2).

This PR removes those unnecessary pass statements.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


