### PR TITLE
Add version option to CLI

### DIFF
--- a/in_toto/__init__.py
+++ b/in_toto/__init__.py
@@ -3,3 +3,6 @@ Configure base logger for in_toto (see in_toto.log for details).
 
 """
 import in_toto.log
+
+# in-toto version
+__version__ = "0.4.0"

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -46,6 +46,7 @@ import argparse
 import logging
 
 import in_toto.util
+from in_toto import __version__
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 LOG = logging.getLogger("in_toto")
@@ -90,6 +91,9 @@ def parse_args():
   in_toto_args.add_argument("-b", "--bits", default=3072, type=int,
                             help="The key size, or key length, of the RSA "
                             "key.", metavar="<bits>")
+
+  parser.add_argument('--version', action='version',
+                      version='{} {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -54,6 +54,7 @@ import sys
 import argparse
 import logging
 import in_toto.runlib
+from in_toto import __version__
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 LOG = logging.getLogger("in_toto")
@@ -97,6 +98,10 @@ examples:
       help=(
       "Command to be executed with options and arguments, separated from"
       " 'in-toto-mock' options by double dash '--'."))
+
+  # version
+  parser.add_argument('--version', action='version',
+                      version='{} version {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -37,6 +37,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             display version number and exit
 
 required named arguments:
   -n <name>, --name <name>

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -99,9 +99,8 @@ examples:
       "Command to be executed with options and arguments, separated from"
       " 'in-toto-mock' options by double dash '--'."))
 
-  # version
   parser.add_argument('--version', action='version',
-                      version='{} version {}'.format(parser.prog, __version__))
+                      version='{} {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -120,6 +120,7 @@ import logging
 import in_toto.util
 import in_toto.user_settings
 import in_toto.runlib
+from in_toto import __version__
 
 from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
     BASE_PATH_ARGS, BASE_PATH_KWARGS, LSTRIP_PATHS_ARGS,
@@ -240,6 +241,10 @@ examples:
       " resulting link metadata's product section when running the 'stop'"
       " subcommand. Symlinks are followed."))
 
+  # version
+  parser.add_argument('--version', action='version',
+                      version='{} version {}'.format(parser.prog, __version__))
+                      
   args = parser.parse_args()
 
   LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -241,10 +241,9 @@ examples:
       " resulting link metadata's product section when running the 'stop'"
       " subcommand. Symlinks are followed."))
 
-  # version
   parser.add_argument('--version', action='version',
-                      version='{} version {}'.format(parser.prog, __version__))
-                      
+                      version='{} {}'.format(parser.prog, __version__))
+
   args = parser.parse_args()
 
   LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -44,6 +44,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             display version number and exit
   -k <path>, --key <path>
                         Path to a PEM formatted private key file used to sign
                         the resulting link metadata. (passing one of '--key'

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -223,9 +223,8 @@ examples:
       "Command to be executed with options and arguments, separated from"
       " 'in-toto-run' options by double dash '--'."))
 
-  # version
   parser.add_argument('--version', action='version',
-                      version='{} version {}'.format(parser.prog, __version__))
+                      version='{} {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -109,7 +109,7 @@ import sys
 import argparse
 import logging
 import in_toto.user_settings
-from in_toto import (util, runlib)
+from in_toto import (util, runlib, __version__)
 
 from in_toto.common_args import (EXCLUDE_ARGS, EXCLUDE_KWARGS,
     BASE_PATH_ARGS, BASE_PATH_KWARGS, LSTRIP_PATHS_ARGS,
@@ -222,6 +222,10 @@ examples:
       help=(
       "Command to be executed with options and arguments, separated from"
       " 'in-toto-run' options by double dash '--'."))
+
+  # version
+  parser.add_argument('--version', action='version',
+                      version='{} version {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -36,6 +36,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             display version number and exit
   -m <path> [<path> ...], --materials <path> [<path> ...]
                         Paths to files or directories, whose paths and hashes
                         are stored in the resulting link metadata before the

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -39,6 +39,7 @@ Returns nonzero value on failure and zero otherwise.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             display version number and exit
   -k <path> [<path> ...], --key <path> [<path> ...]
                         Path(s) to PEM formatted key file(s), used to sign the
                         passed link or layout metadata or to verify its

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -374,10 +374,9 @@ examples:
   verbosity_args.add_argument("-q", "--quiet", dest="quiet",
       help="Suppress all output.", action="store_true")
 
-  # version
   parser.add_argument('--version', action='version',
-                      version='{} version {}'.format(parser.prog, __version__))
-                      
+                      version='{} {}'.format(parser.prog, __version__))
+
   args = parser.parse_args()
 
   LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -109,6 +109,7 @@ from in_toto import exceptions, util
 from in_toto.models.link import FILENAME_FORMAT
 from in_toto.models.metadata import Metablock
 import in_toto.gpg.functions
+from in_toto import __version__
 
 import securesystemslib.formats
 
@@ -373,6 +374,10 @@ examples:
   verbosity_args.add_argument("-q", "--quiet", dest="quiet",
       help="Suppress all output.", action="store_true")
 
+  # version
+  parser.add_argument('--version', action='version',
+                      version='{} version {}'.format(parser.prog, __version__))
+                      
   args = parser.parse_args()
 
   LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -96,6 +96,7 @@ import logging
 import in_toto.util
 from in_toto import verifylib
 from in_toto.models.metadata import Metablock
+from in_toto import __version__
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
 LOG = logging.getLogger("in_toto")
@@ -199,6 +200,10 @@ examples:
 
   verbosity_args.add_argument("-q", "--quiet", dest="quiet",
       help="Suppress all output.", action="store_true")
+
+  # version
+  parser.add_argument('--version', action='version',
+                      version='{} version {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -201,9 +201,8 @@ examples:
   verbosity_args.add_argument("-q", "--quiet", dest="quiet",
       help="Suppress all output.", action="store_true")
 
-  # version
   parser.add_argument('--version', action='version',
-                      version='{} version {}'.format(parser.prog, __version__))
+                      version='{} {}'.format(parser.prog, __version__))
 
   args = parser.parse_args()
 

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -41,6 +41,7 @@ The command returns a nonzero value if verification fails and zero otherwise.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --version             display version number and exit
   --link-dir <path>     Path to directory where link metadata files for steps
                         defined in the root layout should be loaded from. If
                         not passed links are loaded from the current working

--- a/setup.py
+++ b/setup.py
@@ -31,16 +31,26 @@
     pip install git+https://github.com/in-toto/in-toto@develop
     ```
 """
