### PR TITLE
Fix check gpg windows (partial)

### DIFF
--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -180,7 +180,7 @@ class TestLayoutMethods(unittest.TestCase):
 
     layout._validate_keys()
 
-    self.assertEqual(len(layout.get_functionary_key_id_list()), 4)
+    self.assertEqual(len(layout.get_functionary_key_id_list()), 2)
 
     # Must be a valid key object
     with self.assertRaises(securesystemslib.exceptions.FormatError):

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -217,10 +217,10 @@ class TestLayoutMethods(unittest.TestCase):
     self.assertEqual(len(layout.get_functionary_key_id_list()), 0)
 
     layout.add_functionary_keys_from_paths([self.pubkey_path1,
-                                            self.pubkey_path2])
+        self.pubkey_path2])
 
     layout.add_functionary_keys_from_gpg_keyids([self.gpg_keyid1,
-                                                 self.gpg_keyid2], gpg_home=self.gnupg_home)
+        self.gpg_keyid2], gpg_home=self.gnupg_home)
 
     layout._validate_keys()
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -35,7 +35,7 @@ def check_usable_gpg():
     with open(os.devnull, "w") as dev_null_fp:
       subprocess.check_call(['gpg', '--version'], stdout=dev_null_fp)
 
-  except (WindowsError, FileNotFound) as e:
+  except (WindowsError, subprocess.CalledProcessError) as e:
     os.environ["TEST_SKIP_GPG"] = "1"
 
 

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -158,6 +158,7 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
       self.assert_cli_sys_exit(["stop"] + args + ["--products",
           self.test_artifact2, self.test_artifact2], 0)
 
+      @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
       # Start/stop sign with specified gpg keyid
       args = ["--step-name", "test7", "--gpg", self.gpg_keyid, "--gpg-home",
           self.gnupg_home]

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -158,7 +158,13 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
       self.assert_cli_sys_exit(["stop"] + args + ["--products",
           self.test_artifact2, self.test_artifact2], 0)
 
-      @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+  def test_start_stop_gpg(self):
+    """Test CLI command record start/stop with various arguments. """
+
+    # Give wrong password whenever prompted.
+    with mock.patch('in_toto.util.prompt_password', return_value='x'):
       # Start/stop sign with specified gpg keyid
       args = ["--step-name", "test7", "--gpg", self.gpg_keyid, "--gpg-home",
           self.gnupg_home]

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -172,6 +172,7 @@ class TestInTotoRunTool(tests.common.CliTestCase):
     self.assertTrue(os.path.exists(self.test_link_ed25519))
 
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
   def test_main_with_encrypted_ed25519_key(self):
     """Test CLI command with encrypted ed25519 key. """
     key_path = "test_key_ed25519_enc"

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -48,7 +48,6 @@ import in_toto.gpg.util
 import tests.common
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
 class TestInTotoRunTool(tests.common.CliTestCase):
   """Test in_toto_run's main() - requires sys.argv patching; and
   in_toto_run- calls runlib and error logs/exits on Exception. """
@@ -190,6 +189,7 @@ class TestInTotoRunTool(tests.common.CliTestCase):
       self.assertTrue(os.path.exists(linkpath))
 
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
   def test_main_with_specified_gpg_key(self):
     """Test CLI command with specified gpg key. """
     args = ["-n", self.test_step,
@@ -203,6 +203,7 @@ class TestInTotoRunTool(tests.common.CliTestCase):
     self.assertTrue(os.path.exists(link_filename))
 
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
   def test_main_with_default_gpg_key(self):
     """Test CLI command with default gpg key. """
     args = ["-n", self.test_step,

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -162,6 +162,7 @@ class TestInTotoRunTool(tests.common.CliTestCase):
           [self.test_artifact])
 
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
   def test_main_with_unencrypted_ed25519_key(self):
     """Test CLI command with ed25519 key. """
     args = ["-n", self.test_step,

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -48,6 +48,7 @@ import in_toto.gpg.util
 import tests.common
 
 
+@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
 class TestInTotoRunTool(tests.common.CliTestCase):
   """Test in_toto_run's main() - requires sys.argv patching; and
   in_toto_run- calls runlib and error logs/exits on Exception. """

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -32,7 +32,6 @@ WORKING_DIR = os.getcwd()
 
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
 class TestInTotoSignTool(tests.common.CliTestCase):
   """Test in_toto_sign's main() - requires sys.argv patching; error logs/exits
   on Exception. """
@@ -162,6 +161,11 @@ class TestInTotoSignTool(tests.common.CliTestCase):
         "-k", self.alice_pub_path,
         "--verify"
         ], 0)
+
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+  def test_sign_and_verify_gpg(self):
+    """Test signing and verifying Layout and Link metadata with
+    different combinations of arguments. """
 
     # Sign Layout with default gpg key
     self.assert_cli_sys_exit([

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -32,6 +32,7 @@ WORKING_DIR = os.getcwd()
 
 
 
+@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
 class TestInTotoSignTool(tests.common.CliTestCase):
   """Test in_toto_sign's main() - requires sys.argv patching; error logs/exits
   on Exception. """

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -221,6 +221,9 @@ class TestInTotoSignTool(tests.common.CliTestCase):
         "--verify"
         ], 2)
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+  def test_fail_verification_gpg(self):
+    """Fail signature verification. """
     # Fail with wrong gpg keyid (not used for signing)
     self.assert_cli_sys_exit([
         "-f", self.layout_path,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -227,6 +227,7 @@ class TestUtil(unittest.TestCase):
       import_public_keys_from_files_as_dict([name1, name2],
           [KEY_TYPE_ED25519] * 2)
 
+  @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
   def test_import_gpg_public_keys_from_keyring_as_dict(self):
     """Import gpg public keys from keyring and return KEYDICT. """
 


### PR DESCRIPTION
**Fixes issue #**: #264 

**Description of the changes being introduced by the pull request**:
- Separates tests which use GPG so that decorator can be applied
- Fixes the exceptions expected by `check_usable_gpg`
- Adds decorators to other tests without separating them

At this stage this still uses `WindowsError`, and doesn't handle situations where GPG is missing on non-Windows systems.