### PR TITLE
Add tmp dir and gpg key test mixins.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -68,10 +68,14 @@ class TmpDirMixin():
 
 class GPGKeysMixin():
   """Mixin with classmethod to copy GPG rsa test keyring to a subdir 'rsa' in
-  the the CWD.
+  the CWD.
 
   """
   gnupg_home = "rsa"
+  gpg_key_768C43 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
+  gpg_key_85DA58 = "8288ef560ed3795f9df2c0db56193089b285da58"
+  gpg_key_0C8A17 = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
+  gpg_key_D924E9 = "c5a0abe6ec19d0d65f85e2c39be9df5131d924e9"
 
   @classmethod
   def set_up_gpg_keys(cls):

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,6 +25,7 @@
 import os
 import sys
 import inspect
+import tempfile
 
 import unittest
 if sys.version_info >= (3, 3):
@@ -43,6 +44,25 @@ def run_with_portable_scripts(decorated):
     pass
 
   return Patched
+
+
+class TmpDirMixin():
+  """Mixin with classmethods to create and change into a temporary directory,
+  and to change back to the original CWD and remove the temporary directory.
+
+  """
+  @classmethod
+  def set_up_test_dir(cls):
+    """Back up CWD, and create and change into temporary directory. """
+    cls.original_cwd = os.getcwd()
+    cls.test_dir = os.path.realpath(tempfile.mkdtemp())
+    os.chdir(cls.test_dir)
+
+  @classmethod
+  def tear_down_test_dir(cls):
+    """Change back to original CWD and remove temporary directory. """
+    os.chdir(cls.original_cwd)
+    shutil.rmtree(cls.test_dir)
 
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,6 +25,7 @@
 import os
 import sys
 import inspect
+import shutil
 import tempfile
 
 import unittest
@@ -63,6 +64,21 @@ class TmpDirMixin():
     """Change back to original CWD and remove temporary directory. """
     os.chdir(cls.original_cwd)
     shutil.rmtree(cls.test_dir)
+
+
+class GPGKeysMixin():
+  """Mixin with classmethod to copy GPG rsa test keyring to a subdir 'rsa' in
+  the the CWD.
+
+  """
+  gnupg_home = "rsa"
+
+  @classmethod
+  def set_up_gpg_keys(cls):
+    gpg_keys = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
+
+    shutil.copytree(gpg_keys, os.path.join(os.getcwd(), cls.gnupg_home))
 
 
 

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -19,7 +19,6 @@
 
 import os
 import unittest
-import tempfile
 import shutil
 
 from in_toto.models.layout import Layout, Step, Inspection
@@ -29,8 +28,9 @@ import in_toto.exceptions
 import in_toto.verifylib
 import securesystemslib.exceptions
 
+from tests.common import TmpDirMixin
 
-class TestLayoutMethods(unittest.TestCase):
+class TestLayoutMethods(unittest.TestCase, TmpDirMixin):
   """Test Layout methods. """
 
   @classmethod
@@ -39,13 +39,11 @@ class TestLayoutMethods(unittest.TestCase):
     demo files. """
     self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
     self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-
-    # Create directory to run the tests without having everything blow up
-    self.working_dir = os.getcwd()
 
     # Copy GPG keyring to temp test dir
     tests_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+
+    self.set_up_test_dir()
 
     self.gnupg_home = os.path.join(self.test_dir, "rsa")
     shutil.copytree(
@@ -63,15 +61,10 @@ class TestLayoutMethods(unittest.TestCase):
     self.pubkey_path1 = os.path.join(self.test_dir, "bob.pub")
     self.pubkey_path2 = os.path.join(self.test_dir, "carl.pub")
 
-    os.chdir(self.test_dir)
-
-
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
 
   def test_set_relative_expiration(self):

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -28,34 +28,28 @@ import in_toto.exceptions
 import in_toto.verifylib
 import securesystemslib.exceptions
 
-from tests.common import TmpDirMixin
+from tests.common import TmpDirMixin, GPGKeysMixin
 
-class TestLayoutMethods(unittest.TestCase, TmpDirMixin):
+class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
   """Test Layout methods. """
 
   @classmethod
   def setUpClass(self):
     """Create temporary test directory and copy gpg keychain, and rsa keys from
     demo files. """
-    self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
-    self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
-
-    # Copy GPG keyring to temp test dir
-    tests_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
+    demo_files = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "..", "demo_files")
 
     self.set_up_test_dir()
+    self.set_up_gpg_keys()
 
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(
-        os.path.join(tests_dir, "gpg_keyrings", "rsa"),
-        self.gnupg_home)
+    self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
+    self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
 
     # Copy keys to temp test dir
     key_names = ["bob", "bob.pub", "carl.pub"]
     for name in key_names:
-      shutil.copy(
-        os.path.join(tests_dir, "demo_files", name),
-        os.path.join(self.test_dir, name))
+      shutil.copy(os.path.join(demo_files, name), name)
 
     self.key_path = os.path.join(self.test_dir, "bob")
     self.pubkey_path1 = os.path.join(self.test_dir, "bob.pub")

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -43,8 +43,6 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
     self.set_up_test_dir()
     self.set_up_gpg_keys()
 
-    self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
-    self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
 
     # Copy keys to temp test dir
     key_names = ["bob", "bob.pub", "carl.pub"]
@@ -164,8 +162,8 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
     layout.add_functionary_keys_from_paths([self.pubkey_path1,
         self.pubkey_path2])
 
-    layout.add_functionary_keys_from_gpg_keyids([self.gpg_keyid1,
-        self.gpg_keyid2], gpg_home=self.gnupg_home)
+    layout.add_functionary_keys_from_gpg_keyids([self.gpg_key_768C43,
+        self.gpg_key_85DA58], gpg_home=self.gnupg_home)
 
     layout._validate_keys()
 

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -9,12 +9,10 @@
   See LICENSE for licensing information.
 <Purpose>
   Test in_toto_keygen command line tool.
-"""
 
