### PR TITLE
Slighlty optimize tox builds and coverage measurement

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,12 +2,12 @@
 # enable branch coverage in addition to statement coverage
 branch = True
 
-[report]
-exclude_lines =
-  pragma: no cover
-  if __name__ == .__main__.:
-
 omit =
   */tests/*
   */python?.?/*
   */site-packages/*
+
+[report]
+exclude_lines =
+  pragma: no cover
+  if __name__ == .__main__.:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@
 # To run an individual test environment run e.g. tox -e py27
 [tox]
 envlist = py{27,35,36,37}
+skipsdist=True
 
 [testenv]
 deps =


### PR DESCRIPTION
**Fixes issue #**:
None. Motivated by uptane/uptane#195.

**Description of the changes being introduced by the pull request**:
Adds two changes that should make tox builds slightly faster:
- Removes obsolete  default `sdist` creation and in-toto installation inside tox
- Instructs coverage to omit certain files already while measuring and not only when reports are created.

See commit messages for details. Also consider reading uptane/uptane@af22701 for interesting background info about tox, python unittest and coverage.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


