### PR TITLE
Add capabilities to support left stripping from paths when recording artifacts

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -51,6 +51,7 @@ LSTRIP_PATHS_ARGS = ["--lstrip-paths"]
 LSTRIP_PATHS_KWARGS = {
   "dest": "lstrip_paths",
   "required": False,
+  "nargs": "+",
   "metavar": "<path>",
   "help": ("Record the path of artifacts in link metadata after left"
           " stripping the specified <path> from the full path. If"

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -51,7 +51,6 @@ LSTRIP_PATHS_ARGS = ["--lstrip-paths"]
 LSTRIP_PATHS_KWARGS = {
   "dest": "lstrip_paths",
   "required": False,
-  "nargs": 1,
   "metavar": "<path>",
   "help": ("Record the path of artifacts in link metadata after left"
           " stripping the specified <path> from the full path. If"

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -55,6 +55,8 @@ LSTRIP_PATHS_KWARGS = {
   "metavar": "<path>",
   "help": ("Record the path of artifacts in link metadata after left"
           " stripping the specified <path> from the full path. If"
-          " there are multiple prefixes specified, the longest match"
-          " is what is actually stripped from the full path.")
+          " there are multiple prefixes specified, only a single "
+           "prefix can match the path of any artifact and that is "
+           "then left stripped. All prefixes are checked to ensure none "
+           "of them are a left substring of another.")
 }

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -46,3 +46,15 @@ BASE_PATH_KWARGS = {
   "help": ("Record 'materials/products' relative to <path>. If not set,"
           " current working directory is used as base path.")
   }
+
+LSTRIP_PATHS_ARGS = ["--lstrip-paths"]
+LSTRIP_PATHS_KWARGS = {
+  "dest": "lstrip_paths",
+  "required": False,
+  "nargs": "+",
+  "metavar": "<path>",
+  "help": ("Record the path of artifacts in link metadata after left"
+          " stripping the specified <path> from the full path. If"
+          " there are multiple prefixes specified, the longest match"
+          " is what is actually stripped from the full path.")
+}

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -51,7 +51,7 @@ LSTRIP_PATHS_ARGS = ["--lstrip-paths"]
 LSTRIP_PATHS_KWARGS = {
   "dest": "lstrip_paths",
   "required": False,
-  "nargs": "+",
+  "nargs": 1,
   "metavar": "<path>",
   "help": ("Record the path of artifacts in link metadata after left"
           " stripping the specified <path> from the full path. If"

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -21,3 +21,6 @@ class LinkNotFoundError(Error):
 
 class UnsupportedKeyTypeError(Error):
   """Indicates that the specified key type is not yet supported. """
+
+class PrefixError(Error):
+  """Indicates that there is an error because of the prefixes passed. """

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -260,14 +260,14 @@ examples:
       in_toto.runlib.in_toto_record_start(args.step_name, args.materials,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns, base_path=args.base_path)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path, lstrip_paths=args.lstrip_paths)
 
     # Mutually exclusiveness is guaranteed by argparser
     else: # args.command == "stop":
       in_toto.runlib.in_toto_record_stop(args.step_name, args.products,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns, base_path=args.base_path)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path, lstrip_paths=args.lstrip_paths)
 
   except Exception as e:
     log.error("(in-toto-record {0}) {1}: {2}"

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -68,6 +68,9 @@ optional arguments:
                         for additional info.
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
+  --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
+                        from the path of every artifact that contains the prefix.
+                        Currently, the prefix is a single path.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -68,8 +68,13 @@ optional arguments:
                         for additional info.
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
-  --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
-                        from the path of every artifact that contains the prefix.
+  --lstrip-paths <path> [<path> ...]
+                        Record the path of artifacts in link metadata after left
+                        stripping the specified <path> from the full path. If
+                        there are multiple prefixes specified, only a single
+                        prefix can match the path of any artifact and that is
+                        then left stripped. All prefixes are checked to ensure none
+                        of them are a left substring of another.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -69,12 +69,12 @@ optional arguments:
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
   --lstrip-paths <path> [<path> ...]
-                        Record the path of artifacts in link metadata after left
-                        stripping the specified <path> from the full path. If
-                        there are multiple prefixes specified, only a single
-                        prefix can match the path of any artifact and that is
-                        then left stripped. All prefixes are checked to ensure none
-                        of them are a left substring of another.
+                        Record the path of artifacts in link metadata after
+                        left stripping the specified <path> from the full
+                        path. If there are multiple prefixes specified, only a
+                        single prefix can match the path of any artifact and
+                        that is then left stripped. All prefixes are checked
+                        to ensure none of them are a left substring of another.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -115,7 +115,8 @@ import in_toto.user_settings
 import in_toto.runlib
 
 from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
-    BASE_PATH_ARGS, BASE_PATH_KWARGS)
+    BASE_PATH_ARGS, BASE_PATH_KWARGS, LSTRIP_PATHS_ARGS,
+    LSTRIP_PATHS_KWARGS)
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -195,6 +196,7 @@ examples:
 
   parent_parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
   parent_parser.add_argument(*BASE_PATH_ARGS, **BASE_PATH_KWARGS)
+  parent_parser.add_argument(*LSTRIP_PATHS_ARGS, **LSTRIP_PATHS_KWARGS)
 
 
   verbosity_args = parent_parser.add_mutually_exclusive_group(required=False)

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -263,14 +263,16 @@ examples:
       in_toto.runlib.in_toto_record_start(args.step_name, args.materials,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns, base_path=args.base_path, lstrip_paths=args.lstrip_paths)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path,
+          lstrip_paths=args.lstrip_paths)
 
     # Mutually exclusiveness is guaranteed by argparser
     else: # args.command == "stop":
       in_toto.runlib.in_toto_record_stop(args.step_name, args.products,
           signing_key=key, gpg_keyid=gpg_keyid,
           gpg_use_default=gpg_use_default, gpg_home=args.gpg_home,
-          exclude_patterns=args.exclude_patterns, base_path=args.base_path, lstrip_paths=args.lstrip_paths)
+          exclude_patterns=args.exclude_patterns, base_path=args.base_path,
+          lstrip_paths=args.lstrip_paths)
 
   except Exception as e:
     log.error("(in-toto-record {0}) {1}: {2}"

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -70,7 +70,6 @@ optional arguments:
                         set, current working directory is used as base path.
   --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
                         from the path of every artifact that contains the prefix.
-                        Currently, the prefix is a single path.
   -v, --verbose         Verbose execution.
   -q, --quiet           Suppress all output.
 

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -60,6 +60,9 @@ optional arguments:
                         for additional info.
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
+  --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
+                        from the path of every artifact that contains the prefix.
+                        Currently, the prefix is a single path.
   -t {ed25519,rsa}, --key-type {ed25519,rsa}
                         Specify the key-type of the key specified by the
                         '--key' option. If '--key-type' is not passed, default

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -60,8 +60,13 @@ optional arguments:
                         for additional info.
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
-  --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
-                        from the path of every artifact that contains the prefix.
+  --lstrip-paths <path> [<path> ...]
+                        Record the path of artifacts in link metadata after left
+                        stripping the specified <path> from the full path. If
+                        there are multiple prefixes specified, only a single
+                        prefix can match the path of any artifact and that is
+                        then left stripped. All prefixes are checked to ensure none
+                        of them are a left substring of another.
   -t {ed25519,rsa}, --key-type {ed25519,rsa}
                         Specify the key-type of the key specified by the
                         '--key' option. If '--key-type' is not passed, default

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -62,7 +62,6 @@ optional arguments:
                         set, current working directory is used as base path.
   --lstrip-paths <path> If a prefix path is passed, the prefix is left stripped
                         from the path of every artifact that contains the prefix.
-                        Currently, the prefix is a single path.
   -t {ed25519,rsa}, --key-type {ed25519,rsa}
                         Specify the key-type of the key specified by the
                         '--key' option. If '--key-type' is not passed, default

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -61,12 +61,12 @@ optional arguments:
   --base-path <path>    Record 'materials/products' relative to <path>. If not
                         set, current working directory is used as base path.
   --lstrip-paths <path> [<path> ...]
-                        Record the path of artifacts in link metadata after left
-                        stripping the specified <path> from the full path. If
-                        there are multiple prefixes specified, only a single
-                        prefix can match the path of any artifact and that is
-                        then left stripped. All prefixes are checked to ensure none
-                        of them are a left substring of another.
+                        Record the path of artifacts in link metadata after
+                        left stripping the specified <path> from the full
+                        path. If there are multiple prefixes specified, only a
+                        single prefix can match the path of any artifact and
+                        that is then left stripped. All prefixes are checked
+                        to ensure none of them are a left substring of another.
   -t {ed25519,rsa}, --key-type {ed25519,rsa}
                         Specify the key-type of the key specified by the
                         '--key' option. If '--key-type' is not passed, default

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -105,7 +105,8 @@ import in_toto.user_settings
 from in_toto import (util, runlib)
 
 from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
-    BASE_PATH_ARGS, BASE_PATH_KWARGS)
+    BASE_PATH_ARGS, BASE_PATH_KWARGS, LSTRIP_PATHS_ARGS,
+    LSTRIP_PATHS_KWARGS)
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 log = logging.getLogger("in_toto")
@@ -198,6 +199,7 @@ examples:
 
   parser.add_argument(*EXCLUDE_ARGS, **EXCLUDE_KWARGS)
   parser.add_argument(*BASE_PATH_ARGS, **BASE_PATH_KWARGS)