+import os
+import re
+
 from setuptools import setup, find_packages
 
-version = "0.4.0"
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+
+def get_version(filename="in_toto/__init__.py"):
+  with open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
+    for line in initfile.readlines():
+      m = re.match("__version__ *= *['\"](.*)['\"]", line)
+      if m:
+        return m.group(1)
 
 with open("README.md") as f:
   long_description = f.read()
 
 setup(
   name="in-toto",
-  version=version,
   author="New York University: Secure Systems Lab",
   author_email="in-toto-dev@googlegroups.com",
   url="https://in-toto.io",
@@ -98,4 +108,5 @@ setup(
     "Source": "https://github.com/in-toto/in-toto",
     "Bug Reports": "https://github.com/in-toto/in-toto/issues",
   },
+  version=get_version(),
 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@
     pip install git+https://github.com/in-toto/in-toto@develop
     ```
 """
+import io
 import os
 import re
 
@@ -40,7 +41,15 @@ from setuptools import setup, find_packages
 base_dir = os.path.dirname(os.path.abspath(__file__))
 
 def get_version(filename="in_toto/__init__.py"):
-  with open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
+  """
+  Gather version number from specified file.
+
+  This is done through regex processing, so the file is not imported or
+  otherwise executed.
+
+  No format verification of the resulting version number is done.
+  """
+  with io.open(os.path.join(base_dir, filename), encoding="utf-8") as initfile:
     for line in initfile.readlines():
       m = re.match("__version__ *= *['\"](.*)['\"]", line)
       if m:


### PR DESCRIPTION
Closes #303


**Fixes issue #**: #303 

**Description of the changes being introduced by the pull request**: Adds a command-line option `--version` to the various CLI scripts.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [?] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature

Is there a test needed for something like this? If so, you'll have to point me to where (is `--help` tested?).

P.S. The 2 space indentation is kind of odd... but you're consistent with it, so power to you!