### PR TITLE
Pass bytes to securesystemslib's signature functions

### DIFF
--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -77,16 +77,3 @@ class Signable(ValidationMixin):
 
     return securesystemslib.formats.encode_canonical(
         attr.asdict(self)).encode("UTF-8")
-
-  @property
-  def signable_dict(self):
-    """Returns the dictionary representation of Signable, which we pass to
-    securesystemslib signing and verifying functions, where it gets converted
-    to canonical JSON utf-8 encoded bytes before signing and verifying.
-
-    TODO: I'd rather fully control what data is signed here and not in the
-    crypto backend, i.e. pass signable_bytes to the signing/verifying
-    functions. This would require a change to securesystemslib.
-    """
-
-    return attr.asdict(self)

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -158,7 +158,7 @@ class Metablock(ValidationMixin):
     securesystemslib.formats.KEY_SCHEMA.check_match(key)
 
     signature = securesystemslib.keys.create_signature(key,
-        self.signed.signable_dict)
+        self.signed.signable_bytes)
 
     self.signatures.append(signature)
 
@@ -268,7 +268,7 @@ class Metablock(ValidationMixin):
 
     elif securesystemslib.formats.SIGNATURE_SCHEMA.matches(signature):
       valid = securesystemslib.keys.verify_signature(
-          verification_key, signature, self.signed.signable_dict)
+          verification_key, signature, self.signed.signable_bytes)
 
     else:
       valid = False

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -36,6 +36,6 @@ pathspec==0.5.9
 pycparser==2.19           # via cffi
 pynacl==1.3.0             # via securesystemslib
 python-dateutil==2.8.0
-securesystemslib[crypto,pynacl]==0.11.3
+securesystemslib[crypto,pynacl]==0.12.0
 six==1.12.0
 subprocess32==3.5.4 ; python_version < "3"

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
   python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
   packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests",
       "debian"]),
-  install_requires=["six", "securesystemslib[crypto]>=0.11.3", "attrs",
+  install_requires=["six", "securesystemslib[crypto]>=0.12.0", "attrs",
                     "python-dateutil", "iso8601", "pathspec",
                     "subprocess32; python_version < '3'"],
   extras_require={


### PR DESCRIPTION
This is a preparation for an upcoming securesystemslib release (i.e. >0.11.3). Don't merge before that release is available on PyPI!
--


**Fixes issue #**:
Adopting changes from secure-systems-lab/securesystemslib#162 

**Description of the changes being introduced by the pull request**:
This PR changes invocation of securesystemslib signature creation/verification functions to pass the pre-canonicalized and -encoded bytes representation of a signable instead of its dictionary representation.
(This also aligns with the way gpg signature creation/verification functions are called)

The PR also removes the obsolete `Signable.signable_dict` property. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


