### PR TITLE
Make pynacl optional

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,8 @@ install:
   - python -m pip install -U pip
   # Install mock, coverage, and pytest, which are needed for unit testing.
   - pip install -r requirements-ci.txt
+  # Ensure securesystemslib[pynacl] is available as it's required for tests
+  - pip install -r requirements.txt
   - pip install -e .
 
 build: false

--- a/setup.py
+++ b/setup.py
@@ -72,9 +72,18 @@ setup(
   python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests",
       "debian"]),
-  install_requires=["six", "securesystemslib[crypto,pynacl]>=0.11.3", "attrs",
+  install_requires=["six", "securesystemslib[crypto]>=0.11.3", "attrs",
                     "python-dateutil", "iso8601", "pathspec",
                     "subprocess32; python_version < '3'"],
+  extras_require={
+    # Install pynacl as optional dependency to use with securesystemslib, as a
+    # workaround for `"ssl-pynacl": ["securesystemslib[pynacl]>=0.11.3"]`,
+    # which currently is not supported in "extra_require" (see pypa/pip#4957).
+    # TODO: Keep track of changes (version, additional requirements) under the
+    # "pynacl" key in securesystemslib's setup.py.
+    # https://github.com/secure-systems-lab/securesystemslib/blob/master/setup.py#L101
+    "pynacl": ["pynacl>1.2.0"]
+  },
   test_suite="tests.runtests",
   tests_require=["mock"],
   entry_points={


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

install_requires should list "what a project minimally needs to run
correctly"[1](https://packaging.python.org/discussions/install-requires-vs-requirements) and the presence of these dependencies is checked at runtime
when the project is installed via pip.

The securesystemslib pynacl extras allow for faster implementations of
cryptographic algorithms, but aren't required in order to run - therefore
they should not be listed in install_requires.

**Note**: this change allows me to build/run in-toto on a cross-compiled Linux distro without first having to figure out how to cross-compile PyNaCl 😄

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