-import os
+"""
 import sys
 import unittest
-import shutil
 if sys.version_info >= (3, 3):
   from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
 else:

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -15,7 +15,6 @@ import os
 import sys
 import unittest
 import shutil
-import tempfile
 if sys.version_info >= (3, 3):
   from unittest.mock import patch # pylint: disable=no-name-in-module,import-error
 else:
@@ -29,24 +28,20 @@ from in_toto.util import (generate_and_write_rsa_keypair,
 
 import securesystemslib
 
-WORKING_DIR = os.getcwd()
+from tests.common import TmpDirMixin
 
-class TestInTotoKeyGenTool(unittest.TestCase):
+
+class TestInTotoKeyGenTool(unittest.TestCase, TmpDirMixin):
   """Test in_toto_keygen's main() - requires sys.argv patching; error
   logs/exits on Exception. """
 
   @classmethod
   def setUpClass(self):
-    # Create directory where the verification will take place
-    self.working_dir = os.getcwd()
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
   def test_main_required_args(self):
     """Test in-toto-keygen CLI tool with required arguments. """

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -19,18 +19,17 @@
 import os
 import unittest
 import shutil
-import tempfile
 import logging
 
 from in_toto.in_toto_mock import main as in_toto_mock_main
 
-import tests.common
+from tests.common import CliTestCase, TmpDirMixin
 
 # Required to cache and restore default log level
 logger = logging.getLogger("in_toto")
 
 
-class TestInTotoMockTool(tests.common.CliTestCase):
+class TestInTotoMockTool(CliTestCase, TmpDirMixin):
   """Test in_toto_mock's main() - requires sys.argv patching; and
   in_toto_mock- calls runlib and error logs/exits on Exception. """
   cli_main_func = staticmethod(in_toto_mock_main)
@@ -39,16 +38,12 @@ class TestInTotoMockTool(tests.common.CliTestCase):
   def setUpClass(self):
     """Create and change into temporary directory,
     dummy artifact and base arguments. """
+    self.set_up_test_dir()
 
     # Below tests override the base logger ('in_toto') log level to
     # `logging.INFO`. We cache the original log level before running the tests
     # to restore it afterwards.
     self._base_log_level = logger.level
-
-    self.working_dir = os.getcwd()
-
-    self.test_dir = tempfile.mkdtemp()
-    os.chdir(self.test_dir)
 
     self.test_step = "test_step"
     self.test_link = self.test_step + ".link"
@@ -58,12 +53,11 @@ class TestInTotoMockTool(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
     # Restore log level to what it was before running in-toto-mock
     logger.setLevel(self._base_log_level)
+
 
   def tearDown(self):
     try:

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -18,7 +18,6 @@
 """
 import os
 import unittest
-import shutil
 import logging
 
 from in_toto.in_toto_mock import main as in_toto_mock_main

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -32,11 +32,11 @@ import in_toto.util
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT
 from in_toto.in_toto_record import main as in_toto_record_main
 
-from tests.common import CliTestCase, TmpDirMixin
+from tests.common import CliTestCase, TmpDirMixin, GPGKeysMixin
 
 
 
-class TestInTotoRecordTool(CliTestCase, TmpDirMixin):
+class TestInTotoRecordTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
   """Test in_toto_record's main() - requires sys.argv patching; and
   in_toto_record_start/in_toto_record_stop - calls runlib and error logs/exits
   on Exception. """
@@ -46,16 +46,9 @@ class TestInTotoRecordTool(CliTestCase, TmpDirMixin):
   def setUpClass(self):
     """Create and change into temporary directory,
     generate key pair, dummy artifact and base arguments. """