+  parser.add_argument(*LSTRIP_PATHS_ARGS, **LSTRIP_PATHS_KWARGS)
 
   verbosity_args = parser.add_mutually_exclusive_group(required=False)
   verbosity_args.add_argument("-v", "--verbose", dest="verbose",

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -255,7 +255,7 @@ examples:
 
     runlib.in_toto_run(args.step_name, args.materials, args.products,
         args.link_cmd, args.record_streams, key, gpg_keyid, gpg_use_default,
-        args.gpg_home, args.exclude_patterns, args.base_path)
+        args.gpg_home, args.exclude_patterns, args.base_path, args.lstrip_paths)
 
   except Exception as e:
     log.error("(in-toto-run) {0}: {1}".format(type(e).__name__, e))

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -152,7 +152,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
             the path of every artifact that contains the prefix. Currently,
-            a the prefix is a single path.
+            the prefix is a single path.
 
   <Exceptions>
     in_toto.exceptions.ValueError,
@@ -469,7 +469,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
             the path of every artifact that contains the prefix. Currently,
-            a the prefix is a single path.
+            the prefix is a single path.
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
@@ -604,7 +604,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
             the path of every artifact that contains the prefix. Currently,
-            a the prefix is a single path.
+            the prefix is a single path.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
@@ -733,7 +733,7 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
             the path of every artifact that contains the prefix. Currently,
-            a the prefix is a single path.
+            the prefix is a single path.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -225,9 +225,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # Currently, it's set to only take a single prefix in common_args.
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
-        normalized_prefix = lstrip_paths.replace('\\', '/')
         # Path was already normalized above
-        artifacts_dict[artifact.lstrip(normalized_prefix)] = \
+        artifacts_dict[artifact.lstrip(lstrip_paths)] = \
             _hash_artifact(artifact, normalize_line_endings=normalize_line_endings)
       else:
         # Path was already normalized above
