### PR TITLE
Misc linter-related fixes and enhancements

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -122,7 +122,7 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
     Paths are normalized for matching and storing by left stripping "./"
 
     NOTE on exclude patterns:
-      - Uses PathSpec to compile gitignore-style patterns, making use of the 
+      - Uses PathSpec to compile gitignore-style patterns, making use of the
         GitWildMatchPattern class (registered as 'gitwildmatch')
 
       - Patterns are checked for match against the full path relative to each

--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -211,9 +211,8 @@ def import_private_key_from_file(filepath, key_type):
     filepath:
       <filepath> file, a private key file
 
-    key_type: (optional)
-      Type of the private key being imported. If not
-      specified, the key is assumed to be RSA.
+    key_type:
+      Type of the private key being imported.
 
   <Exceptions>
     UnsupportedKeyTypeError, if the key_type specified is unsupported.
@@ -228,9 +227,7 @@ def import_private_key_from_file(filepath, key_type):
     key = prompt_import_ed25519_privatekey_from_file(filepath)
   elif key_type == KEY_TYPE_RSA:
     key = prompt_import_rsa_key_from_file(filepath)
-  else:  # pragma: no cover
-    # This branch is never possible as argparse already checks valid keys
-    # via the choices parameter.
+  else:
     raise UnsupportedKeyTypeError('Unsupported keytype: ' + key_type)
 
   return key

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1455,7 +1455,7 @@ def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
             Default is the current working directory.
 
     substitution_parameters: (optional)
-            a dictionary containing key-value pairs for substituting in the 
+            a dictionary containing key-value pairs for substituting in the
             following metadata fields:
 
               - artifact rules in step and inspection definitions in the layout

--- a/pylintrc
+++ b/pylintrc
@@ -56,7 +56,7 @@ disable=parameter-unpacking, unpacking-in-except, long-suffix, old-ne-operator, 
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=
+enable=trailing-whitespace
 
 
 [REPORTS]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
 pytest
 coverage
-mock
+mock; python_version < '3.3'

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,2 @@
-pytest
 coverage
 mock; python_version < '3.3'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,6 @@ class CapturableStreamHandler(logging.StreamHandler):
   @stream.setter
   def stream(self, value):
     """Disable setting stream. """
-    pass
 
 # Python `unittest` is configured to buffer output to `sys.stdout/sys.stderr`
 # (see `TextTestRunner` in `tests/runtests.py`) and only show it in case a test

--- a/tests/common.py
+++ b/tests/common.py
@@ -27,7 +27,11 @@ import sys
 import inspect
 
 import unittest
-from mock import patch
+if sys.version_info >= (3, 3):
+  from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
+else:
+  from mock import patch # pylint: disable=import-error
+
 
 def run_with_portable_scripts(decorated):
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -86,6 +86,6 @@ class CliTestCase(unittest.TestCase):
     """
     with patch.object(sys, "argv", [self.file_name]
         + cli_args), self.assertRaises(SystemExit) as raise_ctx:
-      self.cli_main_func()
+      self.cli_main_func() # pylint: disable=not-callable
 
     self.assertEqual(raise_ctx.exception.code, status)

--- a/tests/models/test_inspection.py
+++ b/tests/models/test_inspection.py
@@ -18,7 +18,7 @@
 """
 
 import unittest
-from in_toto.models.layout import Layout, Inspection
+from in_toto.models.layout import Inspection
 import securesystemslib.exceptions
 
 class TestInspectionValidator(unittest.TestCase):

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -20,7 +20,6 @@
 import os
 import unittest
 
-import in_toto.util
 from in_toto.models.metadata import Metablock
 from in_toto.models.layout import Layout
 from in_toto.models.link import Link

--- a/tests/models/test_step.py
+++ b/tests/models/test_step.py
@@ -18,7 +18,6 @@
 """
 
 import unittest
-import datetime
 from in_toto.models.layout import Step
 import securesystemslib.keys
 import securesystemslib.exceptions

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -33,7 +33,7 @@ def check_usable_gpg():
     try:
       subprocess.check_call([gpg, "--version"])
 
-    except OSError as e:
+    except OSError:
       pass
 
     else:

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -52,9 +52,6 @@ from in_toto.gpg.exceptions import (PacketParsingError,
     KeyNotFoundError, CommandError, KeyExpirationError)
 from in_toto.gpg.formats import PUBKEY_SCHEMA
 
-import securesystemslib.formats
-import securesystemslib.exceptions
-
 
 @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
 class TestUtil(unittest.TestCase):

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -515,9 +515,9 @@ class TestGPGRSA(unittest.TestCase):
     ssh_key = serialization.load_ssh_public_key(keydata,
         backends.default_backend())
 
-    self.assertEquals(ssh_key.public_numbers().n,
+    self.assertEqual(ssh_key.public_numbers().n,
         our_exported_key.public_numbers().n)
-    self.assertEquals(ssh_key.public_numbers().e,
+    self.assertEqual(ssh_key.public_numbers().e,
         our_exported_key.public_numbers().e)
 
     subkey_keyids = list(key_data["subkeys"].keys())
@@ -660,13 +660,13 @@ class TestGPGDSA(unittest.TestCase):
     ssh_key = serialization.load_ssh_public_key(keydata,
         backends.default_backend())
 
-    self.assertEquals(ssh_key.public_numbers().y,
+    self.assertEqual(ssh_key.public_numbers().y,
         our_exported_key.public_numbers().y)
-    self.assertEquals(ssh_key.public_numbers().parameter_numbers.g,
+    self.assertEqual(ssh_key.public_numbers().parameter_numbers.g,
         our_exported_key.public_numbers().parameter_numbers.g)
-    self.assertEquals(ssh_key.public_numbers().parameter_numbers.q,
+    self.assertEqual(ssh_key.public_numbers().parameter_numbers.q,
         our_exported_key.public_numbers().parameter_numbers.q)
-    self.assertEquals(ssh_key.public_numbers().parameter_numbers.p,
+    self.assertEqual(ssh_key.public_numbers().parameter_numbers.p,
         our_exported_key.public_numbers().parameter_numbers.p)
 
   def test_gpg_sign_and_verify_object_with_default_key(self):

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -20,12 +20,16 @@
 """
 
 import os
