### PR TITLE
Use kwargs in in-toto-run to fix lstrip-paths bug

### DIFF
--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -265,10 +265,11 @@ examples:
       key = util.import_private_key_from_file(args.key, args.key_type)
 
     runlib.in_toto_run(
-        args.step_name, args.materials, args.products,
-        args.link_cmd, args.record_streams, key, gpg_keyid, gpg_use_default,
-        args.gpg_home, args.exclude_patterns, args.base_path,
-        args.lstrip_paths)
+        args.step_name, args.materials, args.products, args.link_cmd,
+        record_streams=args.record_streams, signing_key=key,
+        gpg_keyid=gpg_keyid, gpg_use_default=gpg_use_default,
+        gpg_home=args.gpg_home, exclude_patterns=args.exclude_patterns,
+        base_path=args.base_path, lstrip_paths=args.lstrip_paths)
 
   except Exception as e:
     LOG.error("(in-toto-run) {0}: {1}".format(type(e).__name__, e))

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -147,13 +147,14 @@ class TestInTotoRunTool(tests.common.CliTestCase):
       self.assert_cli_sys_exit(args4, 1)
 
       # Test with lstrip path
-      args5 = named_args + ["--lstrip-paths", self.test_dir] + positional_args
+      strip_prefix = self.test_artifact[:-1]
+      args5 = named_args + ["--lstrip-paths", strip_prefix] + positional_args
       self.assert_cli_sys_exit(args5, 0)
       link_metadata = Metablock.load(self.test_link_rsa)
       self.assertListEqual(list(link_metadata.signed.materials.keys()),
-          [self.test_artifact])
+          [self.test_artifact[len(strip_prefix):]])
       self.assertListEqual(list(link_metadata.signed.products.keys()),
-          [self.test_artifact])
+          [self.test_artifact[len(strip_prefix):]])
 
 
   def test_main_with_unencrypted_ed25519_key(self):


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
The `in-toto-run` cli does not support all of `runlib.in_toto_run`'s arguments. By passing the kwargs as args and omitting some intermediate args the `lstrip_paths` argument is wrongly passed as `compact_json` argument.

This PR fixes the bug by passing all kwargs with their keyword from the `in_toto_run` cli to the corresponding function in `runlib`. It also fixes the existing test.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