-
-    # Find gpg keyring
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     self.set_up_test_dir()
+    self.set_up_gpg_keys()
 
-    # Copy gpg keyring to temp dir
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
     self.gpg_keyid = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
 
     self.rsa_key_path = "test_key_rsa"

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -22,7 +22,6 @@ import os
 import sys
 import unittest
 import shutil
-import tempfile
 
 if sys.version_info >= (3, 3):
   import unittest.mock as mock # pylint: disable=no-name-in-module,import-error
@@ -33,13 +32,11 @@ import in_toto.util
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT
 from in_toto.in_toto_record import main as in_toto_record_main
 
-import tests.common
-
-WORKING_DIR = os.getcwd()
+from tests.common import CliTestCase, TmpDirMixin
 
 
 
-class TestInTotoRecordTool(tests.common.CliTestCase):
+class TestInTotoRecordTool(CliTestCase, TmpDirMixin):
   """Test in_toto_record's main() - requires sys.argv patching; and
   in_toto_record_start/in_toto_record_stop - calls runlib and error logs/exits
   on Exception. """
@@ -49,13 +46,12 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
   def setUpClass(self):
     """Create and change into temporary directory,
     generate key pair, dummy artifact and base arguments. """
-    self.test_dir = tempfile.mkdtemp()
 
     # Find gpg keyring
     gpg_keyring_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
 
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
     # Copy gpg keyring to temp dir
     self.gnupg_home = os.path.join(self.test_dir, "rsa")
@@ -76,9 +72,7 @@ class TestInTotoRecordTool(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(WORKING_DIR)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
 
   def test_start_stop(self):

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -49,8 +49,6 @@ class TestInTotoRecordTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     self.set_up_test_dir()
     self.set_up_gpg_keys()
 
-    self.gpg_keyid = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
-
     self.rsa_key_path = "test_key_rsa"
     in_toto.util.generate_and_write_rsa_keypair(self.rsa_key_path)
 
@@ -139,7 +137,7 @@ class TestInTotoRecordTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
           self.test_artifact2, self.test_artifact2], 0)
 
       # Start/stop sign with specified gpg keyid
