### PR TITLE
Add Python 3.8 to tested versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
           env: TOXENV=py36
         - python: "3.7"
           env: TOXENV=py37
-        - python: "3.7"
+        - python: "3.8"
+          env: TOXENV=py38
+        - python: "3.8"
           env: TOXENV=lint
 
 install:

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -10,10 +10,10 @@
 #   updates.
 #
 # # Gather pip-compile results for each supported Python version
-# for v in 2.7 3.5 3.6 3.7; do
+# for v in 2.7 3.5 3.6 3.7 3.8; do
 #   mkvirtualenv in-toto-env-${v} -p python${v};
 #   pip install pip-tools;
-#   pip-compile requirements.txt -n | grep -v "^#" >> requirements-pinned.combined;
+#   pip-compile requirements.txt -n 2>&1 | grep -v "^#" >> requirements-pinned.combined;
 #   deactivate;
 #   rmvirtualenv in-toto-env-${v};
 # done;
@@ -24,7 +24,6 @@
 # cat requirements-pinned.combined | sort -u >> requirements-pinned.txt
 # rm requirements-pinned.combined
 #
-asn1crypto==1.2.0        # via cryptography
 attrs==19.3.0
 cffi==1.13.2              # via cryptography, pynacl
 colorama==0.4.3           # via securesystemslib
@@ -36,5 +35,6 @@ pathspec==0.7.0
 pycparser==2.19           # via cffi
 pynacl==1.3.0             # via securesystemslib
 python-dateutil==2.8.1
-securesystemslib[crypto,pynacl]==0.12.2
+securesystemslib[crypto,pynacl]==0.13.1
 six==1.13.0
+subprocess32==3.5.4       # via securesystemslib

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 # To run an individual test environment run e.g. tox -e py27
 [tox]
-envlist = lint,py{27,35,36,37}
+envlist = lint,py{27,35,36,37,38}
 skipsdist=True
 
 


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:

- Enable Py 3.8 for tox
- Enable Py 3.8 for travis
- Bump linting tox build Py version from 3.7 to 3.8
- Re-compile requirements-pinned.txt to combine pinned deps for
  all supported Python versions:
  - Removes obsolete transitive dep 'asn1crypto'
  - Updates securesystemslib to latest version
  - Re-adds transitive dependency subprocess
- Add Py 3.8 language classifier to setup.py


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


