### PR TITLE
Add max timeout setting

### DIFF
--- a/doc/source/command-line-tools/settings.rst
+++ b/doc/source/command-line-tools/settings.rst
@@ -21,6 +21,8 @@ Setting Types
   ``in-toto-run`` are searched relative to the base path. The base path itself
   is not included in the link metadata. Default is the current working
   directory.
+- ``LINK_CMD_EXEC_TIMEOUT`` -- maximum timeout setting for the in-toto-run
+  command.
 
 
 Example Usage
@@ -31,6 +33,7 @@ Example Usage
   # Configure settings via bash-style environment variable export
   export IN_TOTO_ARTIFACT_BASE_PATH='/home/user/project'
   export IN_TOTO_ARTIFACT_EXCLUDE_PATTERNS='*.link:.gitignore'
+  export LINK_CMD_EXEC_TIMEOUT='10'
 
 .. code-block:: sh
 
@@ -38,3 +41,4 @@ Example Usage
   [in-toto settings]
   ARTIFACT_BASE_PATH=/home/user/project
   ARTIFACT_EXCLUDE_PATTERNS=*.link:.gitignore
+  LINK_CMD_EXEC_TIMEOUT=10

--- a/doc/source/command-line-tools/settings.rst
+++ b/doc/source/command-line-tools/settings.rst
@@ -33,7 +33,7 @@ Example Usage
   # Configure settings via bash-style environment variable export
   export IN_TOTO_ARTIFACT_BASE_PATH='/home/user/project'
   export IN_TOTO_ARTIFACT_EXCLUDE_PATTERNS='*.link:.gitignore'