-      args = ["--step-name", "test7", "--gpg", self.gpg_keyid, "--gpg-home",
+      args = ["--step-name", "test7", "--gpg", self.gpg_key_768C43, "--gpg-home",
           self.gnupg_home]
       self.assert_cli_sys_exit(["start"] + args, 0)
       self.assert_cli_sys_exit(["stop"] + args, 0)
@@ -153,7 +151,7 @@ class TestInTotoRecordTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
 
   def test_glob_no_unfinished_files(self):
     """Test record stop with missing unfinished files when globbing (gpg). """
-    args = ["--step-name", "test-no-glob", "--gpg", self.gpg_keyid,
+    args = ["--step-name", "test-no-glob", "--gpg", self.gpg_key_768C43,
         "--gpg-home", self.gnupg_home]
     self.assert_cli_sys_exit(["stop"] + args, 1)
 
@@ -164,7 +162,7 @@ class TestInTotoRecordTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     fn2 = UNFINISHED_FILENAME_FORMAT.format(step_name=name, keyid="b12345678")
     open(fn1, "w").close()
     open(fn2, "w").close()
-    args = ["--step-name", name, "--gpg", self.gpg_keyid,
+    args = ["--step-name", name, "--gpg", self.gpg_key_768C43,
         "--gpg-home", self.gnupg_home]
     self.assert_cli_sys_exit(["stop"] + args, 1)
 

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -18,10 +18,8 @@
 
 """
 
-import os
 import sys
 import unittest
-import shutil
 
 if sys.version_info >= (3, 3):
   import unittest.mock as mock # pylint: disable=no-name-in-module,import-error

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -38,10 +38,10 @@ from in_toto.models.metadata import Metablock
 from in_toto.in_toto_run import main as in_toto_run_main
 from in_toto.models.link import FILENAME_FORMAT
 
-from tests.common import CliTestCase, TmpDirMixin
+from tests.common import CliTestCase, TmpDirMixin, GPGKeysMixin
 
 
-class TestInTotoRunTool(CliTestCase, TmpDirMixin):
+class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
   """Test in_toto_run's main() - requires sys.argv patching; and
   in_toto_run- calls runlib and error logs/exits on Exception. """
   cli_main_func = staticmethod(in_toto_run_main)
@@ -50,19 +50,13 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin):
   def setUpClass(self):
     """Create and change into temporary directory,
     generate key pair, dummy artifact and base arguments. """
-
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     self.set_up_test_dir()
+    self.set_up_gpg_keys()
 
     # Copy gpg keyring
     self.default_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
     self.default_gpg_subkeyid = "c5a0abe6ec19d0d65f85e2c39be9df5131d924e9"
     self.non_default_gpg_keyid = "8288ef560ed3795f9df2c0db56193089b285da58"
-
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
 
     self.rsa_key_path = "test_key_rsa"
     generate_and_write_rsa_keypair(self.rsa_key_path)

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -53,11 +53,6 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     self.set_up_test_dir()
     self.set_up_gpg_keys()
 
-    # Copy gpg keyring
-    self.default_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
-    self.default_gpg_subkeyid = "c5a0abe6ec19d0d65f85e2c39be9df5131d924e9"
-    self.non_default_gpg_keyid = "8288ef560ed3795f9df2c0db56193089b285da58"
-
     self.rsa_key_path = "test_key_rsa"
     generate_and_write_rsa_keypair(self.rsa_key_path)
     self.rsa_key = import_private_key_from_file(self.rsa_key_path,
@@ -176,12 +171,12 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
   def test_main_with_specified_gpg_key(self):
     """Test CLI command with specified gpg key. """
     args = ["-n", self.test_step,
-            "--gpg", self.non_default_gpg_keyid,
+            "--gpg", self.gpg_key_85DA58,
             "--gpg-home", self.gnupg_home, "--", "python", "--version"]
 
     self.assert_cli_sys_exit(args, 0)
     link_filename = FILENAME_FORMAT.format(step_name=self.test_step,
-        keyid=self.non_default_gpg_keyid)
+        keyid=self.gpg_key_85DA58)
 
     self.assertTrue(os.path.exists(link_filename))
 
@@ -194,7 +189,7 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     self.assert_cli_sys_exit(args, 0)
 
     link_filename = FILENAME_FORMAT.format(step_name=self.test_step,
-        keyid=self.default_gpg_subkeyid)
+        keyid=self.gpg_key_D924E9)
 
     self.assertTrue(os.path.exists(link_filename))
 

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -21,7 +21,6 @@
 import os
 import sys
 import unittest
-import shutil
 import glob
 
 # Use external backport 'mock' on versions under 3.3

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -20,11 +20,11 @@ import unittest
 
 from in_toto.in_toto_sign import main as in_toto_sign_main
 
-from tests.common import CliTestCase, TmpDirMixin
+from tests.common import CliTestCase, TmpDirMixin, GPGKeysMixin
 
 
 
-class TestInTotoSignTool(CliTestCase, TmpDirMixin):
+class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
   """Test in_toto_sign's main() - requires sys.argv patching; error logs/exits
   on Exception. """
   cli_main_func = staticmethod(in_toto_sign_main)
@@ -35,20 +35,13 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin):
     demo_files = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "demo_files")
 
-    # Find gpg keyring
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     # Create and change into temporary directory
     self.set_up_test_dir()
+    self.set_up_gpg_keys()
 
     # Copy demo files to temp dir
     for file_path in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, file_path), self.test_dir)
-
-    # Copy gpg keyring to temp dir
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
 
     self.default_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
     self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -16,27 +16,21 @@
 import os
 import json
 import shutil
-import tempfile
 import unittest
 
 from in_toto.in_toto_sign import main as in_toto_sign_main
 
-import tests.common
-
-WORKING_DIR = os.getcwd()
+from tests.common import CliTestCase, TmpDirMixin
 
 
 
-class TestInTotoSignTool(tests.common.CliTestCase):
+class TestInTotoSignTool(CliTestCase, TmpDirMixin):
   """Test in_toto_sign's main() - requires sys.argv patching; error logs/exits
   on Exception. """
   cli_main_func = staticmethod(in_toto_sign_main)
 
   @classmethod
   def setUpClass(self):
-    # Backup original cwd
-    self.working_dir = os.getcwd()
-
     # Find demo files
     demo_files = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "demo_files")
@@ -46,8 +40,7 @@ class TestInTotoSignTool(tests.common.CliTestCase):
         os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
 
     # Create and change into temporary directory
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
     # Copy demo files to temp dir
     for file_path in os.listdir(demo_files):
@@ -74,9 +67,7 @@ class TestInTotoSignTool(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp dir. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
 
   def test_sign_and_verify(self):

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -43,10 +43,6 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     for file_path in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, file_path), self.test_dir)
 
-    self.default_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
-    self.gpg_keyid1 = "7b3abb26b97b655ab9296bd15b0bd02e1c768c43"
-    self.gpg_keyid2 = "8288ef560ed3795f9df2c0db56193089b285da58"
-
     self.layout_path = "demo.layout.template"
     self.link_path = "package.2f89b927.link"
     self.alice_path = "alice"
@@ -151,7 +147,7 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     # Verify Layout signed with default gpg key
     self.assert_cli_sys_exit([
         "-f", "tmp_gpg.layout",
-        "-g", self.default_gpg_keyid,
+        "-g", self.gpg_key_0C8A17,
         "--gpg-home", self.gnupg_home,
         "--verify"
         ], 0)
@@ -159,13 +155,13 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     # Sign Layout with two gpg keys
     self.assert_cli_sys_exit([
         "-f", self.layout_path,
-        "-g", self.gpg_keyid1, self.gpg_keyid2,
+        "-g", self.gpg_key_768C43, self.gpg_key_85DA58,
         "-o", "tmp_gpg.layout",
         "--gpg-home", self.gnupg_home
         ], 0)
     self.assert_cli_sys_exit([
         "-f", "tmp_gpg.layout",
-        "-g", self.gpg_keyid1, self.gpg_keyid2,
+        "-g", self.gpg_key_768C43, self.gpg_key_85DA58,
         "--gpg-home", self.gnupg_home,
         "--verify"
         ], 0)
@@ -198,7 +194,7 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     # Fail with wrong gpg keyid (not used for signing)
     self.assert_cli_sys_exit([
         "-f", self.layout_path,
-        "-g", self.default_gpg_keyid,
+        "-g", self.gpg_key_0C8A17,
         "--gpg-home", self.gnupg_home,
         "--verify"
         ], 1)
@@ -256,7 +252,7 @@ class TestInTotoSignTool(CliTestCase, TmpDirMixin, GPGKeysMixin):
     # Wrong multiple gpg keys for Link metadata
     self.assert_cli_sys_exit([
         "-f", self.link_path,
-        "-g", self.gpg_keyid1, self.gpg_keyid2,
+        "-g", self.gpg_key_768C43, self.gpg_key_85DA58,
         ], 2)
 
     # Only one of gpg or regular key can be passed

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -27,7 +27,7 @@ from in_toto.in_toto_verify import main as in_toto_verify_main
 from in_toto.util import import_rsa_key_from_file
 from securesystemslib.interface import import_ed25519_privatekey_from_file
 
-from tests.common import CliTestCase, TmpDirMixin
+from tests.common import CliTestCase, TmpDirMixin, GPGKeysMixin
 
 
 
@@ -211,7 +211,7 @@ class TestInTotoVerifyToolMixedKeys(CliTestCase, TmpDirMixin):
 
 
 @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
-class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin):
+class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin, GPGKeysMixin):
   """ Tests in-toto-verify like TestInTotoVerifyTool but with
   gpg project owner and functionary keys. """
   cli_main_func = staticmethod(in_toto_verify_main)
@@ -221,10 +221,6 @@ class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin):
   def setUpClass(self):
     """Copy test gpg rsa keyring, gpg demo metadata files and demo final
     product to tmp test dir. """
-    # Copy gpg keyring
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     # Copy gpg demo metadata files
     demo_files = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "demo_files_gpg")
@@ -234,9 +230,7 @@ class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin):
         os.path.dirname(os.path.realpath(__file__)), "scripts")
 
     self.set_up_test_dir()
-
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
+    self.set_up_gpg_keys()
 
     self.owner_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
 

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -21,18 +21,17 @@
 import os
 import unittest
 import shutil
-import tempfile
 
 from in_toto.models.metadata import Metablock
 from in_toto.in_toto_verify import main as in_toto_verify_main
 from in_toto.util import import_rsa_key_from_file
 from securesystemslib.interface import import_ed25519_privatekey_from_file
 
-import tests.common
+from tests.common import CliTestCase, TmpDirMixin
 
 
 
-class TestInTotoVerifyTool(tests.common.CliTestCase):
+class TestInTotoVerifyTool(CliTestCase, TmpDirMixin):
   """
   Tests
     - in_toto_verify's main() - requires sys.argv patching;
@@ -60,8 +59,6 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
 
     ...and dumps various layouts for different test scenarios
     """
-    # Backup original cwd
-    self.working_dir = os.getcwd()
 
     # Find demo files
     demo_files = os.path.join(
@@ -70,10 +67,7 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
     scripts_directory = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "scripts")
 
-
-    # Create and change into temporary directory
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
     # Copy demo files to temp dir
     for fn in os.listdir(demo_files):
@@ -104,9 +98,7 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp dir. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
 
   def test_main_required_args(self):
@@ -156,7 +148,7 @@ class TestInTotoVerifyTool(tests.common.CliTestCase):
 
 
 
-class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
+class TestInTotoVerifyToolMixedKeys(CliTestCase, TmpDirMixin):
   """ Tests in-toto-verify like TestInTotoVerifyTool but with
   both rsa and ed25519 project owner and functionary keys. """
   cli_main_func = staticmethod(in_toto_verify_main)
@@ -173,9 +165,6 @@ class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
 
     ...and dumps layout for test scenario
     """
-    # Backup original cwd
-    self.working_dir = os.getcwd()
-
     # Find demo files
     demo_files = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "demo_files")
@@ -183,9 +172,7 @@ class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
     scripts_directory = os.path.join(
       os.path.dirname(os.path.realpath(__file__)), "scripts")
 
-    # Create and change into temporary directory
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
     # Copy demo files to temp dir
     for fn in os.listdir(demo_files):
@@ -213,9 +200,7 @@ class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp dir. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
   def test_main_multiple_keys(self):
     """Test in-toto-verify CLI tool with multiple keys. """
@@ -226,7 +211,7 @@ class TestInTotoVerifyToolMixedKeys(tests.common.CliTestCase):
 
 
 @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
-class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
+class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin):
   """ Tests in-toto-verify like TestInTotoVerifyTool but with
   gpg project owner and functionary keys. """
   cli_main_func = staticmethod(in_toto_verify_main)
@@ -236,18 +221,9 @@ class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
   def setUpClass(self):
     """Copy test gpg rsa keyring, gpg demo metadata files and demo final
     product to tmp test dir. """
-
-    self.working_dir = os.getcwd()
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-
     # Copy gpg keyring
     gpg_keyring_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
-
-    self.owner_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
 
     # Copy gpg demo metadata files
     demo_files = os.path.join(
@@ -255,13 +231,19 @@ class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
 
     # find where the scripts directory is located.
     scripts_directory = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "scripts")
+        os.path.dirname(os.path.realpath(__file__)), "scripts")
+
+    self.set_up_test_dir()
+
+    self.gnupg_home = os.path.join(self.test_dir, "rsa")
+    shutil.copytree(gpg_keyring_path, self.gnupg_home)
+
+    self.owner_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
 
     for fn in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
     # Change into test dir