@@ -286,8 +285,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # Currently, it's set to only take a single prefix in common_args.
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
-            normalized_prefix = lstrip_paths.replace("\\", "/")
-            artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = \
+            artifacts_dict[normalized_filepath.lstrip(lstrip_paths)] = \
                 _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)
           else:
             artifacts_dict[normalized_filepath] = _hash_artifact(filepath,

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -225,8 +225,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
         # Path was already normalized above
-        if artifact.startswith(lstrip_paths[0]):
-          key = artifact[len(lstrip_paths[0]):]
+        if artifact.startswith(lstrip_paths):
+          key = artifact[len(lstrip_paths):]
 
       artifacts_dict[key] = _hash_artifact(artifact,
           normalize_line_endings=normalize_line_endings)
@@ -284,8 +284,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # that prefix is left stripped from the filepath passed.
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
-            if normalized_filepath.startswith(lstrip_paths[0]):
-              key = normalized_filepath[len(lstrip_paths[0]):]
+            if normalized_filepath.startswith(lstrip_paths):
+              key = normalized_filepath[len(lstrip_paths):]
 
           artifacts_dict[key] = _hash_artifact(filepath,
               normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -86,7 +86,7 @@ def _apply_exclude_patterns(names, exclude_filter):
   return sorted(included)
 
 
-def _apply_left_strip(artifact_filepath, artifacts_dict,lstrip_paths=None):
+def _apply_left_strip(artifact_filepath, artifacts_dict, lstrip_paths=None):
   """ Internal helper function to left strip dictionary keys based on
   prefixes passed by the user. """
   if lstrip_paths:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -218,6 +218,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # If a prefix is passed using the argument --lstrip-paths,
         # that prefix is left stripped from the filepath passed.
         # Currently, it's set to only take a single prefix in common_args.
+        # Note: if the prefix doesn't include a trailing /, the dictionary key
+        # may include an unexpected /.
         normalized_prefix = lstrip_paths.replace('\\', '/')
         # Path was already normalized above
         artifacts_dict[artifact.lstrip(normalized_prefix)] = \
@@ -277,6 +279,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # If a prefix is passed using the argument --lstrip-paths,
             # that prefix is left stripped from the filepath passed.
             # Currently, it's set to only take a single prefix in common_args.
+            # Note: if the prefix doesn't include a trailing /, the dictionary key
+            # may include an unexpected /.
             normalized_prefix = lstrip_paths.replace("\\", "/")
             artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = \
                 _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -240,8 +240,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             break
 
       if key in artifacts_dict:
-        raise in_toto.exceptions.PrefixError("Prefix selection has resulted in"
-            " non unique dictionary key '{}'".format(key))
+        raise in_toto.exceptions.PrefixError("Prefix selection has resulted "
+            "in non unique dictionary key '{}'".format(key))
 
       artifacts_dict[key] = _hash_artifact(artifact,
           normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -221,11 +221,11 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         normalized_prefix = lstrip_paths.replace('\\', '/')
         # Path was already normalized above
         artifacts_dict[artifact.lstrip(normalized_prefix)] = \
-          _hash_artifact(artifact, normalize_line_endings=normalize_line_endings)
+            _hash_artifact(artifact, normalize_line_endings=normalize_line_endings)
       else:
         # Path was already normalized above
         artifacts_dict[artifact] = _hash_artifact(artifact,
-          normalize_line_endings=normalize_line_endings)
+            normalize_line_endings=normalize_line_endings)
 
     elif os.path.isdir(artifact):
       for root, dirs, files in os.walk(artifact,
@@ -279,10 +279,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # Currently, it's set to only take a single prefix in common_args.
             normalized_prefix = lstrip_paths.replace("\\", "/")
             artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = \
-              _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)
+                _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)
           else:
             artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
-              normalize_line_endings=normalize_line_endings)
+                normalize_line_endings=normalize_line_endings)
 
     # Path is no file and no directory
     else:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -235,7 +235,9 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # that prefix is left stripped from the filepath passed.
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
-        for prefix in lstrip_paths:
+        for prefix in lstrip_paths: # pragma: no cover
+          # This clause is hit by test_lstrip_paths_valid_prefix_file
+          # but coverage doesn't see it, due to the break statement
           if artifact.startswith(prefix):
             key = artifact[len(prefix):]
             break

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -213,7 +213,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
   # of another
   if lstrip_paths:
     for prefix_one, prefix_two in itertools.combinations(lstrip_paths, 2):
-      if prefix_one.startswith(prefix_two) or
+      if prefix_one.startswith(prefix_two) or \
           prefix_two.startswith(prefix_one):
         raise in_toto.exceptions.PrefixError("'{}' and '{}'"
             "triggered a left substring error".format(prefix_one, prefix_two))
@@ -236,7 +236,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # may include an unexpected /.
         for prefix in lstrip_paths:
           if artifact.startswith(prefix):
-            key = artifact[len(lstrip_paths):]
+            key = artifact[len(prefix):]
             break
 
       artifacts_dict[key] = _hash_artifact(artifact,
@@ -297,7 +297,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # may include an unexpected /.
             for prefix in lstrip_paths:
               if normalized_filepath.startswith(prefix):
-                key = normalized_filepath[len(lstrip_paths):]
+                key = normalized_filepath[len(prefix):]
                 break
 
           artifacts_dict[key] = _hash_artifact(filepath,

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -226,8 +226,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
         # Path was already normalized above
-        artifacts_dict[artifact.lstrip(lstrip_paths)] = \
-            _hash_artifact(artifact, normalize_line_endings=normalize_line_endings)
+        if artifact.startswith(lstrip_paths):
+          artifact = artifact[len(lstrip_paths):]
+        artifacts_dict[artifact] = _hash_artifact(artifact,
+            normalize_line_endings=normalize_line_endings)
       else:
         # Path was already normalized above
         artifacts_dict[artifact] = _hash_artifact(artifact,
@@ -285,8 +287,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # Currently, it's set to only take a single prefix in common_args.
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
-            artifacts_dict[normalized_filepath.lstrip(lstrip_paths)] = \
-                _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)
+            if normalized_filepath.startswith(lstrip_paths):
+              normalized_filepath = normalized_filepath[len(lstrip_paths):]
+            artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
+                normalize_line_endings=normalize_line_endings)
           else:
             artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
                 normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -226,8 +226,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
         # Path was already normalized above
-        if artifact.startswith(lstrip_paths):
-          stripped_artifact = artifact[len(lstrip_paths):]
+        if artifact.startswith(lstrip_paths[0]):
+          stripped_artifact = artifact[len(lstrip_paths[0]):]
         artifacts_dict[stripped_artifact] = _hash_artifact(artifact,
             normalize_line_endings=normalize_line_endings)
       else:
@@ -287,8 +287,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # Currently, it's set to only take a single prefix in common_args.
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
-            if normalized_filepath.startswith(lstrip_paths):
-              normalized_filepath = normalized_filepath[len(lstrip_paths):]
+            if normalized_filepath.startswith(lstrip_paths[0]):
+              normalized_filepath = normalized_filepath[len(lstrip_paths[0]):]
             artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
                 normalize_line_endings=normalize_line_endings)
           else:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -151,8 +151,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
 
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
-            the path of every artifact that contains the prefix. Currently,
-            the prefix is a single path.
+            the path of every artifact that contains the prefix.
 
   <Exceptions>
     in_toto.exceptions.ValueError,
@@ -223,7 +222,6 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
       if lstrip_paths:
         # If a prefix is passed using the argument --lstrip-paths,
         # that prefix is left stripped from the filepath passed.
-        # Currently, it's set to only take a single prefix in common_args.
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
         # Path was already normalized above

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -239,6 +239,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             key = artifact[len(prefix):]
             break
 
+      if key in artifacts_dict:
+        raise in_toto.exceptions.PrefixError("Prefix selection has resulted in"
+            " non unique dictionary key '{}'".format(key))
+
       artifacts_dict[key] = _hash_artifact(artifact,
           normalize_line_endings=normalize_line_endings)
 