-  export LINK_CMD_EXEC_TIMEOUT='10'
+  export IN_TOTO_LINK_CMD_EXEC_TIMEOUT='10'
 
 .. code-block:: sh
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -357,7 +357,8 @@ def execute_link(link_cmd_args, record_streams):
   """
   if record_streams:
     return_code, stdout_str, stderr_str = \
-        securesystemslib.process.run_duplicate_streams(link_cmd_args)
+        securesystemslib.process.run_duplicate_streams(link_cmd_args,
+            timeout=in_toto.settings.LINK_CMD_EXEC_TIMEOUT)
 
   else:
     process = securesystemslib.process.run(link_cmd_args, check=False,

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -358,11 +358,11 @@ def execute_link(link_cmd_args, record_streams):
   if record_streams:
     return_code, stdout_str, stderr_str = \
         securesystemslib.process.run_duplicate_streams(link_cmd_args,
-            timeout=int(in_toto.settings.LINK_CMD_EXEC_TIMEOUT))
+            timeout=float(in_toto.settings.LINK_CMD_EXEC_TIMEOUT))
 
   else:
     process = securesystemslib.process.run(link_cmd_args, check=False,
-      timeout=int(in_toto.settings.LINK_CMD_EXEC_TIMEOUT),
+      timeout=float(in_toto.settings.LINK_CMD_EXEC_TIMEOUT),
       stdout=securesystemslib.process.DEVNULL,
       stderr=securesystemslib.process.DEVNULL)
     stdout_str = stderr_str = ""

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -361,6 +361,7 @@ def execute_link(link_cmd_args, record_streams):
 
   else:
     process = securesystemslib.process.run(link_cmd_args, check=False,
+      timeout=in_toto.settings.LINK_CMD_EXEC_TIMEOUT,
       stdout=securesystemslib.process.DEVNULL,
       stderr=securesystemslib.process.DEVNULL)
     stdout_str = stderr_str = ""

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -358,11 +358,11 @@ def execute_link(link_cmd_args, record_streams):
   if record_streams:
     return_code, stdout_str, stderr_str = \
         securesystemslib.process.run_duplicate_streams(link_cmd_args,
-            timeout=in_toto.settings.LINK_CMD_EXEC_TIMEOUT)
+            timeout=int(in_toto.settings.LINK_CMD_EXEC_TIMEOUT))
 
   else:
     process = securesystemslib.process.run(link_cmd_args, check=False,
-      timeout=in_toto.settings.LINK_CMD_EXEC_TIMEOUT,
+      timeout=int(in_toto.settings.LINK_CMD_EXEC_TIMEOUT),
       stdout=securesystemslib.process.DEVNULL,
       stderr=securesystemslib.process.DEVNULL)
     stdout_str = stderr_str = ""

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -40,3 +40,6 @@ ARTIFACT_EXCLUDE_PATTERNS = ["*.link*", ".git", "*.pyc", "*~"]
 # If not set the current working directory is used as base path
 # FIXME: Do we want different base paths for materials and products?
 ARTIFACT_BASE_PATH = None
+
+# Max timeout for the in-toto-run command
+LINK_CMD_EXEC_TIMEOUT = 10

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -56,7 +56,7 @@ RC_PATHS = [
 # TODO: Should we use `dir` on the module instead? If we list them here, we
 # have to manually update if `settings.py` changes.
 IN_TOTO_SETTINGS = [
-  "ARTIFACT_EXCLUDE_PATTERNS", "ARTIFACT_BASE_PATH"
+  "ARTIFACT_EXCLUDE_PATTERNS", "ARTIFACT_BASE_PATH", "LINK_CMD_EXEC_TIMEOUT"
 ]
 
 

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -88,6 +88,7 @@ def get_env():
     # Exporting variables in e.g. bash
     export IN_TOTO_ARTIFACT_BASE_PATH='/home/user/project'
     export IN_TOTO_ARTIFACT_EXCLUDE_PATTERNS='*.link:.gitignore'
+    export IN_TOTO_LINK_CMD_EXEC_TIMEOUT='10'
     ```
 
     produces
@@ -96,6 +97,7 @@ def get_env():
     {
       "ARTIFACT_BASE_PATH": "/home/user/project"
       "ARTIFACT_EXCLUDE_PATTERNS": ["*.link", ".gitignore"]
+      "LINK_CMD_EXEC_TIMEOUT": "10"
     }
     ```
 
@@ -146,6 +148,7 @@ def get_rc():
     [in-toto setting]
     ARTIFACT_BASE_PATH = /home/user/project
     ARTIFACT_EXCLUDE_PATTERNS = *.link:.gitignore
+    LINK_CMD_EXEC_TIMEOUT = 10
     ```
 
     produces
@@ -154,6 +157,7 @@ def get_rc():
     {
       "ARTIFACT_BASE_PATH": "/home/user/project"
       "ARTIFACT_EXCLUDE_PATTERNS": ["*.link", ".gitignore"]
+      "LINK_CMD_EXEC_TIMEOUT": "10"
     }
     ```
 

--- a/tests/rc_test/.in_totorc
+++ b/tests/rc_test/.in_totorc
@@ -1,4 +1,5 @@
 [settings]
 artifact_base_path=r/c/file
 ARTIFACT_EXCLUDE_PATTERNS=r:c:file
+LINK_CMD_EXEC_TIMEOUT=20
 new_rc_setting=new rc setting

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -453,17 +453,17 @@ class TestLinkCmdExecTimeoutSetting(unittest.TestCase):
     timeout_old = in_toto.settings.LINK_CMD_EXEC_TIMEOUT
 
     # Modify timeout
-    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = -1
+    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = 0.1
 
     # check if exception is raised
     with self.assertRaises(securesystemslib.process.subprocess.TimeoutExpired):
       # Call execute_link to see if new timeout is respected
-      in_toto.runlib.execute_link(['python', '--version'], True)
+      in_toto.runlib.execute_link([sys.executable, '-c', 'while True: pass'], True)
 
     # check if exception is raised
     with self.assertRaises(securesystemslib.process.subprocess.TimeoutExpired):
       # Call execute_link to see if new timeout is respected
-      in_toto.runlib.execute_link(['python', '--version'], False)
+      in_toto.runlib.execute_link([sys.executable, '-c', 'while True: pass'], False)
 
     # Restore original timeout
     in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_old

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -445,6 +445,23 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
     self.assertTrue("sha256" in list(_hash_artifact("foo", ["sha256"]).keys()))
 
 
+class TestLinkCmdExecTimeoutSetting(unittest.TestCase):
+  """Tests LINK_CMD_EXEC_TIMEOUT setting in settings.py file. """
+
+  def test_timeout_setting(self):
+    # Save the old timeout and make sure it's saved properly
+    timeout_old = in_toto.settings.LINK_CMD_EXEC_TIMEOUT
+    self.assertEqual(in_toto.settings.LINK_CMD_EXEC_TIMEOUT, timeout_old)
+
+    # Modify timeout and check that it returns the same value
+    timeout_new = timeout_old + 1
+    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_new
+    self.assertEqual(in_toto.settings.LINK_CMD_EXEC_TIMEOUT, timeout_new)
+
+    # Restore original timeout
+    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_old
+
+
 class TestInTotoRun(unittest.TestCase, TmpDirMixin):
   """"
   Tests runlib.in_toto_run() with different arguments

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -451,12 +451,19 @@ class TestLinkCmdExecTimeoutSetting(unittest.TestCase):
   def test_timeout_setting(self):
     # Save the old timeout and make sure it's saved properly
     timeout_old = in_toto.settings.LINK_CMD_EXEC_TIMEOUT