-    os.chdir(self.test_dir)
     shutil.copytree(scripts_directory, 'scripts')
 
     # Sign layout template with gpg key
@@ -274,9 +256,7 @@ class TestInTotoVerifyToolGPG(tests.common.CliTestCase):
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp dir. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
   def test_gpg_signed_layout_with_gpg_functionary_keys(self):
     """ Successfully test demo supply chain where the layout lists gpg keys

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -232,8 +232,6 @@ class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin, GPGKeysMixin):
     self.set_up_test_dir()
     self.set_up_gpg_keys()
 
-    self.owner_gpg_keyid = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
-
     for fn in os.listdir(demo_files):
       shutil.copy(os.path.join(demo_files, fn), self.test_dir)
 
@@ -244,7 +242,7 @@ class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin, GPGKeysMixin):
     layout_template = Metablock.load("demo.layout.template")
 
     self.layout_path = "gpg_signed.layout"
-    layout_template.sign_gpg(self.owner_gpg_keyid, self.gnupg_home)
+    layout_template.sign_gpg(self.gpg_key_0C8A17, self.gnupg_home)
     layout_template.dump(self.layout_path)
 
 
@@ -256,7 +254,7 @@ class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin, GPGKeysMixin):
     """ Successfully test demo supply chain where the layout lists gpg keys
     as functionary keys and is signed with a gpg key. """
     args = ["--layout", self.layout_path,
-            "--gpg", self.owner_gpg_keyid, "--gpg-home", self.gnupg_home]
+            "--gpg", self.gpg_key_0C8A17, "--gpg-home", self.gnupg_home]
 
     self.assert_cli_sys_exit(args, 0)
 

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -22,7 +22,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 
 import in_toto.settings
@@ -34,6 +33,7 @@ from in_toto.util import (import_rsa_key_from_file,
 
 import in_toto.exceptions
 
+from tests.common import TmpDirMixin
 
 class Test_SubstituteArtifacts(unittest.TestCase):
   """Test parameter substitution on artifact rules. """
@@ -140,7 +140,7 @@ class Test_SubstituteExpectedCommand(unittest.TestCase):
       substitute_parameters(self.layout, {"NOEDITOR": "vim"})
 
 
-class Test_SubstituteOnVerify(unittest.TestCase):
+class Test_SubstituteOnVerify(unittest.TestCase, TmpDirMixin):
   """Test verifylib.verify_command_alignment(command, expected_command)"""
 
   @classmethod
@@ -155,16 +155,11 @@ class Test_SubstituteOnVerify(unittest.TestCase):
         }]
       })
 
-    # Backup original cwd
-    self.working_dir = os.getcwd()
-
     # Find demo files
     demo_files = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "demo_files")
 
-    # Create and change into temporary directory
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-    os.chdir(self.test_dir)
+    self.set_up_test_dir()
 
     # Copy demo files to temp dir
     for fn in os.listdir(demo_files):
@@ -177,8 +172,7 @@ class Test_SubstituteOnVerify(unittest.TestCase):
 
   @classmethod
   def tearDownClass(self):
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
 
   def test_substitute(self):
     """Do a simple substitution on the expected_command field"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -46,22 +46,16 @@ import securesystemslib.exceptions
 from securesystemslib.interface import (import_ed25519_privatekey_from_file,
     import_ed25519_publickey_from_file)
 
