### PR TITLE
Customize CWD for inspections

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -314,7 +314,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
 
   return artifacts_dict
 
-def execute_link(link_cmd_args, record_streams):
+def execute_link(link_cmd_args, record_streams, link_cmd_cwd):
   """
   <Purpose>
     Executes the passed command plus arguments in a subprocess and returns
@@ -330,6 +330,8 @@ def execute_link(link_cmd_args, record_streams):
             A bool that specifies whether to redirect standard output and
             and standard error to a temporary file which is returned to the
             caller (True) or not (False).
+    link_cmd_cwd:
+            A path to the directory where the link command must be executed.
 
   <Exceptions>
     TBA (see https://github.com/in-toto/in-toto/issues/6)
@@ -346,13 +348,14 @@ def execute_link(link_cmd_args, record_streams):
   """
   if record_streams:
     process = in_toto.process.run(link_cmd_args, check=False,
-      stdout=in_toto.process.PIPE, stderr=in_toto.process.PIPE,
-      universal_newlines=True)
+      cwd=link_cmd_cwd, stdout=in_toto.process.PIPE,
+      stderr=in_toto.process.PIPE, universal_newlines=True)
     stdout_str, stderr_str = process.stdout, process.stderr
 
   else:
     process = in_toto.process.run(link_cmd_args, check=False,
-      stdout=in_toto.process.DEVNULL, stderr=in_toto.process.DEVNULL)
+      cwd=link_cmd_cwd, stdout=in_toto.process.DEVNULL,
+      stderr=in_toto.process.DEVNULL)
     stdout_str = stderr_str = ""
 
   return {
@@ -413,7 +416,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     record_streams=False, signing_key=None, gpg_keyid=None,
     gpg_use_default=False, gpg_home=None, exclude_patterns=None,
     base_path=None, compact_json=False, record_environment=False,
-    normalize_line_endings=False, lstrip_paths=None):
+    normalize_line_endings=False, lstrip_paths=None, link_cmd_cwd=None):
   """
   <Purpose>
     Calls functions in this module to run the command passed as link_cmd_args
@@ -479,6 +482,8 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
     lstrip_paths: (optional)
             If a prefix path is passed, the prefix is left stripped from
             the path of every artifact that contains the prefix.
+    link_cmd_cwd: (optional)
+            A path to the directory where the link command must be executed.
 
   <Exceptions>
     securesystemslib.FormatError if a signing_key is passed and does not match
@@ -520,7 +525,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
 
   if link_cmd_args:
     log.info("Running command '{}'...".format(" ".join(link_cmd_args)))
-    byproducts = execute_link(link_cmd_args, record_streams)
+    byproducts = execute_link(link_cmd_args, record_streams, link_cmd_cwd)
   else:
     byproducts = {}
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -164,7 +164,7 @@ def load_links_for_layout(layout, link_dir_path):
   return steps_metadata
 
 
-def run_all_inspections(layout):
+def run_all_inspections(layout, inspection_dir_path):
   """
   <Purpose>
     Extracts all inspections from a passed Layout's inspect field and
@@ -177,6 +177,11 @@ def run_all_inspections(layout):
   <Arguments>
     layout:
             A Layout object which is used to extract the Inspections.
+
+    inspection_dir_path:
+            A path to the directory from which materials for the inspection are
+            read, and products are written to.  Default is the current working
+            directory.
 
   <Exceptions>
     Calls function that raises BadReturnValueError if an inspection returned
@@ -207,9 +212,9 @@ def run_all_inspections(layout):
     # Is the current directory a sensible default? In general?
     # If so, we should probably make it a default in run_link
     # We could use artifact rule paths.
-    material_list = product_list = ["."]
+    material_list = product_list = [inspection_dir_path]
     link = in_toto.runlib.in_toto_run(inspection.name, material_list,
-        product_list, inspection.run)
+        product_list, inspection.run, link_cmd_cwd=inspection_dir_path)
 
     _raise_on_bad_retval(link.signed.byproducts.get("return-value"), inspection.run)
 
@@ -1487,7 +1492,7 @@ def get_summary_link(layout, reduced_chain_link_dict):
 
 
 def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
-    substitution_parameters=None):
+    substitution_parameters=None, inspection_dir_path="."):
   """
   <Purpose>
     Does entire in-toto supply chain verification of a final product
@@ -1561,6 +1566,11 @@ def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
             corresponding to the steps in the passed layout are loaded.
             Default is the current working directory.
 
+    inspection_dir_path: (optional)
+            A path to the directory from which materials for the inspection are
+            read, and products are written to.  Default is the current working
+            directory.
+
     substitution_parameters: (optional)
             a dictionary containing key-value pairs for substituting in the 
             following metadata fields:
@@ -1616,7 +1626,7 @@ def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
   verify_all_item_rules(layout.steps, reduced_chain_link_dict)
 
   log.info("Executing Inspection commands...")
-  inspection_link_dict = run_all_inspections(layout)
+  inspection_link_dict = run_all_inspections(layout, inspection_dir_path)
 
   log.info("Verifying Inspection rules...")
   # Artifact rules for inspections can reference links that correspond to

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -116,7 +116,7 @@ class TestRunAllInspections(unittest.TestCase):
     open(ignore_foo, "w").write("ignore foo")
     in_toto.settings.ARTIFACT_BASE_PATH = ignore_dir
 
-    run_all_inspections(self.layout)
+    run_all_inspections(self.layout, ".")
     link = Metablock.load("touch-bar.link")
     self.assertListEqual(list(link.signed.materials.keys()), ["foo"])
     self.assertListEqual(sorted(list(link.signed.products.keys())), sorted(["foo", "bar"]))
@@ -135,7 +135,7 @@ class TestRunAllInspections(unittest.TestCase):
         }]
     })
     with self.assertRaises(BadReturnValueError):
-      run_all_inspections(layout)
+      run_all_inspections(layout, ".")
 
 
 class TestVerifyCommandAlignment(unittest.TestCase):


### PR DESCRIPTION
**Fixes issue #**:

N/A.

**Description of the changes being introduced by the pull request**:

Customize the CWD where inspections are run (before this, "." was assumed, and the integrator could not override this at runtime).

This PR updates:
1. Where commands for inspections can be run.
2. Where products and materials for inspections are recorded.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