@@ -299,6 +303,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
               if normalized_filepath.startswith(prefix):
                 key = normalized_filepath[len(prefix):]
                 break
+
+          if key in artifacts_dict:
+            raise in_toto.exceptions.PrefixError("Prefix selection has resulted"
+                " in non unique dictionary key '{}'".format(key))
 
           artifacts_dict[key] = _hash_artifact(filepath,
               normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -219,6 +219,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
       # *nix filepaths. A better solution may be in order though...
       artifact = artifact.replace('\\', '/')
 
+      key = artifact
       if lstrip_paths:
         # If a prefix is passed using the argument --lstrip-paths,
         # that prefix is left stripped from the filepath passed.
@@ -227,13 +228,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # may include an unexpected /.
         # Path was already normalized above
         if artifact.startswith(lstrip_paths[0]):
-          stripped_artifact = artifact[len(lstrip_paths[0]):]
-        artifacts_dict[stripped_artifact] = _hash_artifact(artifact,
-            normalize_line_endings=normalize_line_endings)
-      else:
-        # Path was already normalized above
-        artifacts_dict[artifact] = _hash_artifact(artifact,
-            normalize_line_endings=normalize_line_endings)
+          key = artifact[len(lstrip_paths[0]):]
+
+      artifacts_dict[key] = _hash_artifact(artifact,
+          normalize_line_endings=normalize_line_endings)
 
     elif os.path.isdir(artifact):
       for root, dirs, files in os.walk(artifact,
@@ -281,6 +279,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           # FIXME: this is necessary to provide consisency between windows filepaths and
           # *nix filepaths. A better solution may be in order though...
           normalized_filepath = filepath.replace("\\", "/")
+
+          key = normalized_filepath
           if lstrip_paths:
             # If a prefix is passed using the argument --lstrip-paths,
             # that prefix is left stripped from the filepath passed.
@@ -288,12 +288,10 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
             if normalized_filepath.startswith(lstrip_paths[0]):
-              normalized_filepath = normalized_filepath[len(lstrip_paths[0]):]
-            artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
-                normalize_line_endings=normalize_line_endings)
-          else:
-            artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
-                normalize_line_endings=normalize_line_endings)
+              key = normalized_filepath[len(lstrip_paths[0]):]
+
+          artifacts_dict[key] = _hash_artifact(filepath,
+              normalize_line_endings=normalize_line_endings)
 
     # Path is no file and no directory
     else:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -265,6 +265,9 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           # *nix filepaths. A better solution may be in order though...
           normalized_filepath = filepath.replace("\\", "/")
           if lstrip_paths:
+            # If a prefix is passed using the argument --lstrip-paths,
+            # that prefix is left stripped from the filepath passed.
+            # Currently, it's set to only take a single prefix in common_args.
             normalized_prefix = lstrip_paths.replace("\\", "/")
             artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = \
               _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -235,7 +235,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # that prefix is left stripped from the filepath passed.
         # Note: if the prefix doesn't include a trailing /, the dictionary key
         # may include an unexpected /.
-        for prefix in lstrip_paths: # pragma: no cover
+        for prefix in lstrip_paths: # pragma: no branch
           # This clause is hit by test_lstrip_paths_valid_prefix_file
           # but coverage doesn't see it, due to the break statement
           if artifact.startswith(prefix):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -227,8 +227,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
         # may include an unexpected /.
         # Path was already normalized above
         if artifact.startswith(lstrip_paths):
-          artifact = artifact[len(lstrip_paths):]
-        artifacts_dict[artifact] = _hash_artifact(artifact,
+          stripped_artifact = artifact[len(lstrip_paths):]
+        artifacts_dict[stripped_artifact] = _hash_artifact(artifact,
             normalize_line_endings=normalize_line_endings)
       else:
         # Path was already normalized above

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -216,7 +216,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
     for prefix_one, prefix_two in itertools.combinations(lstrip_paths, 2):
       if prefix_one.startswith(prefix_two) or \
           prefix_two.startswith(prefix_one):
-        raise in_toto.exceptions.PrefixError("'{}' and '{}'"
+        raise in_toto.exceptions.PrefixError("'{}' and '{}' "
             "triggered a left substring error".format(prefix_one, prefix_two))
 
   # Compile the gitignore-style patterns

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -264,7 +264,12 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           # FIXME: this is necessary to provide consisency between windows filepaths and
           # *nix filepaths. A better solution may be in order though...
           normalized_filepath = filepath.replace("\\", "/")
-          artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
+          if lstrip_paths:
+            normalized_prefix = lstrip_paths.replace("\\", "/")
+            artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = _hash_artifact(filepath,
+              normalize_line_endings=normalize_line_endings)
+          else:
+            artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
               normalize_line_endings=normalize_line_endings)
 
     # Path is no file and no directory

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -87,7 +87,8 @@ def _apply_exclude_patterns(names, exclude_filter):
 
 
 def record_artifacts_as_dict(artifacts, exclude_patterns=None,
-    base_path=None, follow_symlink_dirs=False, normalize_line_endings=False, lstrip_paths=None):
+    base_path=None, follow_symlink_dirs=False, normalize_line_endings=False,
+    lstrip_paths=None):
   """
   <Purpose>
     Hashes each file in the passed path list. If the path list contains

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -86,7 +86,7 @@ def _apply_exclude_patterns(names, exclude_filter):
 
 
 def record_artifacts_as_dict(artifacts, exclude_patterns=None,
-    base_path=None, follow_symlink_dirs=False, normalize_line_endings=False):
+    base_path=None, follow_symlink_dirs=False, normalize_line_endings=False, lstrip_paths=None):
   """
   <Purpose>
     Hashes each file in the passed path list. If the path list contains
@@ -266,8 +266,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           normalized_filepath = filepath.replace("\\", "/")
           if lstrip_paths:
             normalized_prefix = lstrip_paths.replace("\\", "/")
-            artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = _hash_artifact(filepath,
-              normalize_line_endings=normalize_line_endings)
+            artifacts_dict[normalized_filepath.lstrip(normalized_prefix)] = \
+              _hash_artifact(filepath, normalize_line_endings=normalize_line_endings)
           else:
             artifacts_dict[normalized_filepath] = _hash_artifact(filepath,
               normalize_line_endings=normalize_line_endings)
@@ -382,7 +382,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     record_streams=False, signing_key=None, gpg_keyid=None,
     gpg_use_default=False, gpg_home=None, exclude_patterns=None,
     base_path=None, compact_json=False, record_environment=False,
-    normalize_line_endings=False):
+    normalize_line_endings=False, lstrip_paths=None):
   """
   <Purpose>
     Calls functions in this module to run the command passed as link_cmd_args
@@ -481,7 +481,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
@@ -495,7 +495,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   products_dict = record_artifacts_as_dict(product_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
 
   log.info("Creating link metadata...")
   environment = {}
@@ -534,7 +534,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 def in_toto_record_start(step_name, material_list, signing_key=None,
     gpg_keyid=None, gpg_use_default=False, gpg_home=None,
     exclude_patterns=None, base_path=None, record_environment=False,
-    normalize_line_endings=False):
+    normalize_line_endings=False, lstrip_paths=None):
   """
   <Purpose>
     Starts creating link metadata for a multi-part in-toto step. I.e.
@@ -620,7 +620,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
 
   log.info("Creating preliminary link metadata...")
   environment = {}
@@ -658,7 +658,8 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
 def in_toto_record_stop(step_name, product_list, signing_key=None,
     gpg_keyid=None, gpg_use_default=False, gpg_home=None,
-    exclude_patterns=None, base_path=None, normalize_line_endings=False):
+    exclude_patterns=None, base_path=None, normalize_line_endings=False,
+    lstrip_paths=None):
   """
   <Purpose>
     Finishes creating link metadata for a multi-part in-toto step.
@@ -804,7 +805,7 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
 
   link_metadata.signed.products = record_artifacts_as_dict(product_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
 
   link_metadata.signatures = []
   if signing_key:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -508,7 +508,8 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings,
+      lstrip_paths=lstrip_paths)
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
@@ -522,7 +523,8 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   products_dict = record_artifacts_as_dict(product_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings,
+      lstrip_paths=lstrip_paths)
 
   log.info("Creating link metadata...")
   environment = {}
@@ -651,7 +653,8 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 
   materials_dict = record_artifacts_as_dict(material_list,
       exclude_patterns=exclude_patterns, base_path=base_path,
-      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings, lstrip_paths=lstrip_paths)
+      follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings,
+      lstrip_paths=lstrip_paths)
 
   log.info("Creating preliminary link metadata...")
   environment = {}

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -149,6 +149,11 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             endings before hashing the content of the passed files, for
             cross-platform support.
 
+    lstrip_paths: (optional)
+            If a prefix path is passed, the prefix is left stripped from
+            the path of every artifact that contains the prefix. Currently,
+            a the prefix is a single path.
+
   <Exceptions>
     in_toto.exceptions.ValueError,
         if we cannot change to base path directory
@@ -461,6 +466,10 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
             If True, replaces windows and mac line endings with unix line
             endings before hashing materials and products, for cross-platform
             support.
+    lstrip_paths: (optional)
+            If a prefix path is passed, the prefix is left stripped from
+            the path of every artifact that contains the prefix. Currently,
+            a the prefix is a single path.
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
@@ -592,6 +601,10 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
     normalize_line_endings: (optional)
             If True, replaces windows and mac line endings with unix line
             endings before hashing materials, for cross-platform support.
+    lstrip_paths: (optional)
+            If a prefix path is passed, the prefix is left stripped from
+            the path of every artifact that contains the prefix. Currently,
+            a the prefix is a single path.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
@@ -717,6 +730,10 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
     normalize_line_endings: (optional)
             If True, replaces windows and mac line endings with unix line
             endings before hashing products, for cross-platform support.
+    lstrip_paths: (optional)
+            If a prefix path is passed, the prefix is left stripped from
+            the path of every artifact that contains the prefix. Currently,
+            a the prefix is a single path.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -214,8 +214,17 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
       # *nix filepaths. A better solution may be in order though...
       artifact = artifact.replace('\\', '/')
 
-      # Path was already normalized above
-      artifacts_dict[artifact] = _hash_artifact(artifact,
+      if lstrip_paths:
+        # If a prefix is passed using the argument --lstrip-paths,
+        # that prefix is left stripped from the filepath passed.
+        # Currently, it's set to only take a single prefix in common_args.
+        normalized_prefix = lstrip_paths.replace('\\', '/')
+        # Path was already normalized above
+        artifacts_dict[artifact.lstrip(normalized_prefix)] = \
+          _hash_artifact(artifact, normalize_line_endings=normalize_line_endings)
+      else:
+        # Path was already normalized above
+        artifacts_dict[artifact] = _hash_artifact(artifact,
           normalize_line_endings=normalize_line_endings)
 
     elif os.path.isdir(artifact):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -284,7 +284,6 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
           if lstrip_paths:
             # If a prefix is passed using the argument --lstrip-paths,
             # that prefix is left stripped from the filepath passed.
-            # Currently, it's set to only take a single prefix in common_args.
             # Note: if the prefix doesn't include a trailing /, the dictionary key
             # may include an unexpected /.
             if normalized_filepath.startswith(lstrip_paths[0]):
@@ -468,8 +467,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
             support.
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
-            the path of every artifact that contains the prefix. Currently,
-            the prefix is a single path.
+            the path of every artifact that contains the prefix.
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
@@ -605,8 +603,7 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
             endings before hashing materials, for cross-platform support.
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
-            the path of every artifact that contains the prefix. Currently,
-            the prefix is a single path.
+            the path of every artifact that contains the prefix.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True
@@ -735,8 +732,7 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
             endings before hashing products, for cross-platform support.
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
-            the path of every artifact that contains the prefix. Currently,
-            the prefix is a single path.
+            the path of every artifact that contains the prefix.
 
   <Exceptions>
     ValueError if none of signing_key, gpg_keyid or gpg_use_default=True

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -39,16 +39,8 @@ def check_usable_gpg():
     os.environ["TEST_SKIP_GPG"] = "1"
 
 
-def check_windows_system_python_3():
-  """ Checks if system is a Windows system based on the path separator
-  """
-  if os.path.sep == "\\" and sys.version_info > (3,4):
-    os.environ["TEST_SKIP_WINDOWS_PY3"] = "1"
-
-
 # set the test prerrequisites (so far, we only check if gpg is installed)
 check_usable_gpg()
-check_windows_system_python_3()
 
 suite = defaultTestLoader.discover(start_dir=".")
 result = TextTestRunner(verbosity=2, buffer=True).run(suite)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -38,8 +38,17 @@ def check_usable_gpg():
   except (WindowsError, FileNotFound) as e:
     os.environ["TEST_SKIP_GPG"] = "1"
 
+
+def check_windows_system_python_3():
+  """ Checks if system is a Windows system based on the path separator
+  """
+  if os.path.sep == "\\" and sys.version_info > (3,4):
+    os.environ["TEST_SKIP_WINDOWS_PY3"] = "1"
+
+
 # set the test prerrequisites (so far, we only check if gpg is installed)
 check_usable_gpg()
+check_windows_system_python_3()
 
 suite = defaultTestLoader.discover(start_dir=".")
 result = TextTestRunner(verbosity=2, buffer=True).run(suite)

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -152,6 +152,15 @@ class TestInTotoRunTool(tests.common.CliTestCase):
       args4 = named_args + ["--base-path", "bogus/path"] + positional_args
       self.assert_cli_sys_exit(args4, 1)
 
+      # Test with lstrip path
+      args5 = named_args + ["--lstrip-paths", self.test_dir] + positional_args
+      self.assert_cli_sys_exit(args5, 0)
+      link_metadata = Metablock.load(self.test_link_rsa)
+      self.assertListEqual(list(link_metadata.signed.materials.keys()),
+          [self.test_artifact])
+      self.assertListEqual(list(link_metadata.signed.products.keys()),
+          [self.test_artifact])
+
 
   def test_main_with_unencrypted_ed25519_key(self):
     """Test CLI command with ed25519 key. """

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -242,7 +242,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       pass
 
   @unittest.skipUnless(os.getenv("TEST_SKIP_WINDOWS_PY3"), "test only applies to windows and py3")
-  def test_lstrip_paths_valid_unicode_prefix_file(self):
+  def test_lstrip_paths_valid_unicode_prefix_file_windows_py_3(self):
     # Try to create a file with unicode character
     try:
       os.mkdir("ಠ")

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -210,9 +210,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_file(self):
-    lstrip_paths = "subdir/subsubdir/"
+    lstrip_paths = "./"
     expected_artifacts = sorted(["bar"])
-    artifacts_dict = record_artifacts_as_dict(["bar"],
+    artifacts_dict = record_artifacts_as_dict(["./bar"],
         lstrip_paths=lstrip_paths)
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
         expected_artifacts)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -220,6 +220,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         expected_artifacts)
 
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_WINDOWS_PY3"), "unicode paths tested separately for windows and py3")
   def test_lstrip_paths_valid_unicode_prefix_file(self):
     # Try to create a file with unicode character
     try:
@@ -235,6 +236,27 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
           lstrip_paths=lstrip_paths)
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
           expected_artifacts)
+      os.remove(path)
+    except OSError:
+      # OS doesn't support unicode explicit files
+      pass
+
+  @unittest.skipUnless(os.getenv("TEST_SKIP_WINDOWS_PY3"), "test only applies to windows and py3")
+  def test_lstrip_paths_valid_unicode_prefix_file(self):
+    # Try to create a file with unicode character
+    try:
+      os.mkdir("ಠ")
+      path = "ಠ/foobar"
+      with open(path, "w", encoding="utf-8") as fp:
+        fp.write(path)
+
+      # Attempt to left strip the path now that the file has been created
+      lstrip_paths = "ಠ/"
+      expected_artifacts = sorted(["foobar"])
+      artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
+                                                lstrip_paths=lstrip_paths)
+      self.assertListEqual(sorted(list(artifacts_dict.keys())),
+                           expected_artifacts)
       os.remove(path)
     except OSError:
       # OS doesn't support unicode explicit files

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -188,6 +188,17 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
     os.chdir(self.test_dir)
 
+
+  def test_lstrip_paths(self):
+    lstrip_paths = "subdir/subsubdir"
+    expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
+      "subdir/foosub2", "foosubsub"])
+    artifacts_dict = record_artifacts_as_dict(["."],
+      lstrip_paths=lstrip_paths)
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
+      expected_artifacts)
+
+
   def test_empty_artifacts_list_record_nothing(self):
     """Empty list passed. Return empty dict. """
     self.assertDictEqual(record_artifacts_as_dict([]), {})

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -213,7 +213,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     shutil.copy("subdir/foosub1", path)
     lstrip_paths = ["subdir/", "subdir_new/"]
     with self.assertRaises(in_toto.exceptions.PrefixError):
-      artifacts_dict = record_artifacts_as_dict(["."],
+      record_artifacts_as_dict(["."],
           lstrip_paths=lstrip_paths)
     os.remove(path)
     os.rmdir("subdir_new")

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -236,6 +236,18 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         expected_artifacts)
 
 
+  def test_lstrip_paths_non_unique_key_file(self):
+    os.mkdir("subdir/subsubdir_new")
+    path = "subdir/subsubdir_new/foosubsub"
+    shutil.copy("subdir/subsubdir/foosubsub", path)
+    lstrip_paths = ["subdir/subsubdir/", "subdir/subsubdir_new/"]
+    with self.assertRaises(in_toto.exceptions.PrefixError):
+      record_artifacts_as_dict(["subdir/subsubdir/foosubsub",
+          "subdir/subsubdir_new/foosubsub"], lstrip_paths=lstrip_paths)
+    os.remove(path)
+    os.rmdir("subdir/subsubdir_new")
+
+
   @unittest.skipIf(os.getenv("TEST_SKIP_WINDOWS_PY3"), "unicode paths tested separately for windows and py3")
   def test_lstrip_paths_valid_unicode_prefix_file(self):
     # Try to create a file with unicode character

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -203,8 +203,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
   def test_lstrip_paths_substring_prefix_directory(self):
     lstrip_paths = ["subdir/subsubdir/", "subdir/"]
     with self.assertRaises(in_toto.exceptions.PrefixError):
-      artifacts_dict = record_artifacts_as_dict(["."],
-          lstrip_paths=lstrip_paths)
+      record_artifacts_as_dict(["."], lstrip_paths=lstrip_paths)
 
 
   def test_lstrip_paths_non_unique_key(self):
@@ -213,8 +212,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     shutil.copy("subdir/foosub1", path)
     lstrip_paths = ["subdir/", "subdir_new/"]
     with self.assertRaises(in_toto.exceptions.PrefixError):
-      record_artifacts_as_dict(["."],
-          lstrip_paths=lstrip_paths)
+      record_artifacts_as_dict(["."], lstrip_paths=lstrip_paths)
     os.remove(path)
     os.rmdir("subdir_new")
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -281,9 +281,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       lstrip_paths = ["ಠ/"]
       expected_artifacts = sorted(["foo"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
-                                                lstrip_paths=lstrip_paths)
+          lstrip_paths=lstrip_paths)
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
-                           expected_artifacts)
+          expected_artifacts)
       os.remove(path)
       os.rmdir("ಠ")
     except OSError:

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -210,9 +210,9 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_file(self):
-    lstrip_paths = "./"
-    expected_artifacts = sorted(["bar"])
-    artifacts_dict = record_artifacts_as_dict(["./bar"],
+    lstrip_paths = "subdir/subsubdir/"
+    expected_artifacts = sorted(["foosubsub"])
+    artifacts_dict = record_artifacts_as_dict(["./subdir/subsubdir/foosubsub"],
         lstrip_paths=lstrip_paths)
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
         expected_artifacts)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -224,13 +224,12 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     # Try to create a file with unicode character
     try:
       os.mkdir("ಠ")
-      path = "ಠ/foobar"
-      with open(path, "w") as fp:
-        fp.write(path)
+      path = "ಠ/foo"
+      shutil.copy("foo", path)
 
       # Attempt to left strip the path now that the file has been created
       lstrip_paths = "ಠ/"
-      expected_artifacts = sorted(["foobar"])
+      expected_artifacts = sorted(["foo"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
           lstrip_paths=lstrip_paths)
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
@@ -245,13 +244,12 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     # Try to create a file with unicode character
     try:
       os.mkdir("ಠ")
-      path = "ಠ/foobar"
-      with open(path, "w", encoding="utf-8") as fp:
-        fp.write(path)
+      path = "ಠ/foo"
+      shutil.copy("foo", path)
 
       # Attempt to left strip the path now that the file has been created
       lstrip_paths = "ಠ/"
-      expected_artifacts = sorted(["foobar"])
+      expected_artifacts = sorted(["foo"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
                                                 lstrip_paths=lstrip_paths)
       self.assertListEqual(sorted(list(artifacts_dict.keys())),

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -242,6 +242,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
           expected_artifacts)
       os.remove(path)
+      os.rmdir("ಠ")
     except OSError:
       # OS doesn't support unicode explicit files
       pass
@@ -262,6 +263,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       self.assertListEqual(sorted(list(artifacts_dict.keys())),
                            expected_artifacts)
       os.remove(path)
+      os.rmdir("ಠ")
     except OSError:
       # OS doesn't support unicode explicit files
       pass

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -189,7 +189,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     os.chdir(self.test_dir)
 
 
-  def test_lstrip_paths_valid_prefix(self):
+  def test_lstrip_paths_valid_prefix_directory(self):
     lstrip_paths = "subdir/subsubdir/"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
         "subdir/foosub2", "foosubsub"])
@@ -199,7 +199,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         expected_artifacts)
 
 
-  def test_lstrip_paths_invalid_prefix(self):
+  def test_lstrip_paths_invalid_prefix_directory(self):
     lstrip_paths = "not/a/directory/"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
                                  "subdir/foosub2", "subdir/subsubdir/foosubsub"])

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -189,7 +189,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     os.chdir(self.test_dir)
 
 
-  def test_lstrip_paths(self):
+  def test_lstrip_paths_valid_prefix(self):
     lstrip_paths = "subdir/subsubdir"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
       "subdir/foosub2", "foosubsub"])

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -200,6 +200,13 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         expected_artifacts)
 
 
+  def test_lstrip_paths_substring_prefix_directory(self):
+    lstrip_paths = ["subdir/subsubdir/", "subdir/"]
+    with self.assertRaises(in_toto.exceptions.PrefixError):
+      artifacts_dict = record_artifacts_as_dict(["."],
+          lstrip_paths=lstrip_paths)
+
+
   def test_lstrip_paths_invalid_prefix_directory(self):
     lstrip_paths = ["not/a/directory/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -248,29 +248,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     os.rmdir("subdir/subsubdir_new")
 
 
-  @unittest.skipIf(os.getenv("TEST_SKIP_WINDOWS_PY3"), "unicode paths tested separately for windows and py3")
   def test_lstrip_paths_valid_unicode_prefix_file(self):
-    # Try to create a file with unicode character
-    try:
-      os.mkdir("ಠ")
-      path = "ಠ/foo"
-      shutil.copy("foo", path)
-
-      # Attempt to left strip the path now that the file has been created
-      lstrip_paths = ["ಠ/"]
-      expected_artifacts = sorted(["foo"])
-      artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
-          lstrip_paths=lstrip_paths)
-      self.assertListEqual(sorted(list(artifacts_dict.keys())),
-          expected_artifacts)
-      os.remove(path)
-      os.rmdir("ಠ")
-    except OSError:
-      # OS doesn't support unicode explicit files
-      pass
-
-  @unittest.skipUnless(os.getenv("TEST_SKIP_WINDOWS_PY3"), "test only applies to windows and py3")
-  def test_lstrip_paths_valid_unicode_prefix_file_windows_py_3(self):
     # Try to create a file with unicode character
     try:
       os.mkdir("ಠ")

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -191,7 +191,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_directory(self):
-    lstrip_paths = "subdir/subsubdir/"
+    lstrip_paths = ["subdir/subsubdir/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
         "subdir/foosub2", "foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -201,7 +201,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_invalid_prefix_directory(self):
-    lstrip_paths = "not/a/directory/"
+    lstrip_paths = ["not/a/directory/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
                                  "subdir/foosub2", "subdir/subsubdir/foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -211,7 +211,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_file(self):
-    lstrip_paths = "subdir/subsubdir/"
+    lstrip_paths = ["subdir/subsubdir/"]
     expected_artifacts = sorted(["foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["./subdir/subsubdir/foosubsub"],
         lstrip_paths=lstrip_paths)
@@ -228,7 +228,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       shutil.copy("foo", path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = "ಠ/"
+      lstrip_paths = ["ಠ/"]
       expected_artifacts = sorted(["foo"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
           lstrip_paths=lstrip_paths)
@@ -248,7 +248,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       shutil.copy("foo", path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = "ಠ/"
+      lstrip_paths = ["ಠ/"]
       expected_artifacts = sorted(["foo"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
                                                 lstrip_paths=lstrip_paths)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -126,7 +126,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
 
-
   @classmethod
   def tearDownClass(self):
     """Change back to working dir, remove temp directory, restore settings. """

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -191,7 +191,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_directory(self):
-    lstrip_paths = ["subdir/subsubdir/"]
+    lstrip_paths = "subdir/subsubdir/"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
         "subdir/foosub2", "foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -201,7 +201,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_invalid_prefix_directory(self):
-    lstrip_paths = ["not/a/directory/"]
+    lstrip_paths = "not/a/directory/"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
                                  "subdir/foosub2", "subdir/subsubdir/foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -211,7 +211,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_file(self):
-    lstrip_paths = ["subdir/subsubdir/"]
+    lstrip_paths = "subdir/subsubdir/"
     expected_artifacts = sorted(["foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["./subdir/subsubdir/foosubsub"],
         lstrip_paths=lstrip_paths)
@@ -229,7 +229,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = ["ಠ/"]
+      lstrip_paths = "ಠ/"
       expected_artifacts = sorted(["foobar"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
           lstrip_paths=lstrip_paths)
@@ -250,7 +250,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = ["ಠ/"]
+      lstrip_paths = "ಠ/"
       expected_artifacts = sorted(["foobar"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
                                                 lstrip_paths=lstrip_paths)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#coding=utf-8
 
 """
 <Program Name>
