### PR TITLE
Add DCO info and slightly reword contributor info

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,21 +14,25 @@ contributors.  The project's Consensus Builder (CB) is
 Justin Cappos <jcappos@nyu.edu, @JustinCappos>.
 
 ## Contributions
-A contributor can [submit GitHub pull
-requests](https://github.com/in-toto/in-toto#instructions-for-contributors)
-to the project's repositories.  They must follow the project's [code of
-conduct](CODE-OF-CONDUCT.md), the [code style
+A contributor can submit GitHub pull requests to the project's repositories.
+They must follow the project's [code of
+conduct](CODE-OF-CONDUCT.md), the [Developer Certificate of
+Origin (DCO)](https://developercertificate.org/) and the [code style
 guidelines](https://github.com/secure-systems-lab/code-style-guidelines), and
-must unit test any new software feature or change.  Submitted pull requests
-undergo review and automated testing, including, but not limited to:
+they must unit test any new software feature or change.  Submitted pull
+requests undergo review and automated testing, including, but not limited to:
 
 * Unit and build testing via [Tox](https://tox.readthedocs.io/en/latest/) on
 [Travis CI](https://travis-ci.org/in-toto/in-toto) and
 [AppVeyor](https://ci.appveyor.com/project/in-toto/in-toto)
 * Static code analysis via [Pylint](https://www.pylint.org/) and
 [Bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit)
-* Review by one or more maintainers
+* Checks for *Signed-off-by* commits via [Probot: DCO](https://probot.github.io/apps/dco/)
+* Review by one or more [maintainers](MAINTAINERS.txt)
 
+See [*Instructions for
+Contributors*](https://github.com/in-toto/in-toto#instructions-for-contributors)
+for help.
 
 ## Changes in maintainership
 

--- a/README.md
+++ b/README.md
@@ -199,14 +199,18 @@ Please do not use the GitHub issue tracker to submit vulnerability reports. The
 issue tracker is intended for bug reports and to make feature requests.
 
 ## Instructions for Contributors
-Note: Development of in-toto occurs on the "develop" branch of this repository.
-
-Contributions can be made by submitting GitHub pull requests. Take a look at
+Development of in-toto occurs on the "develop" branch of this repository.
+Contributions can be made by submitting GitHub *Pull Requests*. Take a look at
 our [development
 guidelines](https://github.com/secure-systems-lab/lab-guidelines/blob/master/dev-workflow.md)
-for detailed instructions. Submitted code should follow our [code style
-guidelines](https://github.com/secure-systems-lab/code-style-guidelines),
-which provide examples of what to do (or not to do) when writing Python code.
+for detailed instructions. Submitted code should follow our [style
+guidelines](https://github.com/secure-systems-lab/code-style-guidelines) and
+must be unit tested.
+
+Contributors must also indicate acceptance of the [Developer Certificate of
+Origin (DCO)](https://developercertificate.org/) by appending a `Signed-off-by:
+Your Name <example@domain.com>` to each git commit message (see [`git commit
+--signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff)).
 
 
 ## Acknowledgments


### PR DESCRIPTION
**Fixes issue #**:
Related to #270 (close after updating CII best practice page)

**Description of the changes being introduced by the pull request**:
Update sections "Instructions for Contributors" in `README.md` and "Contributions" in `GOVERNANCE.md` to link to the "Developer Certificate of Origin (DCO)" and list its adherence, fulfilled by adding a `signed-off-by` line to commit messages, as a contribution requirement.

Also mentions used and useful tooling, i.e. probot and `git commit --signoff`.

Plus minor overhaul of contribution instruction texts.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


