### PR TITLE
Increase timeout to accommodate tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,5 +28,8 @@ install:
 
 build: false
 
+before_test:
+  - gpg-agent --daemon
+
 test_script:
   - python tests/runtests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,8 +31,8 @@ build: false
 # before_test:
 #   - gpg-agent --daemon
 
-test_script:
-  - python tests/runtests.py
+# test_script:
+#   - python tests/runtests.py
 
 on_finish:
   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,17 @@ environment:
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 32
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 32
+    # - PYTHON: "C:\\Python36"
+    #   PYTHON_VERSION: 3.6
+    #   PYTHON_ARCH: 32
 
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
+    # - PYTHON: "C:\\Python35"
+    #   PYTHON_VERSION: 3.5
+    #   PYTHON_ARCH: 32
 
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 32
+    # - PYTHON: "C:\\Python27"
+    #   PYTHON_VERSION: 2.7
+    #   PYTHON_ARCH: 32
 
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
@@ -28,8 +28,11 @@ install:
 
 build: false
 
-before_test:
-  - gpg-agent --daemon
+# before_test:
+#   - gpg-agent --daemon
 
 test_script:
   - python tests/runtests.py
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,16 @@
 import sys
 import logging
+
+# Increase timeout to accommodate tests on AppVeyor, which seems to have
+# troubles finishing gpg operations within the securesystemslib default of 3s.
+# NOTE: This must be done before importing in_toto, because in_toto
+# transitively imports 'securesystemslib.process', which locks the default
+# timeout arguments in its functions. Also note that this only works if in_toto
+# tests are invoked as modules, e.g. via 'runtests.py' or 'python -m ...'.
+# TODO: This needs to be fixed in securesystemslib
+import securesystemslib.settings
+securesystemslib.settings.SUBPROCESS_TIMEOUT = 100
+
 import in_toto
 
 class CapturableStreamHandler(logging.StreamHandler):


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
AppVeyor seems to have troubles finishing gpg operations within the securesystemslib default of 3 seconds.

This PR increases the subprocess timeout for running tests only to 10 seconds.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