+import sys
 import shutil
 import tempfile
 import unittest
-from mock import patch
-import time
-import datetime
+
+if sys.version_info >= (3, 3):
+  from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
+else:
+  from mock import patch # pylint: disable=import-error
+
 from six import string_types
 from copy import deepcopy
 from collections import OrderedDict

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -259,6 +259,8 @@ class TestCommon(unittest.TestCase):
     # Parse corresponding raw packet for comparison
     _, header_len, _, _ = parse_packet_header(
         self.raw_key_bundle[PACKET_TYPE_PRIMARY_KEY]["packet"])
+
+    # pylint: disable=unsubscriptable-object
     parsed_raw_packet = parse_pubkey_payload(bytearray(
           self.raw_key_bundle[PACKET_TYPE_PRIMARY_KEY]["packet"][header_len:]))
 

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -16,7 +16,10 @@ import sys
 import unittest
 import shutil
 import tempfile
-from mock import patch
+if sys.version_info >= (3, 3):
+  from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
+else:
+  from mock import patch # pylint: disable=import-error
 
 from in_toto.in_toto_keygen import main as in_toto_keygen_main
 from in_toto.util import (generate_and_write_rsa_keypair,

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -14,19 +14,17 @@
 import os
 import sys
 import unittest
-import argparse
 import shutil
 import tempfile
 from mock import patch
+
 from in_toto.in_toto_keygen import main as in_toto_keygen_main
 from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_generate_and_write_rsa_keypair, prompt_password,
     generate_and_write_ed25519_keypair,
-    prompt_generate_and_write_ed25519_keypair,
-    import_rsa_key_from_file, prompt_import_rsa_key_from_file)
-from in_toto import exceptions
+    prompt_generate_and_write_ed25519_keypair, import_rsa_key_from_file)
+
 import securesystemslib
-from securesystemslib.keys import generate_rsa_key
 
 WORKING_DIR = os.getcwd()
 

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -17,13 +17,10 @@
 
 """
 import os
-import sys
 import unittest
-import argparse
 import shutil
 import tempfile
 import logging
-from mock import patch
 
 from in_toto.in_toto_mock import main as in_toto_mock_main
 

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -24,13 +24,10 @@ import unittest
 import shutil
 import tempfile
 
-# Use external backport 'mock' on versions under 3.3
 if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-
+  import unittest.mock as mock # pylint: disable=no-name-in-module,import-error
 else:
-  import mock
-
+  import mock # pylint: disable=import-error
 
 import in_toto.util
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -21,10 +21,8 @@
 import os
 import sys
 import unittest
-import argparse
 import shutil
 import tempfile
-
 
 # Use external backport 'mock' on versions under 3.3
 if sys.version_info >= (3, 3):
@@ -33,11 +31,9 @@ if sys.version_info >= (3, 3):
 else:
   import mock
 
-from mock import patch
 
 import in_toto.util
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT
-from in_toto.models.metadata import Metablock
 from in_toto.in_toto_record import main as in_toto_record_main
 
 import tests.common

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -21,7 +21,6 @@
 import os
 import sys
 import unittest
-import argparse
 import shutil
 import glob
 import tempfile
@@ -33,18 +32,14 @@ if sys.version_info >= (3, 3):
 else:
   import mock
 
-from mock import patch
-
 from in_toto.util import (generate_and_write_rsa_keypair,
     generate_and_write_ed25519_keypair, import_private_key_from_file,
     KEY_TYPE_RSA, KEY_TYPE_ED25519)
 
-from in_toto.models.link import Link
 from in_toto.models.metadata import Metablock
 from in_toto.in_toto_run import main as in_toto_run_main
 from in_toto.models.link import FILENAME_FORMAT
 
-import in_toto.gpg.util
 import tests.common
 
 

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -27,10 +27,9 @@ import tempfile
 
 # Use external backport 'mock' on versions under 3.3
 if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-
+  import unittest.mock as mock # pylint: disable=no-name-in-module,import-error
 else:
-  import mock
+  import mock # pylint: disable=import-error
 
 from in_toto.util import (generate_and_write_rsa_keypair,
     generate_and_write_ed25519_keypair, import_private_key_from_file,

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -304,7 +304,9 @@ class TestInTotoSignTool(tests.common.CliTestCase):
         ], 2)
 
     # Valid JSON but not valid Link or Layout
-    open("tmp.json", "wb").write(json.dumps({}).encode("utf-8"))
+    with open("tmp.json", "wb") as f:
+      f.write(json.dumps({}).encode("utf-8"))
+
     self.assert_cli_sys_exit([
         "-f", "tmp.json",
         "-k", "key-not-used",

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -14,15 +14,10 @@
 """
 
 import os
