### PR TITLE
Fix issue 378: duplicate imports

### DIFF
--- a/in_toto/util.py
+++ b/in_toto/util.py
@@ -12,8 +12,6 @@ import securesystemslib.exceptions
 import securesystemslib.gpg.functions
 
 from in_toto.exceptions import UnsupportedKeyTypeError
-from securesystemslib.interface import (import_ed25519_privatekey_from_file,
-    import_ed25519_publickey_from_file)
 
 DEFAULT_RSA_KEY_BITS = 3072
 
@@ -170,7 +168,8 @@ def import_public_keys_from_files_as_dict(filepaths, key_types=None):
   for idx, filepath in enumerate(filepaths):
 
     if key_types[idx] == KEY_TYPE_ED25519:
-      key = import_ed25519_publickey_from_file(filepath)
+      key = securesystemslib.interface.import_ed25519_publickey_from_file(
+          filepath)
     elif key_types[idx] == KEY_TYPE_RSA:
       key = import_rsa_key_from_file(filepath)
     else:  # pragma: no cover
@@ -241,10 +240,12 @@ def prompt_import_ed25519_privatekey_from_file(filepath):
   """
   password = None
   try:
-    import_ed25519_privatekey_from_file(filepath, password)
+    securesystemslib.interface.import_ed25519_privatekey_from_file(
+        filepath, password)
   except securesystemslib.exceptions.CryptoError:
     password = prompt_password()
-  return import_ed25519_privatekey_from_file(filepath, password)
+  return securesystemslib.interface.import_ed25519_privatekey_from_file(
+      filepath, password)
 
 
 def prompt_import_rsa_key_from_file(filepath):

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -39,8 +39,6 @@ import in_toto.models.layout
 import in_toto.models.link
 import in_toto.formats
 from in_toto.models.metadata import Metablock
-from in_toto.models.link import (FILENAME_FORMAT, FILENAME_FORMAT_SHORT)
-from in_toto.models.layout import SUBLAYOUT_LINK_DIR_FORMAT
 from in_toto.exceptions import (RuleVerificationError, LayoutExpiredError,
     ThresholdVerificationError, BadReturnValueError,
     SignatureVerificationError)
@@ -144,7 +142,8 @@ def load_links_for_layout(layout, link_dir_path):
       for keyid in [authorized_keyid] + list(layout.keys.get(authorized_keyid,
           {}).get("subkeys", {}).keys()):
 
-        filename = FILENAME_FORMAT.format(step_name=step.name, keyid=keyid)
+        filename = in_toto.models.link.FILENAME_FORMAT.format(
+            step_name=step.name, keyid=keyid)
         filepath = os.path.join(link_dir_path, filename)
 
         try:
@@ -222,7 +221,8 @@ def run_all_inspections(layout):
 
     # Dump the inspection link file for auditing
     # Keep in mind that this pollutes the verifier's (client's) filesystem.
-    filename = FILENAME_FORMAT_SHORT.format(step_name=inspection.name)
+    filename = in_toto.models.link.FILENAME_FORMAT_SHORT.format(
+        step_name=inspection.name)
     link.dump(filename)
 
     in_toto.settings.ARTIFACT_BASE_PATH = base_path_backup
@@ -1311,11 +1311,11 @@ def verify_sublayouts(layout, chain_link_dict, superlayout_link_dir_path):
         # name relative the the current link directory path, i.e. if there
         # are multiple levels of sublayout nesting, the links are expected to
         # be nested accordingly
-        sublayout_link_dir = SUBLAYOUT_LINK_DIR_FORMAT.format(
+        sub_link_dir = in_toto.models.layout.SUBLAYOUT_LINK_DIR_FORMAT.format(
             name=step_name, keyid=keyid)
 
         sublayout_link_dir_path = os.path.join(
-            superlayout_link_dir_path, sublayout_link_dir)
+            superlayout_link_dir_path, sub_link_dir)
 
         # Make a recursive call to in_toto_verify with the
         # layout and the extracted key object


### PR DESCRIPTION
We had a few unnecessary duplicate imports.
This commit removes the additional "from-import" lines,
and just uses the full path for the import.

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:

Fixes issue #378 

**Description of the changes being introduced by the pull request**:

Use imports and not `from .. import ..`-lines. I also realized that the latter is against our Code Style Guidelines.. ^^

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


