### PR TITLE
Update command descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ To learn more about the different rule types, their guarantees and how they are 
 `in-toto-run` generates link metadata for the given command-line option and 
 runs it as its own command. See the [this simple usage example from the demo 
 application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). 
-For a detailed list of all the arguments, run `in-toto-run --help` or look at 
-the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
+For a detailed list of all the command line arguments, run `in-toto-run --help` 
+or look at the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -79,9 +79,9 @@ by a single command. Use `in-toto-record start ...` to create a
 preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
-link metadata file. For a detailed list of all arguments, run `in-toto-record start --help`
-or `in-toto-record stop --help`. You can also find the documentation 
-[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
+link metadata file. For a detailed list of all command line arguments and their usage,
+run `in-toto-record start --help` or `in-toto-record stop --help`. You can also 
+find the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product
 
@@ -97,8 +97,9 @@ Use `in-toto-verify` on the final product to verify that
 - materials and products of each step were in place as defined by the rules, and
 - run the defined inspections
 
-For a detailed list of arguments and usage, run `in-toto-verify --help` or look 
-at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
+For a detailed list of all command line arguments and their usage, run 
+`in-toto-verify --help` or look at the code documentation 
+[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
 
 #### Signatures
 `in-toto-sign`, unlike `in-toto-verify`, can only add, replace, and 
@@ -114,8 +115,9 @@ This tool is intended to sign layouts created by the layout web wizard, but
 also serves well to re-sign test and demo data. For example, it can be used 
 if metadata formats or signing routines change.
 
-For a detailed list of arguments and usage, run `in-toto-sign --help` or look 
-at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
+For a detailed list of all command line arguments and their usage, run 
+`in-toto-sign --help` or look at the code documentation 
+[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
 
 #### Settings
 Settings can be configured in [`in_toto.settings`](https://github.com/in-toto/in-toto/blob/develop/in_toto/settings.py), via prefixed environment variables or in RCfiles in one of the following

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To learn more about the different rule types, their guarantees and how they are 
 ##### in-toto-run
 `in-toto-run` generates link metadata for the given command-line option and 
 runs it as its own command. See [this simple usage example from the demo application 
-for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). 
+for more details](https://github.com/in-toto/demo). 
 For a detailed list of all the command line arguments, run `in-toto-run --help` 
 or look at the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` is used to execute a step in the software supply chain. This can be
-anything relevant to the project such as tagging a release with `git`, running
-a test, or building a binary. The relevant step name and command are
+`in-toto-run` is used to execute a step in the software supply chain. This can
+be anything relevant to the project such as tagging a release with `git`,
+running a test, or building a binary. The relevant step name and command are
 passed as arguments, along with materials, which are files required for that
 step's command to execute, and products which are files expected as a result
 of the execution of that command. These, and other relevant details

--- a/README.md
+++ b/README.md
@@ -66,20 +66,7 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` generates link metadata for the given command-line option and runs it as its own command. See the [this simple usage example from the demo application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain).
-
-```shell
-in-toto-run  --step-name <unique step name>
-            {--key <functionary signing key path>,  --gpg [<functionary gpg signing key id>]}
-            [--gpg-home <path to gpg keyring>]
-            [--base-path <filepath>]
-            [--materials <filepath>[ <filepath> ...]]
-            [--products <filepath>[ <filepath> ...]]
-            [--record-streams]
-            [--no-command]
-            [--verbose] -- <cmd> [args]
-```
-
+`in-toto-run` generates link metadata for the given command-line option and runs it as its own command. See the [this simple usage example from the demo application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). For a detailed list of all the arguments, run `in-toto-run -help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -88,21 +75,8 @@ by a single command. Use `in-toto-record start ...` to create a
 preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
-link metadata file.
-
-```shell
-usage: in-toto-record start --step-name <unique step name>
-                            (--key <signing key path> | --gpg [<gpg keyid>])
-                            [--gpg-home <gpg keyring path>] [-v]
-                            [--base-path <filepath>]
-                            [--materials <material path> [<material path> ...]]
-
-usage: in-toto-record stop -step-name <unique step name>
-                           (--key <signing key path> | --gpg [<gpg keyid>])
-                           [--gpg-home <gpg keyring path>] [-v]
-                           [--base-path <filepath>]
-                           [--products <product path> [<product path> ...]]
-```
+link metadata file. For a detailed list of all arguments, run 'in-toto-record start --help`
+or `in-toto-record stop --help`. You can also find the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ To learn more about the different rule types, their guarantees and how they are 
 
 ##### in-toto-run
 
-`in-toto-run` is used to execute one of the software supply chain steps. The 
-relevant step name and command are passed as arguments, along with materials, 
-which are files required for command execution, and products which are files
-expected as a result of the execution of the command. These, and other 
-relevant details pertaining to the step are stored in a link file, which is 
-signed using the functionary's key.
+`in-toto-run` is used to execute a step in the software supply chain. This can be 
+anything relevant to the project such as tagging a release with `git`, running 
+a test, or building a binary to ship. The relevant step name and command are 
+passed as arguments, along with materials, which are files required for that 
+step's command to execute, and products which are files expected as a result 
+of the execution of that command. These, and other relevant details 
+pertaining to the step are stored in a link file, which is signed using the 
+functionary's key. If materials are not passed to the command, the link file 
+generated just doesn't record them.
 
 See [this simple usage example from the demo application 
 for more details](https://github.com/in-toto/demo). 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ generated just doesn't record them.
 See [this simple usage example from the demo application
 for more details](https://github.com/in-toto/demo).
 For a detailed list of all the command line arguments, run `in-toto-run --help`
-or look at the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py) here.
+or look at the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -90,8 +90,7 @@ commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
 link metadata file. For a detailed list of all command line arguments and their usage,
 run `in-toto-record start --help` or `in-toto-record stop --help`. You can also
-find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py)
-here.
+find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product
 
@@ -109,8 +108,7 @@ Use `in-toto-verify` on the final product to verify that
 
 For a detailed list of all command line arguments and their usage, run
 `in-toto-verify --help` or look at the
-[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py)
-here.
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
 
 #### Signatures
 `in-toto-sign` is a metadata signature helper tool to add, replace, and
@@ -129,8 +127,7 @@ formats or signing routines change.
 
 For a detailed list of all command line arguments and their usage, run
 `in-toto-sign --help` or look at the
-[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py)
-here.
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
 
 #### Settings
 Settings can be configured in [`in_toto.settings`](https://github.com/in-toto/in-toto/blob/develop/in_toto/settings.py), via prefixed environment variables or in RCfiles in one of the following

--- a/README.md
+++ b/README.md
@@ -66,8 +66,15 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` generates link metadata for the given command-line option and 
-runs it as its own command. See [this simple usage example from the demo application 
+
+`in-toto-run` is used to execute one of the software supply chain steps. The 
+relevant step name and command are passed as arguments, along with materials, 
+which are files required for command execution, and products which are files
+expected as a result of the execution of the command. These, and other 
+relevant details pertaining to the step are stored in a link file, which is 
+signed using the functionary's key.
+
+See [this simple usage example from the demo application 
 for more details](https://github.com/in-toto/demo). 
 For a detailed list of all the command line arguments, run `in-toto-run --help` 
 or look at the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ step's command to execute, and products which are files expected as a result
 of the execution of that command. These, and other relevant details
 pertaining to the step are stored in a link file, which is signed using the
 functionary's key. If materials are not passed to the command, the link file
-generated just doesn't record them.
+generated just doesn't record them. Similarly, if the execution of a command
+via `in-toto-run` doesn't result in any products, they're not recorded in the
+link file.
 
 See [this simple usage example from the demo application
 for more details](https://github.com/in-toto/demo).

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ layout metadata is written to the path of the input file while link metadata
 is written to '&lt;name&gt;.&lt;keyid prefix&gt;.link')
 - verify signatures
 
-This tool is intended to sign layouts created by the layout web wizard, but 
-also serves well to re-sign test and demo data. For example, it can be used 
-if metadata formats or signing routines change.
+This tool is intended to sign layouts created by the 
+[layout web wizard](https://in-toto.engineering.nyu.edu/), but also serves 
+well to re-sign test and demo data. For example, it can be used if metadata 
+formats or signing routines change.
 
 For a detailed list of all command line arguments and their usage, run 
 `in-toto-sign --help` or look at the 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` generates link metadata for the given command-line option and runs it as its own command. See the [this simple usage example from the demo application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). For a detailed list of all the arguments, run `in-toto-run --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
+`in-toto-run` generates link metadata for the given command-line option and 
+runs it as its own command. See the [this simple usage example from the demo 
+application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). 
+For a detailed list of all the arguments, run `in-toto-run --help` or look at 
+the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -76,7 +80,8 @@ preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
 link metadata file. For a detailed list of all arguments, run `in-toto-record start --help`
-or `in-toto-record stop --help`. You can also find the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
+or `in-toto-record stop --help`. You can also find the documentation 
+[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product
 
@@ -92,16 +97,25 @@ Use `in-toto-verify` on the final product to verify that
 - materials and products of each step were in place as defined by the rules, and
 - run the defined inspections
 
-For a detailed list of arguments and usage, run `in-toto-verify --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
+For a detailed list of arguments and usage, run `in-toto-verify --help` or look 
+at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
 
 #### Signatures
-`in-toto-sign`, unlike `in-toto-verify`, can only add, replace, and verify signatures within in-toto Link or Layout metadata, with options to
-- replace (default) or add signature(s), with layout metadata able to be signed by multiple keys at once while link metadata can only be signed by one key at a time
-- write signed metadata to a specified path (if no output path is specified, layout metadata is written to the path of the input file while link metadata is written to '<name>.<keyid prefix>.link')
+`in-toto-sign`, unlike `in-toto-verify`, can only add, replace, and 
+verify signatures within in-toto Link or Layout metadata, with options to
+- replace (default) or add signature(s), with layout metadata able to be 
+signed by multiple keys at once while link metadata can only be signed by one key at a time
+- write signed metadata to a specified path (if no output path is specified, 
+layout metadata is written to the path of the input file while link metadata 
+is written to '<name>.<keyid prefix>.link')
 - verify signatures
-This tool is intended to sign layouts created by the layout web wizard, but also serves well to re-sign test and demo data. For example, it can be used if metadata formats or signing routines change.
 
-For a detailed list of arguments and usage, run `in-toto-sign --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
+This tool is intended to sign layouts created by the layout web wizard, but 
+also serves well to re-sign test and demo data. For example, it can be used 
+if metadata formats or signing routines change.
+
+For a detailed list of arguments and usage, run `in-toto-sign --help` or look 
+at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
 
 #### Settings
 Settings can be configured in [`in_toto.settings`](https://github.com/in-toto/in-toto/blob/develop/in_toto/settings.py), via prefixed environment variables or in RCfiles in one of the following

--- a/README.md
+++ b/README.md
@@ -92,12 +92,7 @@ Use `in-toto-verify` on the final product to verify that
 - materials and products of each step were in place as defined by the rules, and
 - run the defined inspections
 
-```shell
-in-toto-verify --layout <layout path>
-               {--layout-keys <filepath>[ <filepath> ...],  --gpg <keyid> [ <keyid> ...]}
-               [--gpg-home <path to gpg keyring>]
-               [--verbose]
-```
+For a detailed list of arguments and usage, run `in-toto-verify --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
 
 #### Signatures
 `in-toto-sign`, unlike `in-toto-verify`, can only add, replace, and verify signatures within in-toto Link or Layout metadata, with options to
@@ -105,11 +100,8 @@ in-toto-verify --layout <layout path>
 - write signed metadata to a specified path (if no output path is specified, layout metadata is written to the path of the input file while link metadata is written to '<name>.<keyid prefix>.link')
 - verify signatures
 This tool is intended to sign layouts created by the layout web wizard, but also serves well to re-sign test and demo data. For example, it can be used if metadata formats or signing routines change.
-```shell
-usage: in-toto-sign [-h] -f <path> [-k <path> [<path> ...]]
-                    [-t <key_type> [<key_type> ...]] [-g [<id> [<id> ...]]]
-                    [--gpg-home <path>] [-o <path>] [-a] [--verify] [-v | -q]
-```
+
+For a detailed list of arguments and usage, run `in-toto-sign --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
 
 #### Settings
 Settings can be configured in [`in_toto.settings`](https://github.com/in-toto/in-toto/blob/develop/in_toto/settings.py), via prefixed environment variables or in RCfiles in one of the following

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ generated just doesn't record them.
 See [this simple usage example from the demo application 
 for more details](https://github.com/in-toto/demo). 
 For a detailed list of all the command line arguments, run `in-toto-run --help` 
-or look at the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
+or look at the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py) here.
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -91,7 +91,8 @@ commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
 link metadata file. For a detailed list of all command line arguments and their usage,
 run `in-toto-record start --help` or `in-toto-record stop --help`. You can also 
-find the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
+find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py) 
+here.
 
 #### Release final product
 
@@ -108,8 +109,9 @@ Use `in-toto-verify` on the final product to verify that
 - run the defined inspections
 
 For a detailed list of all command line arguments and their usage, run 
-`in-toto-verify --help` or look at the code documentation 
-[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
+`in-toto-verify --help` or look at the 
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py) 
+here.
 
 #### Signatures
 `in-toto-sign` is a metadata signature helper tool to add, replace, and 
@@ -126,8 +128,9 @@ also serves well to re-sign test and demo data. For example, it can be used
 if metadata formats or signing routines change.
 
 For a detailed list of all command line arguments and their usage, run 
-`in-toto-sign --help` or look at the code documentation 
-[here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py).
+`in-toto-sign --help` or look at the 
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py) 
+here.
 
 #### Settings
 Settings can be configured in [`in_toto.settings`](https://github.com/in-toto/in-toto/blob/develop/in_toto/settings.py), via prefixed environment variables or in RCfiles in one of the following

--- a/README.md
+++ b/README.md
@@ -66,19 +66,19 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` is used to execute a step in the software supply chain. This can be 
-anything relevant to the project such as tagging a release with `git`, running 
-a test, or building a binary to ship. The relevant step name and command are 
-passed as arguments, along with materials, which are files required for that 
-step's command to execute, and products which are files expected as a result 
-of the execution of that command. These, and other relevant details 
-pertaining to the step are stored in a link file, which is signed using the 
-functionary's key. If materials are not passed to the command, the link file 
+`in-toto-run` is used to execute a step in the software supply chain. This can be
+anything relevant to the project such as tagging a release with `git`, running
+a test, or building a binary to ship. The relevant step name and command are
+passed as arguments, along with materials, which are files required for that
+step's command to execute, and products which are files expected as a result
+of the execution of that command. These, and other relevant details
+pertaining to the step are stored in a link file, which is signed using the
+functionary's key. If materials are not passed to the command, the link file
 generated just doesn't record them.
 
-See [this simple usage example from the demo application 
-for more details](https://github.com/in-toto/demo). 
-For a detailed list of all the command line arguments, run `in-toto-run --help` 
+See [this simple usage example from the demo application
+for more details](https://github.com/in-toto/demo).
+For a detailed list of all the command line arguments, run `in-toto-run --help`
 or look at the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py) here.
 
 ##### in-toto-record
@@ -89,8 +89,8 @@ preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
 link metadata file. For a detailed list of all command line arguments and their usage,
-run `in-toto-record start --help` or `in-toto-record stop --help`. You can also 
-find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py) 
+run `in-toto-record start --help` or `in-toto-record stop --help`. You can also
+find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py)
 here.
 
 #### Release final product
@@ -107,29 +107,29 @@ Use `in-toto-verify` on the final product to verify that
 - materials and products of each step were in place as defined by the rules, and
 - run the defined inspections
 
-For a detailed list of all command line arguments and their usage, run 
-`in-toto-verify --help` or look at the 
-[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py) 
+For a detailed list of all command line arguments and their usage, run
+`in-toto-verify --help` or look at the
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py)
 here.
 
 #### Signatures
-`in-toto-sign` is a metadata signature helper tool to add, replace, and 
+`in-toto-sign` is a metadata signature helper tool to add, replace, and
 verify signatures within in-toto Link or Layout metadata, with options to:
-- replace (default) or add signature(s), with layout metadata able to be 
+- replace (default) or add signature(s), with layout metadata able to be
 signed by multiple keys at once while link metadata can only be signed by one key at a time
-- write signed metadata to a specified path (if no output path is specified, 
-layout metadata is written to the path of the input file while link metadata 
+- write signed metadata to a specified path (if no output path is specified,
+layout metadata is written to the path of the input file while link metadata
 is written to '&lt;name&gt;.&lt;keyid prefix&gt;.link')
 - verify signatures
 
-This tool is intended to sign layouts created by the 
-[layout web wizard](https://in-toto.engineering.nyu.edu/), but also serves 
-well to re-sign test and demo data. For example, it can be used if metadata 
+This tool is intended to sign layouts created by the
+[layout web wizard](https://in-toto.engineering.nyu.edu/), but also serves
+well to re-sign test and demo data. For example, it can be used if metadata
 formats or signing routines change.
 
-For a detailed list of all command line arguments and their usage, run 
-`in-toto-sign --help` or look at the 
-[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py) 
+For a detailed list of all command line arguments and their usage, run
+`in-toto-sign --help` or look at the
+[code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_sign.py)
 here.
 
 #### Settings

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
 link metadata file. For a detailed list of all command line arguments and their usage,
-run `in-toto-record start --help` or `in-toto-record stop --help`. You can also
-find the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
+run `in-toto-record start --help` or `in-toto-record stop --help`, or look at
+the [code documentation](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ passed as arguments, along with materials, which are files required for that
 step's command to execute, and products which are files expected as a result
 of the execution of that command. These, and other relevant details
 pertaining to the step are stored in a link file, which is signed using the
-functionary's key. If materials are not passed to the command, the link file
-generated just doesn't record them. Similarly, if the execution of a command
-via `in-toto-run` doesn't result in any products, they're not recorded in the
-link file.
+functionary's key.
+
+If materials are not passed to the command, the link file generated just doesn't
+record them. Similarly, if the execution of a command via `in-toto-run` doesn't
+result in any products, they're not recorded in the link file. Similarly, any
+materials or products passed to the command are recorded in the link file even
+if they're not part of the execution of the command.
 
 See [this simple usage example from the demo application
 for more details](https://github.com/in-toto/demo).

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ For a detailed list of all command line arguments and their usage, run
 [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_verify.py).
 
 #### Signatures
-`in-toto-sign`, unlike `in-toto-verify`, can only add, replace, and 
-verify signatures within in-toto Link or Layout metadata, with options to
+`in-toto-sign` is a metadata signature helper tool to add, replace, and 
+verify signatures within in-toto Link or Layout metadata, with options to:
 - replace (default) or add signature(s), with layout metadata able to be 
 signed by multiple keys at once while link metadata can only be signed by one key at a time
 - write signed metadata to a specified path (if no output path is specified, 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ verify signatures within in-toto Link or Layout metadata, with options to
 signed by multiple keys at once while link metadata can only be signed by one key at a time
 - write signed metadata to a specified path (if no output path is specified, 
 layout metadata is written to the path of the input file while link metadata 
-is written to '<name>.<keyid prefix>.link')
+is written to '&lt;name&gt;.&lt;keyid prefix&gt;.link')
 - verify signatures
 
 This tool is intended to sign layouts created by the layout web wizard, but 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ verify signatures within in-toto Link or Layout metadata, with options to:
 signed by multiple keys at once while link metadata can only be signed by one key at a time
 - write signed metadata to a specified path (if no output path is specified,
 layout metadata is written to the path of the input file while link metadata
-is written to '&lt;name&gt;.&lt;keyid prefix&gt;.link')
+is written to `<name>.<keyid prefix>.link`)
 - verify signatures
 
 This tool is intended to sign layouts created by the

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ To learn more about the different rule types, their guarantees and how they are 
 
 ##### in-toto-run
 `in-toto-run` generates link metadata for the given command-line option and 
-runs it as its own command. See the [this simple usage example from the demo 
-application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). 
+runs it as its own command. See [this simple usage example from the demo application 
+for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). 
 For a detailed list of all the command line arguments, run `in-toto-run --help` 
 or look at the code documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-
 `in-toto-run` is used to execute a step in the software supply chain. This can be 
 anything relevant to the project such as tagging a release with `git`, running 
 a test, or building a binary to ship. The relevant step name and command are 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To learn more about the different rule types, their guarantees and how they are 
 #### Carrying out software supply chain steps
 
 ##### in-toto-run
-`in-toto-run` generates link metadata for the given command-line option and runs it as its own command. See the [this simple usage example from the demo application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). For a detailed list of all the arguments, run `in-toto-run -help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
+`in-toto-run` generates link metadata for the given command-line option and runs it as its own command. See the [this simple usage example from the demo application for more details](https://github.com/in-toto/demo#tampering-with-the-software-supply-chain). For a detailed list of all the arguments, run `in-toto-run --help` or look at the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_run.py).
 
 ##### in-toto-record
 `in-toto-record` works similar to `in-toto-run` but can be used for
@@ -75,7 +75,7 @@ by a single command. Use `in-toto-record start ...` to create a
 preliminary link file that only records the *materials*, then run the
 commands of that step or edit files manually and finally use
 `in-toto-record stop ...` to record the *products* and generate the actual
-link metadata file. For a detailed list of all arguments, run 'in-toto-record start --help`
+link metadata file. For a detailed list of all arguments, run `in-toto-record start --help`
 or `in-toto-record stop --help`. You can also find the documentation [here](https://github.com/in-toto/in-toto/blob/develop/in_toto/in_toto_record.py).
 
 #### Release final product

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To learn more about the different rule types, their guarantees and how they are 
 in-toto-run  --step-name <unique step name>
             {--key <functionary signing key path>,  --gpg [<functionary gpg signing key id>]}
             [--gpg-home <path to gpg keyring>]
+            [--base-path <filepath>]
             [--materials <filepath>[ <filepath> ...]]
             [--products <filepath>[ <filepath> ...]]
             [--record-streams]
@@ -93,11 +94,13 @@ link metadata file.
 usage: in-toto-record start --step-name <unique step name>
                             (--key <signing key path> | --gpg [<gpg keyid>])
                             [--gpg-home <gpg keyring path>] [-v]
+                            [--base-path <filepath>]
                             [--materials <material path> [<material path> ...]]
 
 usage: in-toto-record stop -step-name <unique step name>
                            (--key <signing key path> | --gpg [<gpg keyid>])
                            [--gpg-home <gpg keyring path>] [-v]
+                           [--base-path <filepath>]
                            [--products <product path> [<product path> ...]]
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To learn more about the different rule types, their guarantees and how they are 
 ##### in-toto-run
 `in-toto-run` is used to execute a step in the software supply chain. This can be
 anything relevant to the project such as tagging a release with `git`, running
-a test, or building a binary to ship. The relevant step name and command are
+a test, or building a binary. The relevant step name and command are
 passed as arguments, along with materials, which are files required for that
 step's command to execute, and products which are files expected as a result
 of the execution of that command. These, and other relevant details

--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ of the execution of that command. These, and other relevant details
 pertaining to the step are stored in a link file, which is signed using the
 functionary's key.
 
-If materials are not passed to the command, the link file generated just doesn't
-record them. Similarly, if the execution of a command via `in-toto-run` doesn't
-result in any products, they're not recorded in the link file. Similarly, any
-materials or products passed to the command are recorded in the link file even
-if they're not part of the execution of the command.
+If materials are not passed to the command, the link file generated just
+doesn't record them. Similarly, if the execution of a command via
+`in-toto-run` doesn't result in any products, they're not recorded in the link
+file. Any files that are modified or used in any way during the execution of
+the command are not recorded in the link file unless explicitly passed as
+artifacts. Conversely, any materials or products passed to the command are
+recorded in the link file even if they're not part of the execution
+of the command.
 
 See [this simple usage example from the demo application
 for more details](https://github.com/in-toto/demo).


### PR DESCRIPTION
**Fixes issue**: The base-path argument was missing from the documentation for in-toto-run and in-toto-record in the README file.

**Description of the changes being introduced by the pull request**: The argument has been added to the relevant sections.