@@ -125,6 +126,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
 
+
   @classmethod
   def tearDownClass(self):
     """Change back to working dir, remove temp directory, restore settings. """
@@ -216,6 +218,27 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         lstrip_paths=lstrip_paths)
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
         expected_artifacts)
+
+
+  def test_lstrip_paths_valid_unicode_prefix_file(self):
+    # Try to create a file with unicode character
+    try:
+      os.mkdir("ಠ")
+      path = "ಠ/foobar"
+      with open(path, "w") as fp:
+        fp.write(path)
+
+      # Attempt to left strip the path now that the file has been created
+      lstrip_paths = "ಠ/"
+      expected_artifacts = sorted(["foobar"])
+      artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
+          lstrip_paths=lstrip_paths)
+      self.assertListEqual(sorted(list(artifacts_dict.keys())),
+          expected_artifacts)
+      os.remove(path)
+    except OSError:
+      # OS doesn't support unicode explicit files
+      pass
 
 
   def test_empty_artifacts_list_record_nothing(self):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -207,6 +207,18 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
           lstrip_paths=lstrip_paths)
 
 
+  def test_lstrip_paths_non_unique_key(self):
+    os.mkdir("subdir_new")
+    path = "subdir_new/foosub1"
+    shutil.copy("subdir/foosub1", path)
+    lstrip_paths = ["subdir/", "subdir_new/"]
+    with self.assertRaises(in_toto.exceptions.PrefixError):
+      artifacts_dict = record_artifacts_as_dict(["."],
+          lstrip_paths=lstrip_paths)
+    os.remove(path)
+    os.rmdir("subdir_new")
+
+
   def test_lstrip_paths_invalid_prefix_directory(self):
     lstrip_paths = ["not/a/directory/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -209,6 +209,15 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
                          expected_artifacts)
 
 
