### PR TITLE
Fix various minor gpg packet parsing issues

### DIFF
--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -122,7 +122,7 @@ def parse_packet_header(data, expected_type=None):
 
   # If Bit 6 of 1st octet is set we parse a New Format Packet Length, and
   # an Old Format Packet Lengths otherwise
-  if data[0] & 0x40:
+  if data[0] & 0x40: # pragma: no cover
     # In new format packet lengths the packet type is encoded in Bits 5-0 of
     # the 1st octet of the packet
     packet_type = data[0] & 0x3f
@@ -146,6 +146,10 @@ def parse_packet_header(data, expected_type=None):
       header_len = 6
       body_len = data[2] << 24 | data[3] << 16 | data[4] << 8 | data[5]
 
+    else:
+      # raise PacketParsingError below if lengths cannot be determined
+      pass
+
   else:
     # In old format packet lengths the packet type is encoded in Bits 5-2 of
     # the 1st octet and the length type in Bits 1-0
@@ -158,19 +162,23 @@ def parse_packet_header(data, expected_type=None):
       body_len = data[1]
       header_len = 2
 
-    elif length_type == 1:
+    elif length_type == 1: # pragma: no branch
       header_len = 3
       body_len = struct.unpack(">H", data[1:header_len])[0]
 
-    elif length_type == 2:
+    elif length_type == 2: # pragma: no cover
       header_len = 5
       body_len = struct.unpack(">I", data[1:header_len])[0]
 
-    elif length_type == 3:
+    elif length_type == 3: # pragma: no cover
       raise in_toto.gpg.exceptions.PacketParsingError("Old length format "
           "packets of indeterminate length are not supported")
 
-  if header_len == None or body_len == None:
+    else: # pragma: no cover
+      # raise PacketParsingError below if lengths cannot be determined
+      pass
+
+  if header_len == None or body_len == None: # pragma: no cover
     raise in_toto.gpg.exceptions.PacketParsingError("Could not determine "
         "packet length")
 

--- a/in_toto/gpg/util.py
+++ b/in_toto/gpg/util.py
@@ -187,12 +187,12 @@ def parse_subpackets(subpacket_octets):
     length = subpacket_octets[ptr]
     ptr += 1
 
-    if length > 192 and length < 255 : # pragma: no cover
+    if length >= 192 and length < 255 : # pragma: no cover
       length = ((length - 192 << 8) + (subpacket_octets[ptr] + 192))
       ptr += 1
 
     if length == 255: # pragma: no cover
-      length = struct.unpack(">I", subpacket_octets[ptr:ptr + 4])
+      length = struct.unpack(">I", subpacket_octets[ptr:ptr + 4])[0]
       ptr += 4
 
     packet_type = subpacket_octets[ptr]


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
-  Update gpg signature subpacket parsing to look for subpackets in both hashed and unhashed sections of a packet (ed1ccd5)
- Fix two subpacket header length parsing bugs (4841508)
- Support gpg new format packet length header  (29c781a)

Please see commit messages for details.

*__Noteworthy__*:
I discovered these bugs while working on gpg self-signature verification (related to #245), by running `in_toto.gpg.functions.gpg_export_pubkey(keyid)` over all public keys in my system gpg keyring.
```bash
# Use to get a list of all keyids
gpg --list-keys --with-colons 2>&1 | grep ^pub | grep -Eo --color=never [A-F0-9]\{16\,}
```

Although the gpg packets that triggered these bugs seem to be rare and are not relevant for our purposes (e.g. large user attribute packets), we still need to be able to parse them. Because if we fail to determine the end of any packet, we will fail to parse all subsequent potentially relevant packets in the stream of consecutive packets.

Due to the rareness of these gpg packets we currently deem the effort to manually craft them for testing purposes infeasible. 

**Please verify and check that the pull request fulfills the following
requirements**:
- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


