### PR TITLE
Use constant from securesystemslib to detect GPG in tests

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -35,6 +35,6 @@ pathspec==0.7.0
 pycparser==2.19           # via cffi
 pynacl==1.3.0             # via securesystemslib
 python-dateutil==2.8.1
-securesystemslib[crypto,pynacl]==0.14.0
+securesystemslib[crypto,pynacl]==0.14.2
 six==1.14.0
 subprocess32==3.5.4       # via securesystemslib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-securesystemslib[crypto,pynacl]>=0.12.0
+securesystemslib[crypto,pynacl]>=0.14.1
 attrs
 python-dateutil
 iso8601

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -20,29 +20,6 @@
 
 from unittest import defaultTestLoader, TextTestRunner
 import sys
-import os
-import subprocess
-
-def check_usable_gpg():
-  """Set `TEST_SKIP_GPG` environment variable if neither gpg2 nor gpg is
-  available.
-
-  """
-  os.environ["TEST_SKIP_GPG"] = "1"
-  for gpg in ["gpg2", "gpg"]:
-    try:
-      subprocess.check_call([gpg, "--version"])
-
-    except OSError:
-      pass
-
-    else:
-      # If one of the two exists, we can unset the skip envvar and ...
-      os.environ.pop("TEST_SKIP_GPG", None)
-      # ... abort the availability check.:
-      break
-
-check_usable_gpg()
 
 suite = defaultTestLoader.discover(start_dir=".")
 result = TextTestRunner(verbosity=2, buffer=True).run(suite)

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -26,6 +26,7 @@ from in_toto.models.metadata import Metablock
 from in_toto.in_toto_verify import main as in_toto_verify_main
 from in_toto.util import import_rsa_key_from_file
 from securesystemslib.interface import import_ed25519_privatekey_from_file
+from securesystemslib.gpg.constants import HAVE_GPG
 
 from tests.common import CliTestCase, TmpDirMixin, GPGKeysMixin
 
@@ -210,7 +211,7 @@ class TestInTotoVerifyToolMixedKeys(CliTestCase, TmpDirMixin):
     self.assert_cli_sys_exit(args, 0)
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestInTotoVerifyToolGPG(CliTestCase, TmpDirMixin, GPGKeysMixin):
   """ Tests in-toto-verify like TestInTotoVerifyTool but with
   gpg project owner and functionary keys. """

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -53,6 +53,7 @@ from in_toto.exceptions import (RuleVerificationError,
 from in_toto.util import import_rsa_key_from_file, import_public_keys_from_files_as_dict
 from in_toto.rulelib import unpack_rule
 import securesystemslib.gpg.functions
+from securesystemslib.gpg.constants import HAVE_GPG
 
 import securesystemslib.exceptions
 import in_toto.exceptions
@@ -1116,7 +1117,7 @@ class TestInTotoVerifyThresholds(unittest.TestCase):
 
 
 
-@unittest.skipIf(os.getenv("TEST_SKIP_GPG"), "gpg not found")
+@unittest.skipIf(not HAVE_GPG, "gpg not found")
 class TestInTotoVerifyThresholdsGpgSubkeys(
     unittest.TestCase, TmpDirMixin, GPGKeysMixin):
   """


### PR DESCRIPTION
**Fixes issue #**:

**Description of the changes being introduced by the pull request**:
Use the new constant in securesystemslib 0.14.1 to check for the presence of GPG while running tests.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


