### PR TITLE
in_toto_verifylib: fix require/disallow queue

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1038,7 +1038,11 @@ def verify_item_rules(source_name, source_type, rules, links):
     _type = rule_data["rule_type"]
     _pattern = rule_data["pattern"]
 
-    # All rules except "disallow" consume artifacts in the queue
+
+    # Initialize empty consumed set as fallback for rules that do not consume
+    # artifacts. All rules except "disallow" and "require" consume artifacts.
+    consumed = set()
+
     if _type == "match":
       consumed = verify_match_rule(
           rule_data, artifacts_queue, artifacts, links)
@@ -1062,11 +1066,9 @@ def verify_item_rules(source_name, source_type, rules, links):
     # artifacts were not consumed as intended
     elif _type == "disallow":
       verify_disallow_rule(_pattern, artifacts_queue)
-      consumed = set()
 
     elif _type == "require":
       verify_require_rule(_pattern, artifacts_queue)
-      consumed = set()
 
     else: # pragma: no cover (unreachable)
       raise securesystemslib.exceptions.FormatError(

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -958,13 +958,15 @@ def verify_item_rules(source_name, source_type, rules, links):
     The mode of operation is similar to that of a firewall:
     In the beginning all materials or products of the step or inspection are
     placed into an artifact queue. The rules are then applied sequentially,
-    consuming artifacts in the queue, i.e. removing them from the queue, on
-    success.
-    The only exception is the "DISALLOW" rule. It does not consume artifacts
-    but instead raises a RuleVerificationError if its pattern matches any
-    artifacts in the queue.
-    Thus, each set of rules should have a terminal "DISALLOW" rule in order
-    to be effective.
+    consuming artifacts in the queue, i.e. removing them from the queue upon
+    successful application.
+
+    The consumption of artifacts by itself has no effects on the verification.
+    Only through a subsequent "DISALLOW" rule, that finds unconsumed artifacts,
+    is an exception raised. Similarly does the "REQUIRE" rule raise exception,
+    if it does not find the artifact it requires, because it has falsely been
+    consumed or was not there from the beginning.
+
 
 
   <Arguments>
@@ -994,8 +996,8 @@ def verify_item_rules(source_name, source_type, rules, links):
         format.
 
     RuleVerificationError
-        if a DISALLOW rule matches any artifacts in the corresponding artifact
-        queue.
+        if a DISALLOW rule matches disallowed artifacts, or
+        if a REQUIRE rule does not find a required artifact.
 
   <Side Effects>
     Clears and populates the global RULE_TRACE data structure.

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1062,11 +1062,11 @@ def verify_item_rules(source_name, source_type, rules, links):
     # artifacts were not consumed as intended
     elif _type == "disallow":
       verify_disallow_rule(_pattern, artifacts_queue)
-      consumed = artifacts_queue
+      consumed = set()
 
     elif _type == "require":
       verify_require_rule(_pattern, artifacts_queue)
-      consumed = artifacts_queue
+      consumed = set()
 
     else: # pragma: no cover (unreachable)
       raise securesystemslib.exceptions.FormatError(


### PR DESCRIPTION
**Fixes issue #**: None

**Description of the changes being introduced by the pull request**:

This reverts commit 21129a6e52ad848fe34e40dcf942bea089c72060 and
replaces the consumed = artifacts_queue with consumed = set(), the
reason as to why is that a require rule passing overwrites all the queue
with a set() call...


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature