### PR TITLE
Output and record standard streams in in-toto-run

### DIFF
--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -48,7 +48,7 @@ optional arguments:
                         gpg' option. If '--gpg-home' is not passed, the
                         default GPG keyring is used.
   -b, --record-streams  If passed 'stdout' and 'stderr' of the executed
-                        command are redirected and stored in the resulting
+                        command are duplicated and stored in the resulting
                         link metadata.
   -x, --no-command      Generate link metadata without executing a command,
                         e.g. for a 'signed off by' step.
@@ -188,7 +188,7 @@ examples:
 
   parser.add_argument("-s", "--record-streams", dest="record_streams",
       default=False, action="store_true", help=(
-      "If passed 'stdout' and 'stderr' of the executed command are redirected"
+      "If passed 'stdout' and 'stderr' of the executed command are duplicated"
       " and stored in the resulting link metadata."))
 
   parser.add_argument("-x", "--no-command", dest="no_command", default=False,

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -178,11 +178,13 @@ def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
   stderr_fd, stderr_name = tempfile.mkstemp()
   try:
     with io.open(stdout_name, "r") as stdout_reader, \
-        io.open(stderr_name, "r") as stderr_reader:
+        os.fdopen(stdout_fd, "w") as stdout_writer, \
+        io.open(stderr_name, "r") as stderr_reader, \
+        os.fdopen(stderr_fd, "w") as stderr_writer:
 
       # Start child , writing standard streams to temporary files
-      proc = subprocess.Popen(cmd, stdout=stdout_fd,
-          stderr=stderr_fd, universal_newlines=True)
+      proc = subprocess.Popen(cmd, stdout=stdout_writer,
+          stderr=stderr_writer, universal_newlines=True)
       proc_start_time = time.time()
 
       stdout_str = stderr_str = ""

--- a/in_toto/process.py
+++ b/in_toto/process.py
@@ -19,11 +19,16 @@
   - require the Py3 subprocess backport `subprocess32` on Python2,
   - in-toto namespace subprocess constants (DEVNULL, PIPE) and
   - provide a custom `subprocess.run` wrapper
+  - provide a special `run_duplicate_streams` function
 
 """
+import os
+import sys
+import io
+import tempfile
 import logging
+import time
 import shlex
-
 import six
 
 if six.PY2:
@@ -44,7 +49,6 @@ PIPE = subprocess.PIPE
 log = logging.getLogger(__name__)
 
 
-# TODO: Properly duplicate standard streams (issue #11)
 def run(cmd, check=True, timeout=SUBPROCESS_TIMEOUT, **kwargs):
   """
   <Purpose>
@@ -118,3 +122,97 @@ def run(cmd, check=True, timeout=SUBPROCESS_TIMEOUT, **kwargs):
     del kwargs["stdin"]
 
   return subprocess.run(cmd, check=check, timeout=timeout, **kwargs)
+
+
+
+
+def run_duplicate_streams(cmd, timeout=SUBPROCESS_TIMEOUT):
+  """
+  <Purpose>
+    Provide a function that executes a command in a subprocess and returns its
+    exit code and the contents of what it printed to its standard streams upon
+    termination.
+
+    NOTE: The function might behave unexpectedly with interactive commands.
+
+
+  <Arguments>
+    cmd:
+            The command and its arguments. (list of str, or str)
+            Splits a string specifying a command and its argument into a list
+            of substrings, if necessary.
+
+    timeout: (default see settings.SUBPROCESS_TIMEOUT)
+            If the timeout expires, the child process will be killed and waited
+            for and then subprocess.TimeoutExpired  will be raised.
+
+  <Exceptions>
+    securesystemslib.exceptions.FormatError:
+            If the `cmd` is a list and does not match
+            in_toto.formats.LIST_OF_ANY_STRING_SCHEMA.
+
+    OSError:
+            If the given command is not present or non-executable.
+
+    subprocess.TimeoutExpired:
+            If the process does not terminate after timeout seconds. Default
+            is `settings.SUBPROCESS_TIMEOUT`
+
+  <Side Effects>
+    The side effects of executing the given command in this environment.
+
+  <Returns>
+    A tuple of command's exit code, standard output and standard error
+    contents.
+
+  """
+  if isinstance(cmd, six.string_types):
+    cmd = shlex.split(cmd)
+  else:
+    formats.LIST_OF_ANY_STRING_SCHEMA.check_match(cmd)
+
+  # Use temporary files as targets for child process standard stream redirects
+  # They seem to work better (i.e. do not hang) than pipes, when using
+  # interactive commands like `vi`.
+  stdout_fd, stdout_name = tempfile.mkstemp()
+  stderr_fd, stderr_name = tempfile.mkstemp()
+  try:
+    with io.open(stdout_name, "r") as stdout_reader, \
+        io.open(stderr_name, "r") as stderr_reader:
+
+      # Start child , writing standard streams to temporary files
+      proc = subprocess.Popen(cmd, stdout=stdout_fd,
+          stderr=stderr_fd, universal_newlines=True)
+      proc_start_time = time.time()
+
+      stdout_str = stderr_str = ""
+      stdout_part = stderr_part = ""
+
+      # Read as long as the process runs or there is data on one of the streams
+      while proc.poll() is None or stdout_part or stderr_part:
+
+        # Raise timeout error in they same manner as `subprocess` would do it
+        if (timeout is not None and
+            time.time() > proc_start_time + timeout):
+          proc.kill()
+          proc.wait()
+          raise subprocess.TimeoutExpired(cmd, timeout)
+
+        # Read from child process's redirected streams, write to parent
+        # process's standard streams and construct retuirn values
+        stdout_part = stdout_reader.read()
+        stderr_part = stderr_reader.read()
+        sys.stdout.write(stdout_part)
+        sys.stderr.write(stderr_part)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        stdout_str += stdout_part
+        stderr_str += stderr_part
+
+  finally:
+    # The work is done or was interrupted, the temp files can be removed
+    os.remove(stdout_name)
+    os.remove(stderr_name)
+
+  # Return process exit code and captured stream
+  return proc.poll(), stdout_str, stderr_str

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -309,20 +309,19 @@ def execute_link(link_cmd_args, record_streams):
     - The return value of the executed command.
   """
   if record_streams:
-    process = in_toto.process.run(link_cmd_args, check=False,
-      stdout=in_toto.process.PIPE, stderr=in_toto.process.PIPE,
-      universal_newlines=True)
-    stdout_str, stderr_str = process.stdout, process.stderr
+    return_code, stdout_str, stderr_str = \
+        in_toto.process.run_duplicate_streams(link_cmd_args)
 
   else:
     process = in_toto.process.run(link_cmd_args, check=False,
       stdout=in_toto.process.DEVNULL, stderr=in_toto.process.DEVNULL)
     stdout_str = stderr_str = ""
+    return_code = process.returncode
 
   return {
       "stdout": stdout_str,
       "stderr": stderr_str,
-      "return-value": process.returncode
+      "return-value": return_code
     }
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -19,13 +19,17 @@
 import os
 import tempfile
 import unittest
+import shlex
+import mock
+import io
+import sys
 import in_toto.process
 
 
 class Test_Process(unittest.TestCase):
   """Test subprocess interface. """
 
-  def test_input_vs_stdin(self):
+  def test_run_input_vs_stdin(self):
     """Test that stdin kwarg is only used if input kwarg is not supplied. """
 
     # Create a temporary file, passed as `stdin` argument
@@ -48,6 +52,68 @@ class Test_Process(unittest.TestCase):
     # Clean up
     stdin_file.close()
     os.remove(path)
+
+
+  def test_run_duplicate_streams(self):
+    """Test output as streams and as returned.  """
+    # Command that prints 'foo' to stdout and 'bar' to stderr.
+    cmd = ("python -c \""
+        "import sys;"
+        "sys.stdout.write('foo');"
+        "sys.stderr.write('bar');\"")
+
+    # Create and open fake targets for standard streams
+    stdout_fd, stdout_fn = tempfile.mkstemp()
+    stderr_fd, stderr_fn = tempfile.mkstemp()
+    with io.open(stdout_fn, "r+") as fake_stdout, \
+        io.open(stderr_fn, "r+") as fake_stderr:
+
+      # Backup original standard streams and redirect to fake targets
+      real_stdout = sys.stdout
+      real_stderr = sys.stderr
+      sys.stdout = fake_stdout
+      sys.stderr = fake_stderr
+
+      # Run command
+      ret_code, ret_stdout, ret_stderr = \
+          in_toto.process.run_duplicate_streams(cmd)
+
+      # Rewind fake standard streams
+      fake_stdout.seek(0)
+      fake_stderr.seek(0)
+
+      # Assert that what was printed and what was returned is correct
+      self.assertTrue(ret_stdout == fake_stdout.read() == "foo")
+      self.assertTrue(ret_stderr == fake_stderr.read() == "bar")
+      # Also assert the default return value
+      self.assertEqual(ret_code, 0)
+
+      # Reset original streams
+      sys.stdout = real_stdout
+      sys.stderr = real_stderr
+
+    # Remove fake standard streams
+    os.remove(stdout_fn)
+    os.remove(stderr_fn)
+
+
+  def test_run_duplicate_streams_arg_return_code(self):
+    """Test command arg as string and list and return code. """
+    cmd_str = ("python -c \""
+        "import sys;"
+        "sys.exit(100)\"")
+    cmd_list = shlex.split(cmd_str)
+
+    for cmd in [cmd_str, cmd_list]:
+      return_code, _, _ = in_toto.process.run_duplicate_streams(cmd)
+      self.assertEqual(return_code, 100)
+
+
+  def test_run_duplicate_streams_timeout(self):
+    """Test raise TimeoutExpired. """
+    with self.assertRaises(in_toto.process.subprocess.TimeoutExpired):
+      in_toto.process.run_duplicate_streams("python --version", timeout=-1)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Fixes issue #**:
Fixes #11 

**Description of the changes being introduced by the pull request**:
Add `subprocess.run`-like function to `in_toto.process` module that redirects standard output and standard error of the executed command to temporary files and both writes the contents to the corresponding streams of the parent process during execution and also returns them along
with the child process's return code upon its termination.

This function is called `in_toto_run` when passing `record_streams=True`.

The PR is a friendly takeover of #160. Thanks for the solid ground work, @ng1355! 

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