-import sys
 import json
 import shutil
 import tempfile
 import unittest
-
-from mock import patch
-from in_toto import exceptions
-import in_toto.gpg.util
 
 from in_toto.in_toto_sign import main as in_toto_sign_main
 

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -19,18 +19,12 @@
 """
 
 import os
-import sys
 import unittest
-import argparse
 import shutil
 import tempfile
-from mock import patch
 
-from in_toto.models.link import Link
-from in_toto.models.layout import Layout
 from in_toto.models.metadata import Metablock
 from in_toto.in_toto_verify import main as in_toto_verify_main
-from in_toto import exceptions
 from in_toto.util import import_rsa_key_from_file
 from securesystemslib.interface import import_ed25519_privatekey_from_file
 

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -76,8 +76,9 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
+
     shutil.copytree(scripts_directory, 'scripts')
 
     # Load layout template
@@ -187,8 +188,8 @@ class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     shutil.copytree(scripts_directory, 'scripts')
 
@@ -256,9 +257,8 @@ class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
     scripts_directory = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "scripts")
 
-
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     # Change into test dir
     os.chdir(self.test_dir)

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -167,8 +167,8 @@ class Test_SubstituteOnVerify(unittest.TestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     # load alice's key
     self.alice = import_rsa_key_from_file("alice")

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -85,12 +85,12 @@ class Test_SubstituteArtifacts(unittest.TestCase):
     """Do a simple substitution on the expected_command field"""
     substitute_parameters(self.layout, {"SOURCE_THING": "vim",
       "SOURCE_STEP": "source_step", "NEW_THING": "new_thing"})
-    self.assertEquals(self.layout.steps[0].expected_materials[0][1], "vim")
-    self.assertEquals(self.layout.steps[0].expected_materials[0][5], "source_step")
-    self.assertEquals(self.layout.steps[0].expected_products[0][1], "new_thing")
-    self.assertEquals(self.layout.inspect[0].expected_materials[0][1], "vim")
-    self.assertEquals(self.layout.inspect[0].expected_materials[0][5], "source_step")
-    self.assertEquals(self.layout.inspect[0].expected_products[0][1], "new_thing")
+    self.assertEqual(self.layout.steps[0].expected_materials[0][1], "vim")
+    self.assertEqual(self.layout.steps[0].expected_materials[0][5], "source_step")
+    self.assertEqual(self.layout.steps[0].expected_products[0][1], "new_thing")
+    self.assertEqual(self.layout.inspect[0].expected_materials[0][1], "vim")
+    self.assertEqual(self.layout.inspect[0].expected_materials[0][5], "source_step")
+    self.assertEqual(self.layout.inspect[0].expected_products[0][1], "new_thing")
 
 
 
@@ -121,7 +121,7 @@ class Test_SubstituteRunField(unittest.TestCase):
   def test_substitute(self):
     """Check that the substitution is performed on the run field."""
     substitute_parameters(self.layout, {"COMMAND": "touch"})
-    self.assertEquals(self.layout.inspect[0].run[0], "touch")
+    self.assertEqual(self.layout.inspect[0].run[0], "touch")
 
 
   def test_inspection_fail_with_non_zero_retval(self):
@@ -147,7 +147,7 @@ class Test_SubstituteExpectedCommand(unittest.TestCase):
   def test_substitute(self):
     """Do a simple substitution on the expected_command field"""
     substitute_parameters(self.layout, {"EDITOR": "vim"})
-    self.assertEquals(self.layout.steps[0].expected_command[0], "vim")
+    self.assertEqual(self.layout.steps[0].expected_command[0], "vim")
 
 
   def test_substitute_no_var(self):
@@ -208,7 +208,7 @@ class Test_SubstituteOnVerify(unittest.TestCase):
       in_toto_verify(signed_layout, self.alice_pub_dict,
           substitution_parameters={"EDITOR":"vim"})
 
-    self.assertEquals(self.layout.steps[0].expected_command[0], "vim")
+    self.assertEqual(self.layout.steps[0].expected_command[0], "vim")
 
 
 if __name__ == "__main__":

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -44,7 +44,7 @@ class Test_SubstituteArtifacts(unittest.TestCase):
         "inspect": [{
           "name": "do-the-thing",
           "expected_materials": [
-            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM", 
+            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM",
               "{SOURCE_STEP}"]
           ],
           "expected_products": [
@@ -55,7 +55,7 @@ class Test_SubstituteArtifacts(unittest.TestCase):
           "name": "artifacts",
           "expected_command": [],
           "expected_materials": [
-            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM", 
+            ["MATCH", "{SOURCE_THING}", "WITH", "MATERIALS", "FROM",
               "{SOURCE_STEP}"]
           ],
           "expected_products": [

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -22,33 +22,16 @@
 
 import os
 import shutil
-import copy
 import tempfile
 import unittest
-import glob
-from mock import patch
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
 
 import in_toto.settings
 from in_toto.models.metadata import Metablock
-from in_toto.models.link import Link, FILENAME_FORMAT
-from in_toto.models.layout import (Step, Inspection, Layout,
-    SUBLAYOUT_LINK_DIR_FORMAT)
-from in_toto.verifylib import (verify_delete_rule, verify_create_rule,
-    verify_modify_rule, verify_allow_rule, verify_disallow_rule,
-    verify_match_rule, verify_item_rules, verify_all_item_rules,
-    verify_command_alignment, run_all_inspections, in_toto_verify,
-    verify_sublayouts, get_summary_link, _raise_on_bad_retval,
-    load_links_for_layout, verify_link_signature_thresholds,
-    verify_threshold_constraints, substitute_parameters)
-from in_toto.exceptions import (RuleVerificationError,
-    SignatureVerificationError, LayoutExpiredError, BadReturnValueError,
-    ThresholdVerificationError)
-from in_toto.util import import_rsa_key_from_file, import_public_keys_from_files_as_dict
-import in_toto.gpg.functions
+from in_toto.models.layout import  Layout
+from in_toto.verifylib import in_toto_verify, substitute_parameters
+from in_toto.util import (import_rsa_key_from_file,
+    import_public_keys_from_files_as_dict)
 
-import securesystemslib.exceptions
 import in_toto.exceptions
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,7 +20,6 @@ import os
 import tempfile
 import unittest
 import shlex
-import mock
 import io
 import sys
 import in_toto.process

--- a/tests/test_rulelib.py
+++ b/tests/test_rulelib.py
@@ -63,61 +63,61 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     """Test generic rule proper packing and unpacking. """
     rule = ["CREATE", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "create")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "create")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_create_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_create_rule("foo"))
 
 
     rule = ["DELETE", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "delete")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "delete")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_delete_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_delete_rule("foo"))
 
 
     rule = ["MODIFY", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "modify")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "modify")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_modify_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_modify_rule("foo"))
 
 
     rule = ["ALLOW", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "allow")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "allow")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_allow_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_allow_rule("foo"))
 
 
     rule = ["DISALLOW", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "disallow")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "disallow")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_disallow_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_disallow_rule("foo"))
 
     rule = ["REQUIRE", "foo"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 2)
-    self.assertEquals(rule_data["rule_type"], "require")
-    self.assertEquals(rule_data["pattern"], "foo")
+    self.assertEqual(len(list(rule_data.keys())), 2)
+    self.assertEqual(rule_data["rule_type"], "require")
+    self.assertEqual(rule_data["pattern"], "foo")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_require_rule("foo"))
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_require_rule("foo"))
 
 
   def test_unpack_and_pack_match_rule(self):
@@ -126,16 +126,16 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "IN", "source-path", "WITH",
         "PRODUCTS", "IN", "dest-path", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 6)
-    self.assertEquals(rule_data["rule_type"], "match")
-    self.assertEquals(rule_data["pattern"], "foo")
-    self.assertEquals(rule_data["source_prefix"], "source-path")
-    self.assertEquals(rule_data["dest_prefix"], "dest-path")
-    self.assertEquals(rule_data["dest_type"], "products")
-    self.assertEquals(rule_data["dest_name"], "step-name")
+    self.assertEqual(len(list(rule_data.keys())), 6)
+    self.assertEqual(rule_data["rule_type"], "match")
+    self.assertEqual(rule_data["pattern"], "foo")
+    self.assertEqual(rule_data["source_prefix"], "source-path")
+    self.assertEqual(rule_data["dest_prefix"], "dest-path")
+    self.assertEqual(rule_data["dest_type"], "products")
+    self.assertEqual(rule_data["dest_name"], "step-name")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_rule("MATCH", "foo",
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_rule("MATCH", "foo",
         source_prefix="source-path", dest_type="PRODUCTS",
         dest_prefix="dest-path", dest_name="step-name"))
 
@@ -143,16 +143,16 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "IN", "source-path", "WITH",
         "MATERIALS", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 6)
-    self.assertEquals(rule_data["rule_type"], "match")
-    self.assertEquals(rule_data["pattern"], "foo")
-    self.assertEquals(rule_data["source_prefix"], "source-path")
-    self.assertEquals(rule_data["dest_prefix"], "")
-    self.assertEquals(rule_data["dest_type"], "materials")
-    self.assertEquals(rule_data["dest_name"], "step-name")
+    self.assertEqual(len(list(rule_data.keys())), 6)
+    self.assertEqual(rule_data["rule_type"], "match")
+    self.assertEqual(rule_data["pattern"], "foo")
+    self.assertEqual(rule_data["source_prefix"], "source-path")
+    self.assertEqual(rule_data["dest_prefix"], "")
+    self.assertEqual(rule_data["dest_type"], "materials")
+    self.assertEqual(rule_data["dest_name"], "step-name")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_rule("MATCH", "foo",
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_rule("MATCH", "foo",
         source_prefix="source-path", dest_type="MATERIALS",
         dest_name="step-name"))
 
@@ -160,30 +160,30 @@ class TestArtifactRuleUnpack(unittest.TestCase):
     rule = ["MATCH", "foo", "WITH",
         "PRODUCTS", "IN", "dest-path", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 6)
-    self.assertEquals(rule_data["rule_type"], "match")
-    self.assertEquals(rule_data["pattern"], "foo")
-    self.assertEquals(rule_data["source_prefix"], "")
-    self.assertEquals(rule_data["dest_prefix"], "dest-path")
-    self.assertEquals(rule_data["dest_type"], "products")
-    self.assertEquals(rule_data["dest_name"], "step-name")
+    self.assertEqual(len(list(rule_data.keys())), 6)
+    self.assertEqual(rule_data["rule_type"], "match")
+    self.assertEqual(rule_data["pattern"], "foo")
+    self.assertEqual(rule_data["source_prefix"], "")
+    self.assertEqual(rule_data["dest_prefix"], "dest-path")
+    self.assertEqual(rule_data["dest_type"], "products")
+    self.assertEqual(rule_data["dest_name"], "step-name")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_rule("MATCH", "foo",
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_rule("MATCH", "foo",
         dest_type="PRODUCTS", dest_prefix="dest-path", dest_name="step-name"))
 
     rule = ["MATCH", "foo", "WITH", "PRODUCTS", "FROM", "step-name"]
     rule_data = unpack_rule(rule)
-    self.assertEquals(len(list(rule_data.keys())), 6)
-    self.assertEquals(rule_data["rule_type"], "match")
-    self.assertEquals(rule_data["pattern"], "foo")
-    self.assertEquals(rule_data["source_prefix"], "")
-    self.assertEquals(rule_data["dest_prefix"], "")
-    self.assertEquals(rule_data["dest_type"], "products")
-    self.assertEquals(rule_data["dest_name"], "step-name")
+    self.assertEqual(len(list(rule_data.keys())), 6)
+    self.assertEqual(rule_data["rule_type"], "match")
+    self.assertEqual(rule_data["pattern"], "foo")
+    self.assertEqual(rule_data["source_prefix"], "")
+    self.assertEqual(rule_data["dest_prefix"], "")
+    self.assertEqual(rule_data["dest_type"], "products")
+    self.assertEqual(rule_data["dest_name"], "step-name")
 
-    self.assertEquals(rule, pack_rule_data(rule_data))
-    self.assertEquals(rule, pack_rule("MATCH", "foo",
+    self.assertEqual(rule, pack_rule_data(rule_data))
+    self.assertEqual(rule, pack_rule("MATCH", "foo",
         dest_type="PRODUCTS", dest_name="step-name"))
 
   def test_pack_rule_wrong_types(self):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -519,7 +519,7 @@ class TestInTotoRun(unittest.TestCase):
     """Successfully run, verify cwd. """
     link = in_toto_run(self.step_name, [], [], ["python", "--version"],
         record_environment=True)
-    self.assertEqual(link.signed.environment["workdir"], 
+    self.assertEqual(link.signed.environment["workdir"],
         os.getcwd().replace("\\", "/"))
 
   def test_normalize_line_endings(self):
@@ -664,7 +664,7 @@ class TestInTotoRecordStop(unittest.TestCase):
     in_toto_record_start(self.step_name, [], self.key, record_environment=True)
     in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
-    self.assertEqual(link.signed.environment["workdir"], 
+    self.assertEqual(link.signed.environment["workdir"],
         os.getcwd().replace('\\', '/'))
     os.remove(self.link_name)
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -513,7 +513,7 @@ class TestInTotoRun(unittest.TestCase):
         [self.test_artifact], ["python", "--version"], True, self.key)
     link_dump = Metablock.load(
         FILENAME_FORMAT.format(step_name=self.step_name, keyid=self.key["keyid"]))
-    self.assertEquals(repr(link), repr(link_dump))
+    self.assertEqual(repr(link), repr(link_dump))
 
   def test_in_toto_run_verify_recorded_artifacts(self):
     """Successfully run, verify properly recorded artifacts. """
@@ -526,7 +526,7 @@ class TestInTotoRun(unittest.TestCase):
     """Successfully run, verify cwd. """
     link = in_toto_run(self.step_name, [], [], ["python", "--version"],
         record_environment=True)
-    self.assertEquals(link.signed.environment["workdir"], 
+    self.assertEqual(link.signed.environment["workdir"], 
         os.getcwd().replace("\\", "/"))
 
   def test_normalize_line_endings(self):
@@ -607,7 +607,7 @@ class TestInTotoRecordStart(unittest.TestCase):
     in_toto_record_start(
         self.step_name, [self.test_material], self.key)
     link = Metablock.load(self.link_name_unfinished)
-    self.assertEquals(list(link.signed.materials.keys()), [self.test_material])
+    self.assertEqual(list(link.signed.materials.keys()), [self.test_material])
     os.remove(self.link_name_unfinished)
 
   def test_create_unfininished_metadata_verify_signature(self):
@@ -663,7 +663,7 @@ class TestInTotoRecordStop(unittest.TestCase):
     in_toto_record_start(self.step_name, [], self.key)
     in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
-    self.assertEquals(list(link.signed.products.keys()), [self.test_product])
+    self.assertEqual(list(link.signed.products.keys()), [self.test_product])
     os.remove(self.link_name)
 
   def test_create_metadata_with_expected_cwd(self):
@@ -671,7 +671,7 @@ class TestInTotoRecordStop(unittest.TestCase):
     in_toto_record_start(self.step_name, [], self.key, record_environment=True)
     in_toto_record_stop(self.step_name, [self.test_product], self.key)
     link = Metablock.load(self.link_name)
-    self.assertEquals(link.signed.environment["workdir"], 
+    self.assertEqual(link.signed.environment["workdir"], 
         os.getcwd().replace('\\', '/'))
     os.remove(self.link_name)
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -34,8 +34,7 @@ from in_toto.runlib import (in_toto_run, in_toto_record_start,
     _hash_artifact)
 from in_toto.util import (generate_and_write_rsa_keypair,
     prompt_import_rsa_key_from_file)
-from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
-    FILENAME_FORMAT_SHORT)
+from in_toto.models.link import UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT
 
 import securesystemslib.formats
 import securesystemslib.exceptions

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -682,7 +682,7 @@ class TestInTotoRecordStop(unittest.TestCase):
     in_toto_record_stop(self.step_name, [], self.key)
     with self.assertRaises(IOError):
       open(self.link_name_unfinished, "r")
-    open(self.link_name, "r")
+    self.assertTrue(os.path.isfile(self.link_name))
     os.remove(self.link_name)
 
   def test_missing_unfinished_file(self):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -18,8 +18,6 @@
   Test runlib functions.
 
 """
