### PR TITLE
Remove unecessary `elif`s after break 

### DIFF
--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -254,7 +254,7 @@ class Metablock(ValidationMixin):
       if signature["keyid"] == verification_keyid:
         break
 
-      elif signature["keyid"] in list(
+      if signature["keyid"] in list(
           verification_key.get("subkeys", {}).keys()):
         break
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -448,18 +448,18 @@ def verify_link_signature_thresholds(layout, chain_link_dict):
         authorized_key = layout.keys.get(authorized_keyid)
         main_key_for_subkey = main_keys_for_subkeys.get(authorized_keyid)
 
-        # The signing key is authorized
+        # The signing key is authorized ...
         if authorized_key and link_keyid == authorized_keyid:
           verification_key = authorized_key
           break
 
-        # The signing key is an authorized subkey
-        elif main_key_for_subkey and link_keyid == authorized_keyid:
+        # ... or the signing key is an authorized subkey ...
+        if main_key_for_subkey and link_keyid == authorized_keyid:
           verification_key = main_key_for_subkey
           break
 
-        # The signing key is a subkey of an authorized key
-        elif (authorized_key and
+        # ... or the signing key is a subkey of an authorized key
+        if (authorized_key and
             link_keyid in authorized_key.get("subkeys", {}).keys()):
           verification_key = authorized_key
           break


### PR DESCRIPTION
**Fixes issue #**:
None.

**Description of the changes being introduced by the pull request**:
Pylint, of late, flags these constructs and make ours tests fail:

```
lint run-test: commands[0] | pylint in_toto
************* Module in_toto.verifylib
in_toto/verifylib.py:452:8: R1723: Unnecessary "elif" after "break" (no-else-break)
************* Module in_toto.models.metadata
in_toto/models/metadata.py:254:6: R1723: Unnecessary "elif" after "break" (no-else-break)
```

Let's make pylint happy.

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