-from tests.common import TmpDirMixin
+from tests.common import TmpDirMixin, GPGKeysMixin
 
-class TestUtil(unittest.TestCase, TmpDirMixin):
+class TestUtil(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
   """Test various util functions. Mostly related to RSA key creation or
   loading."""
 
   @classmethod
   def setUpClass(self):
-    # Copy gpg keyring
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     self.set_up_test_dir()
-
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
+    self.set_up_gpg_keys()
 
 
   @classmethod

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -216,11 +216,7 @@ class TestUtil(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
   def test_import_gpg_public_keys_from_keyring_as_dict(self):
     """Import gpg public keys from keyring and return KEYDICT. """
 
-    keyids = [
-      "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17",
-      "7b3abb26b97b655ab9296bd15b0bd02e1c768c43",
-      "8288ef560ed3795f9df2c0db56193089b285da58"
-    ]
+    keyids = [self.gpg_key_0C8A17, self.gpg_key_768C43, self.gpg_key_85DA58]
 
     # Succefully import public keys from keychain as keydictionary
     key_dict = import_gpg_public_keys_from_keyring_as_dict(keyids,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,7 +21,6 @@
 import os
 import sys
 import shutil
-import tempfile
 import unittest
 
 if sys.version_info >= (3, 3):
@@ -47,29 +46,28 @@ import securesystemslib.exceptions
 from securesystemslib.interface import (import_ed25519_privatekey_from_file,
     import_ed25519_publickey_from_file)
 
-class TestUtil(unittest.TestCase):
+from tests.common import TmpDirMixin
+
+class TestUtil(unittest.TestCase, TmpDirMixin):
   """Test various util functions. Mostly related to RSA key creation or
   loading."""
 
   @classmethod
   def setUpClass(self):
-    # Create directory where the verification will take place
-    self.working_dir = os.getcwd()
-    self.test_dir = os.path.realpath(tempfile.mkdtemp())
-
     # Copy gpg keyring
     gpg_keyring_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
+
+    self.set_up_test_dir()
+
     self.gnupg_home = os.path.join(self.test_dir, "rsa")
     shutil.copytree(gpg_keyring_path, self.gnupg_home)
 
-    os.chdir(self.test_dir)
 
   @classmethod
   def tearDownClass(self):
-    """Change back to initial working dir and remove temp test directory. """
-    os.chdir(self.working_dir)
-    shutil.rmtree(self.test_dir)
+    self.tear_down_test_dir()
+
 
   def test_unrecognized_key_type(self):
     """Trigger UnsupportedKeyTypeError. """

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -17,10 +17,7 @@
   Test util functions.
 
 """
-
-import os
 import sys
-import shutil
 import unittest
 
 if sys.version_info >= (3, 3):

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -57,7 +57,7 @@ import securesystemslib.gpg.functions
 import securesystemslib.exceptions
 import in_toto.exceptions
 
-from tests.common import TmpDirMixin
+from tests.common import TmpDirMixin, GPGKeysMixin
 
 
 class Test_RaiseOnBadRetval(unittest.TestCase):
@@ -1117,7 +1117,8 @@ class TestInTotoVerifyThresholds(unittest.TestCase):
 
 
 @unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
-class TestInTotoVerifyThresholdsGpgSubkeys(unittest.TestCase, TmpDirMixin):
+class TestInTotoVerifyThresholdsGpgSubkeys(
+    unittest.TestCase, TmpDirMixin, GPGKeysMixin):
   """
   Test the following 8 scenarios for combinations of link authorization,
   where a link is either signed by a master or subkey (SIG), and the
@@ -1149,15 +1150,8 @@ class TestInTotoVerifyThresholdsGpgSubkeys(unittest.TestCase, TmpDirMixin):
 
   @classmethod
   def setUpClass(self):
-
-    # Find demo files
-    gpg_keyring_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "gpg_keyrings", "rsa")
-
     self.set_up_test_dir()
-
-    self.gnupg_home = os.path.join(self.test_dir, "rsa")
-    shutil.copytree(gpg_keyring_path, self.gnupg_home)
+    self.set_up_gpg_keys()
 
     self.master = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
     self.sub = "c5a0abe6ec19d0d65f85e2c39be9df5131d924e9"

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -1153,24 +1153,20 @@ class TestInTotoVerifyThresholdsGpgSubkeys(
     self.set_up_test_dir()
     self.set_up_gpg_keys()
 
-    self.master = "8465a1e2e0fb2b40adb2478e18fb3f537e0c8a17"
-    self.sub = "c5a0abe6ec19d0d65f85e2c39be9df5131d924e9"
-
     master_key = securesystemslib.gpg.functions.export_pubkey(
-        self.master, self.gnupg_home)
-    sub_key = master_key["subkeys"][self.sub]
+        self.gpg_key_0C8A17, self.gnupg_home)
+    sub_key = master_key["subkeys"][self.gpg_key_D924E9]
 
     # We need a gpg key without subkeys to test the normal scenario (M M M),
     # because keys with signing subkeys always use that subkey for signing.
-    self.master2 = "7B3ABB26B97B655AB9296BD15B0BD02E1C768C43"
     master_key2 = securesystemslib.gpg.functions.export_pubkey(
-        self.master2, self.gnupg_home)
+        self.gpg_key_768C43, self.gnupg_home)
 
 
     self.pub_key_dict = {
-      self.master: master_key,
-      self.sub: sub_key,
-      self.master2: master_key2
+      self.gpg_key_0C8A17: master_key,
+      self.gpg_key_D924E9: sub_key,
+      self.gpg_key_768C43: master_key2
     }
 
     self.step_name = "name"
@@ -1207,7 +1203,7 @@ class TestInTotoVerifyThresholdsGpgSubkeys(
   def test_verify_link_signature_thresholds__M_M_M(self):
     """Normal scenario. """
     layout, chain_link_dict = self._verify_link_signature_tresholds(
-        self.master2, self.master2, self.master2)
+        self.gpg_key_768C43, self.gpg_key_768C43, self.gpg_key_768C43)
 
     #print("path: {}".format(os.environ['PATH']))
     verify_link_signature_thresholds(layout, chain_link_dict)
@@ -1221,22 +1217,22 @@ class TestInTotoVerifyThresholdsGpgSubkeys(
     # Even if gpg would use the masterkey, these scenarios are not allowed,
     # see table in docstring of testcase
     signature = securesystemslib.gpg.functions.create_signature(
-        b"data", self.master, self.gnupg_home)
+        b"data", self.gpg_key_0C8A17, self.gnupg_home)
 
-    self.assertTrue(signature["keyid"] == self.sub)
+    self.assertTrue(signature["keyid"] == self.gpg_key_D924E9)
 
 
   def test_verify_link_signature_thresholds__S_M_M(self):
     """Allowed trust delegation. """
     layout, chain_link_dict = self._verify_link_signature_tresholds(
-        self.sub, self.master, self.master)
+        self.gpg_key_D924E9, self.gpg_key_0C8A17, self.gpg_key_0C8A17)
     verify_link_signature_thresholds(layout, chain_link_dict)
 
 
   def test_verify_link_signature_thresholds__S_M_S(self):
     """Cannot associate keys. """
     layout, chain_link_dict = self._verify_link_signature_tresholds(
-        self.sub, self.master, self.sub)
+        self.gpg_key_D924E9, self.gpg_key_0C8A17, self.gpg_key_D924E9)
     with self.assertRaises(ThresholdVerificationError):
       verify_link_signature_thresholds(layout, chain_link_dict)
 