-import six
-
 import os
 import unittest
 import shutil
@@ -149,10 +147,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
       with self.assertRaises(ValueError):
         record_artifacts_as_dict(["."], base_path=base_path)
 
-    def tearDown(self):
-      """ change back to the test dir, in case any tests fail """
-      os.chdir(self.test_dir)
-
 
   def test_base_path_is_child_dir(self):
     """Test path of recorded artifacts and cd back with child as base."""
@@ -280,7 +274,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Traverse dir and subdirs. Record three files. """
     artifacts_dict = record_artifacts_as_dict(["."])
 
-    for key, val in six.iteritems(artifacts_dict):
+    for val in list(artifacts_dict.values()):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(list(artifacts_dict.keys())),
@@ -386,7 +380,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase):
     """Explicitly record files and subdirs. """
     artifacts_dict = record_artifacts_as_dict(["foo", "subdir"])
 
-    for key, val in six.iteritems(artifacts_dict):
+    for val in list(artifacts_dict.values()):
       securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
 
     self.assertListEqual(sorted(list(artifacts_dict.keys())),

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -18,10 +18,7 @@
 import six
 
 import os
-import sys
 import unittest
-import shutil
-import tempfile
 import in_toto.settings
 import in_toto.user_settings
 

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -71,8 +71,8 @@ class TestUserSettings(unittest.TestCase):
     self.assertListEqual(rc_dict["ARTIFACT_EXCLUDE_PATTERNS"], ["r", "c", "file"])
 
     # Parsed but ignored in `set_settings` (not in case sensitive whitelist)
-    self.assertEquals(rc_dict["artifact_base_path"], "r/c/file")
-    self.assertEquals(rc_dict["new_rc_setting"], "new rc setting")
+    self.assertEqual(rc_dict["artifact_base_path"], "r/c/file")
+    self.assertEqual(rc_dict["new_rc_setting"], "new rc setting")
 
 
   def test_get_env(self):
@@ -80,14 +80,14 @@ class TestUserSettings(unittest.TestCase):
     env_dict = in_toto.user_settings.get_env()
 
     # Parsed and used by `set_settings` to monkeypatch settings
-    self.assertEquals(env_dict["ARTIFACT_BASE_PATH"], "e/n/v")
+    self.assertEqual(env_dict["ARTIFACT_BASE_PATH"], "e/n/v")
 
     # Parsed (and split) but overriden by rcfile setting in `set_settings`
     self.assertListEqual(env_dict["ARTIFACT_EXCLUDE_PATTERNS"],
         ["e", "n", "v"])
 
     # Parsed but ignored in `set_settings` (not in case sensitive whitelist)
-    self.assertEquals(env_dict["NOT_WHITELISTED"], "parsed")
+    self.assertEqual(env_dict["NOT_WHITELISTED"], "parsed")
 
     # Not parsed because of missing prefix
     self.assertFalse("NOT_PARSED" in env_dict)
@@ -98,7 +98,7 @@ class TestUserSettings(unittest.TestCase):
     in_toto.user_settings.set_settings()
 
     # From envvar IN_TOTO_ARTIFACT_BASE_PATH
-    self.assertEquals(in_toto.settings.ARTIFACT_BASE_PATH, "e/n/v")
+    self.assertEqual(in_toto.settings.ARTIFACT_BASE_PATH, "e/n/v")
 
     # From RCfile setting (has precedence over envvar setting)
     self.assertListEqual(in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,16 +20,8 @@
 
 import os
 import shutil
-import sys
 import tempfile
 import unittest
-
-# Use external backport 'mock' on versions under 3.3
-if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-
-else:
-  import mock
 
 from mock import patch
 
@@ -46,6 +38,7 @@ from in_toto.util import (
     prompt_import_rsa_key_from_file,
     import_gpg_public_keys_from_keyring_as_dict)
 
+from in_toto.exceptions import UnsupportedKeyTypeError
 import securesystemslib.formats
 import securesystemslib.exceptions
 from securesystemslib.interface import (import_ed25519_privatekey_from_file,
@@ -76,14 +69,9 @@ class TestUtil(unittest.TestCase):
     shutil.rmtree(self.test_dir)
 
   def test_unrecognized_key_type(self):
-    """Create and read the wrong key type. """
-    wrong_key_type = "wrong_key_type"
-    open(wrong_key_type, "w").write(wrong_key_type)
-
-    # Give wrong password whenever prompted.
-    with mock.patch('in_toto.util.prompt_password', return_value='x'):
-      with self.assertRaises(TypeError):
-        import_private_key_from_file(wrong_key_type)
+    """Trigger UnsupportedKeyTypeError. """
+    with self.assertRaises(UnsupportedKeyTypeError):
+      import_private_key_from_file("ignored_key_path", "wrong_key_type")
 
   def test_create_and_import_rsa(self):
     """Create RS key and import private and public key separately. """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -118,9 +118,9 @@ class TestUtil(unittest.TestCase):
     bits = 3072
     generate_and_write_rsa_keypair(name, bits, password)
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
-      private_key = import_rsa_key_from_file(name)
+      import_rsa_key_from_file(name)
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
-      private_key = import_rsa_key_from_file(name, "wrong-password")
+      import_rsa_key_from_file(name, "wrong-password")
 
   def test_import_non_existing_rsa(self):
     """Try import non-existing RSA key, raises exception. """
@@ -190,9 +190,9 @@ class TestUtil(unittest.TestCase):
     password = "123456"
     generate_and_write_ed25519_keypair(name, password)
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
-      private_key = import_ed25519_privatekey_from_file(name)
+      import_ed25519_privatekey_from_file(name)
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
-      private_key = import_ed25519_privatekey_from_file(name, "wrong-password")
+      import_ed25519_privatekey_from_file(name, "wrong-password")
 
   def test_import_ed25519_public_keys_from_files_as_dict(self):
     """Create and import multiple Ed25519 public keys and return KEYDICT. """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -35,7 +35,7 @@ from mock import patch
 
 import in_toto.formats
 from in_toto.util import (
-    KEY_TYPE_ED25519, KEY_TYPE_RSA,
+    KEY_TYPE_ED25519,
     generate_and_write_rsa_keypair,
     generate_and_write_ed25519_keypair,
     import_rsa_key_from_file,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -118,7 +118,8 @@ class TestUtil(unittest.TestCase):
   def test_import_rsa_wrong_format(self):
     """Try import wrongly formatted RSA key, raises exception. """
     not_an_rsa = "not_an_rsa"
-    open(not_an_rsa, "w").write(not_an_rsa)
+    with open(not_an_rsa, "w") as f:
+      f.write(not_an_rsa)
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       import_rsa_key_from_file(not_an_rsa)
 
@@ -136,7 +137,8 @@ class TestUtil(unittest.TestCase):
 
     # Import wrongly formatted key raises an exception
     not_an_rsa = "not_an_rsa"
-    open(not_an_rsa, "w").write(not_an_rsa)
+    with open(not_an_rsa, "w") as f:
+      f.write(not_an_rsa)
 
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       import_public_keys_from_files_as_dict([name1 + ".pub", not_an_rsa])
@@ -203,7 +205,8 @@ class TestUtil(unittest.TestCase):
 
     # Import wrongly formatted key raises an exception
     not_an_ed25519 = "not_an_ed25519"
-    open(not_an_ed25519, "w").write(not_an_ed25519)
+    with open(not_an_ed25519, "w") as f:
+      f.write(not_an_ed25519)
 
     with self.assertRaises(securesystemslib.exceptions.Error):
       import_public_keys_from_files_as_dict([name1 + ".pub",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,11 +19,15 @@
 """
 
 import os
