### PR TITLE
Bump release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## in-toto v0.4.1
+
+* Update securesystemslib dependency to v0.12.0 (#299)
+* Add `--version` option to CLI tools (#310)
+* Address linter warnings (#308)
+* Update downstream debian metadata (#302, #305, #309)
+
 ## in-toto v0.4.0
 
 * Add REQUIRE artifact rule support (#269, #280)

--- a/in_toto/__init__.py
+++ b/in_toto/__init__.py
@@ -5,4 +5,4 @@ Configure base logger for in_toto (see in_toto.log for details).
 import in_toto.log
 
 # in-toto version
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
Patch-release for breaking changes in new `securesystemslib` version 0.12.0 (https://github.com/secure-systems-lab/securesystemslib/pull/184).

TODO:
- [x] Wait for `securesystemslib 0.12.0` to be released on PyPI
- [x] Merge https://github.com/in-toto/in-toto/pull/299 to adapt in-toto to breaking changes
- [x] Rebase this release PR onto in-toto's main branch
- [ ] Release `in-toto 0.4.1`