@@ -1244,14 +1240,14 @@ class TestInTotoVerifyThresholdsGpgSubkeys(
   def test_verify_link_signature_thresholds__S_S_M(self):
     """No trust delegation and can find key in key store. """
     layout, chain_link_dict = self._verify_link_signature_tresholds(
-        self.sub, self.sub, self.master)
+        self.gpg_key_D924E9, self.gpg_key_D924E9, self.gpg_key_0C8A17)
     verify_link_signature_thresholds(layout, chain_link_dict)
 
 
   def test_verify_link_signature_thresholds__S_S_S(self):
     """Generalizes to normal scenario. """
     layout, chain_link_dict = self._verify_link_signature_tresholds(
-        self.sub, self.sub, self.sub)
+        self.gpg_key_D924E9, self.gpg_key_D924E9, self.gpg_key_D924E9)
     verify_link_signature_thresholds(layout, chain_link_dict)
 
 


### PR DESCRIPTION
**Fixes issue #**:
Supersedes #216
Partially fixes #87 

**Description of the changes being introduced by the pull request**:
- Adds two test mixins `TmpDirMixin` and `GPGKeysMixin` with methods and change to a temporary directory, change back to the original cwd and delete the temporary directory, and to copy gpg rsa keys to the cwd. 

- Removes repetitive code from test setup and teardown methods and uses mixins instead

NOTE: the mixin has a class variable `gnupg_home` which contains the path to the keyring relative to cwd. This fixes an issue with gpg on windows that has troubles migrating old keyrings if the homedir
is passed as absolute path with drive prefix (e.g. `C:/path/to/keyring`).
 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