+import sys
 import shutil
 import tempfile
 import unittest
 
-from mock import patch
+if sys.version_info >= (3, 3):
+  from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
+else:
+  from mock import patch # pylint: disable=import-error
 
 import in_toto.formats
 from in_toto.util import (

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -1455,7 +1455,6 @@ class TestInTotoVerifyMultiLevelSublayouts(unittest.TestCase):
         keys["alice_pub"]["keyid"]: keys["alice_pub"]
       }
 
-    root_layout_name = "root.layout"
     root_layout_step_name = "delegated-to-bob"
 
     root_layout = Metablock(signed=Layout(

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -315,10 +315,10 @@ class TestVerifyRule(unittest.TestCase):
         exception = e
 
       if should_raise and not exception:
-         self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
+        self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
 
       if exception and not should_raise:
-          self.fail("Unexpected {}\n{}".format(exception, msg))
+        self.fail("Unexpected {}\n{}".format(exception, msg))
 
 
   def test_verify_require_rule(self):
@@ -347,10 +347,10 @@ class TestVerifyRule(unittest.TestCase):
         exception = e
 
       if should_raise and not exception:
-         self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
+        self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
 
       if exception and not should_raise:
-          self.fail("Unexpected {}\n{}".format(exception, msg))
+        self.fail("Unexpected {}\n{}".format(exception, msg))
 
 
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -19,13 +19,19 @@
 """
 
 import os
+import sys
 import shutil
 import copy
 import tempfile
 import unittest
 import glob
 import shlex
-from mock import patch
+
+if sys.version_info >= (3, 3):
+  from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
+else:
+  from mock import patch # pylint: disable=import-error
+
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -103,7 +103,8 @@ class TestRunAllInspections(unittest.TestCase):
     self.working_dir = os.getcwd()
     self.test_dir = os.path.realpath(tempfile.mkdtemp())
     os.chdir(self.test_dir)
-    open("foo", "w").write("foo")
+    with open("foo", "w") as f:
+      f.write("foo")
 
   @classmethod
   def tearDownClass(self):
@@ -115,7 +116,8 @@ class TestRunAllInspections(unittest.TestCase):
     """Create new dummy test dir and set as base path, must ignore. """
     ignore_dir = os.path.realpath(tempfile.mkdtemp())
     ignore_foo = os.path.join(ignore_dir, "ignore_foo")
-    open(ignore_foo, "w").write("ignore foo")
+    with open(ignore_foo, "w") as f:
+      f.write("ignore foo")
     in_toto.settings.ARTIFACT_BASE_PATH = ignore_dir
 
     run_all_inspections(self.layout)

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -708,8 +708,8 @@ class TestInTotoVerify(unittest.TestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     # copy scripts over
     shutil.copytree(scripts_directory, "scripts")
@@ -1363,8 +1363,8 @@ class TestVerifySublayouts(unittest.TestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     # copy portable scripts over
     shutil.copytree(scripts_directory, 'scripts')
@@ -1639,8 +1639,8 @@ class TestGetSummaryLink(unittest.TestCase):
     os.chdir(self.test_dir)
 
     # Copy demo files to temp dir
-    for file in os.listdir(demo_files):
-      shutil.copy(os.path.join(demo_files, file), self.test_dir)
+    for fn in os.listdir(demo_files):
+      shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     self.demo_layout = Metablock.load("demo.layout.template")
     self.code_link = Metablock.load("package.2f89b927.link")

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -1659,14 +1659,14 @@ class TestGetSummaryLink(unittest.TestCase):
     """Create summary link from demo link files and compare properties. """
     sum_link = get_summary_link(self.demo_layout.signed, self.demo_links, "")
 
-    self.assertEquals(sum_link.signed._type, self.code_link.signed._type)
-    self.assertEquals(sum_link.signed.name, "")
-    self.assertEquals(sum_link.signed.materials, self.code_link.signed.materials)
+    self.assertEqual(sum_link.signed._type, self.code_link.signed._type)
+    self.assertEqual(sum_link.signed.name, "")
+    self.assertEqual(sum_link.signed.materials, self.code_link.signed.materials)
 
-    self.assertEquals(sum_link.signed.products, self.package_link.signed.products)
-    self.assertEquals(sum_link.signed.command, self.package_link.signed.command)
-    self.assertEquals(sum_link.signed.byproducts, self.package_link.signed.byproducts)
-    self.assertEquals(sum_link.signed.byproducts.get("return-value"),
+    self.assertEqual(sum_link.signed.products, self.package_link.signed.products)
+    self.assertEqual(sum_link.signed.command, self.package_link.signed.command)
+    self.assertEqual(sum_link.signed.byproducts, self.package_link.signed.byproducts)
+    self.assertEqual(sum_link.signed.byproducts.get("return-value"),
         self.package_link.signed.byproducts.get("return-value"))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     bandit
 
 commands =
-    # Run pylint, using secure system lab's pylintrc configuration file
+    # Run pylint, using the Secure System Lab's pylintrc as base config
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
     pylint in_toto
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ commands =
     # Run pylint, using the Secure System Lab's pylintrc as base config
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
     pylint in_toto
+    # Run pylint on tests too, allowing protected member access (W0212)
+    pylint tests --disable W0212
 
     # Run bandit, a security linter from OpenStack Security
     # Note: We exclude tests that fail on importing or using the subprocess or

--- a/tox.ini
+++ b/tox.ini
@@ -22,22 +22,20 @@ commands =
     pylint tests --disable W0212
 
     # Run bandit, a security linter from OpenStack Security
-    # Note: We exclude tests that fail on importing or using the subprocess or
-    # subprocess32 modules, which are considered to have low severity security
-    # implications, but are required by in-toto. We do not skip subprocess
-    # calls with shell=True (B602).
-    # https://docs.openstack.org/bandit/latest/blacklists/blacklist_imports.html#b404-import-subprocess
-    # https://docs.openstack.org/bandit/latest/plugins/subprocess_popen_with_shell_equals_true.html
-    # https://docs.openstack.org/bandit/latest/plugins/subprocess_without_shell_equals_true.html
-    bandit -r in_toto --skip B404,B603,B303 -x in_toto/util.py
-    # Note: We exclude tests that fail on specifying the default value of a variable resembling a password
-    # for in_toto/util.py as it is a false positive. We actually never use hardcoded passwords.
-    # https://docs.openstack.org/bandit/latest/plugins/b107_hardcoded_password_funcdef.html
-    # Furthermore, for GPG we are *required* to use SHA1 as the hash function to compute
-    # keyids, so B303 is added
-    bandit in_toto/util.py --skip B107,B404,B603,B303
+    # Exclude files that need special treatment and are tested below
+    bandit -r in_toto -x in_toto/util.py,in_toto/process.py,in_toto/gpg/util.py
+    # Ignore false positive "hardcoded password" warning
+    # NOTE: Should become obsolete with in-toto/in-toto#80
+    # https://bandit.readthedocs.io/en/latest/plugins/b107_hardcoded_password_funcdef.html
+    bandit in_toto/util.py --skip B107
+    # Allow blacklisted but required subprocess
+    # https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b404-import-subprocess
+    bandit in_toto/process.py --skip B404
+    # Allow blacklisted SHA1 required for gpg keyids
+    # TODO: Will become obsolete with in-toto/in-toto#275
+    # https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5
+    bandit in_toto/gpg/util.py --skip B303
 
-    # Integrating tox with setup.py test is as p of Oct 2016 discouraged
-    # http://tox.readthedocs.io/en/latest/example/basic.html#integration-with-setup-py-test-command
+    # Run unittests with coverage
     coverage run tests/runtests.py
     coverage report -m --fail-under 99


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
This PR
- enables  trailing whitespace check in `pylint` and fixes trailing whitespace  (fb7e46c),
- updates the usage of `bandit` in `tox` (5518bf3)
- removes the obsolete ci requirement pytest (1cb0ec3)
- enables `pylint` for the tests and fixes thereby unmasked errors (2f12af2 ff.)

Despite the large diff, the PR should be easy to review, as most changes are rather mechanical/repetitive.

I strongly recommend to review commit by commit.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