-    self.assertEqual(in_toto.settings.LINK_CMD_EXEC_TIMEOUT, timeout_old)
 
-    # Modify timeout and check that it returns the same value
-    timeout_new = timeout_old + 1
-    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_new
-    self.assertEqual(in_toto.settings.LINK_CMD_EXEC_TIMEOUT, timeout_new)
+    # Modify timeout
+    in_toto.settings.LINK_CMD_EXEC_TIMEOUT = -1
+
+    # check if exception is raised
+    with self.assertRaises(securesystemslib.process.subprocess.TimeoutExpired):
+      # Call execute_link to see if new timeout is respected
+      in_toto.runlib.execute_link(['python', '--version'], True)
+
+    # check if exception is raised
+    with self.assertRaises(securesystemslib.process.subprocess.TimeoutExpired):
+      # Call execute_link to see if new timeout is respected
+      in_toto.runlib.execute_link(['python', '--version'], False)
 
     # Restore original timeout
     in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_old

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -40,6 +40,7 @@ class TestUserSettings(unittest.TestCase):
 
     os.environ["IN_TOTO_ARTIFACT_EXCLUDE_PATTERNS"] = "e:n:v"
     os.environ["IN_TOTO_ARTIFACT_BASE_PATH"] = "e/n/v"
+    os.environ["IN_TOTO_LINK_CMD_EXEC_TIMEOUT"] = "0.1"
     os.environ["IN_TOTO_NOT_WHITELISTED"] = "parsed"
     os.environ["NOT_PARSED"] = "ignored"
 
@@ -56,6 +57,7 @@ class TestUserSettings(unittest.TestCase):
     # ... and delete test environment variables
     del os.environ["IN_TOTO_ARTIFACT_EXCLUDE_PATTERNS"]
     del os.environ["IN_TOTO_ARTIFACT_BASE_PATH"]
+    del os.environ["IN_TOTO_LINK_CMD_EXEC_TIMEOUT"]
     del os.environ["IN_TOTO_NOT_WHITELISTED"]
     del os.environ["NOT_PARSED"]
 
@@ -66,6 +68,7 @@ class TestUserSettings(unittest.TestCase):
 
     # Parsed (and split) and used by `set_settings` to monkeypatch settings
     self.assertListEqual(rc_dict["ARTIFACT_EXCLUDE_PATTERNS"], ["r", "c", "file"])
+    self.assertEqual(rc_dict["LINK_CMD_EXEC_TIMEOUT"], "20")
 
     # Parsed but ignored in `set_settings` (not in case sensitive whitelist)
     self.assertEqual(rc_dict["artifact_base_path"], "r/c/file")
@@ -82,6 +85,9 @@ class TestUserSettings(unittest.TestCase):
     # Parsed (and split) but overriden by rcfile setting in `set_settings`
     self.assertListEqual(env_dict["ARTIFACT_EXCLUDE_PATTERNS"],
         ["e", "n", "v"])
+
+    # Parsed and used by `set_settings`
+    self.assertEqual(env_dict["LINK_CMD_EXEC_TIMEOUT"], "0.1")
 
     # Parsed but ignored in `set_settings` (not in case sensitive whitelist)
     self.assertEqual(env_dict["NOT_WHITELISTED"], "parsed")
@@ -100,6 +106,7 @@ class TestUserSettings(unittest.TestCase):
     # From RCfile setting (has precedence over envvar setting)
     self.assertListEqual(in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS,
         ["r", "c", "file"])
+    self.assertEqual(in_toto.settings.LINK_CMD_EXEC_TIMEOUT, "20")
 
     # Not whitelisted rcfile settings are ignored by `set_settings`
     self.assertTrue("new_rc_setting" in in_toto.user_settings.get_rc())


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**: 

Allow the user to specify a timeout for the `in-toto-run` command in settings.py. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


