### PR TITLE
Fix illegal modification of artifact queue

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -688,6 +688,8 @@ def verify_match_rule(rule, source_artifacts_queue, source_artifacts, links):
   dest_name = rule_data["dest_name"]
   dest_type = rule_data["dest_type"]
 
+  matched_artifacts = set()
+
   # Extract destination link
   # FIXME: In alignment with in-toto/in-toto#204, we should return the
   # unmodified source artifact queue instead of raising an exception.
@@ -769,9 +771,9 @@ def verify_match_rule(rule, source_artifacts_queue, source_artifacts, links):
 
     # Only if matching went well, do we remove it from the queue. Subsequent
     # rules (e.g. DISALLOW) won't see this artifact anymore.
-    source_artifacts_queue.remove(full_source_path)
+    matched_artifacts.add(full_source_path)
 
-  return source_artifacts_queue
+  return list(set(source_artifacts_queue) - set(matched_artifacts))
 
 
 def verify_create_rule(rule, source_materials_queue, source_products_queue):
@@ -1122,11 +1124,11 @@ def verify_item_rules(source_name, source_type, rules, links):
   # Create generic source artifacts list and queue depending on the source type
   if source_type == "materials":
     source_artifacts = source_materials
-    source_artifacts_queue = source_materials_queue
+    source_artifacts_queue = list(source_materials_queue)
 
   elif source_type == "products":
     source_artifacts = source_products
-    source_artifacts_queue = source_products_queue
+    source_artifacts_queue = list(source_products_queue)
 
   else:
     raise securesystemslib.exceptions.FormatError(


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
During artifact rule verification `verify_item_rules` may pass the
`source_artifacts_queue` to `verify_match_rule`, which returns an
updated version of the queue (minus matched artifacts) and
overrides the original `source_artifacts_queue`.

However, the queue is passed to `verify_match_rule` by reference,
and modified directly. While this wouldn't be a problem for
`source_artifacts_queue`, as it is modified and then returned to
override itself, there is another reference pointing to that list,
i.e. (depending on whether `verify_item_rules` operates on material
or product rules) `source_products_queue` or `source_artifacts_queue`,
neither of which should not be modified by `verify_match_rule`.

This commit changes `verify_match_rule` to not modify the passed
reference and also makes an actual copy of `source_materials_queue`
and `source_products_queue` in `verify_item_rules` just to be safe.

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