+  def test_lstrip_paths_valid_prefix_file(self):
+    lstrip_paths = "subdir/subsubdir/"
+    expected_artifacts = sorted(["bar"])
+    artifacts_dict = record_artifacts_as_dict(["bar"],
+        lstrip_paths=lstrip_paths)
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
+        expected_artifacts)
+
+
   def test_empty_artifacts_list_record_nothing(self):
     """Empty list passed. Return empty dict. """
     self.assertDictEqual(record_artifacts_as_dict([]), {})

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -192,7 +192,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_directory(self):
-    lstrip_paths = "subdir/subsubdir/"
+    lstrip_paths = ["subdir/subsubdir/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
         "subdir/foosub2", "foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -202,7 +202,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_invalid_prefix_directory(self):
-    lstrip_paths = "not/a/directory/"
+    lstrip_paths = ["not/a/directory/"]
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
                                  "subdir/foosub2", "subdir/subsubdir/foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
@@ -212,7 +212,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix_file(self):
-    lstrip_paths = "subdir/subsubdir/"
+    lstrip_paths = ["subdir/subsubdir/"]
     expected_artifacts = sorted(["foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["./subdir/subsubdir/foosubsub"],
         lstrip_paths=lstrip_paths)
@@ -230,7 +230,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = "ಠ/"
+      lstrip_paths = ["ಠ/"]
       expected_artifacts = sorted(["foobar"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
           lstrip_paths=lstrip_paths)
@@ -251,7 +251,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         fp.write(path)
 
       # Attempt to left strip the path now that the file has been created
-      lstrip_paths = "ಠ/"
+      lstrip_paths = ["ಠ/"]
       expected_artifacts = sorted(["foobar"])
       artifacts_dict = record_artifacts_as_dict(["./ಠ/"],
                                                 lstrip_paths=lstrip_paths)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -192,11 +192,11 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
   def test_lstrip_paths_valid_prefix(self):
     lstrip_paths = "subdir/subsubdir"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
-      "subdir/foosub2", "foosubsub"])
+        "subdir/foosub2", "foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],
-      lstrip_paths=lstrip_paths)
+        lstrip_paths=lstrip_paths)
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
-      expected_artifacts)
+        expected_artifacts)
 
 
   def test_empty_artifacts_list_record_nothing(self):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -199,6 +199,16 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
         expected_artifacts)
 
 
+  def test_lstrip_paths_invalid_prefix(self):
+    lstrip_paths = "not/a/directory/"
+    expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
+                                 "subdir/foosub2", "subdir/subsubdir/foosubsub"])
+    artifacts_dict = record_artifacts_as_dict(["."],
+        lstrip_paths=lstrip_paths)
+    self.assertListEqual(sorted(list(artifacts_dict.keys())),
+                         expected_artifacts)
+
+
   def test_empty_artifacts_list_record_nothing(self):
     """Empty list passed. Return empty dict. """
     self.assertDictEqual(record_artifacts_as_dict([]), {})

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -190,7 +190,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
 
 
   def test_lstrip_paths_valid_prefix(self):
-    lstrip_paths = "subdir/subsubdir"
+    lstrip_paths = "subdir/subsubdir/"
     expected_artifacts = sorted(["bar", "foo", "subdir/foosub1",
         "subdir/foosub2", "foosubsub"])
     artifacts_dict = record_artifacts_as_dict(["."],


### PR DESCRIPTION
**Fixes issue #**: #194 (partially)

**Description of the changes being introduced by the pull request**:
The command line argument `--lstrip-paths` now accepts a single prefix which will then be left stripped from all matching paths of artifacts. This left stripped path is then used as the key to the dictionary when recording artifacts.
