### PR TITLE
WIP: fix 260, add persist_inspection_links parameter

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -182,8 +182,8 @@ def run_all_inspections(layout, persist_inspection_links):
             A Layout object which is used to extract the Inspections.
 
     persist_inspection_links:
-            A boolean that determines whether or not link metadata files for
-            inspection are written to cwd.
+            A boolean indicating whether link metadata files for inspection
+            are written to cwd.
 
   <Exceptions>
     Calls function that raises BadReturnValueError if an inspection returned
@@ -224,11 +224,11 @@ def run_all_inspections(layout, persist_inspection_links):
 
     inspection_links_dict[inspection.name] = link
 
-    # If the client requests persistent inspection links,
+    # If client requests persistent inspection links,
     # Dump the inspection link file for auditing
     # Keep in mind that this pollutes the verifier's (client's) filesystem.
     if persist_inspection_links:
-      filename = in_toto.models.link.FILENAME_FORMAT_SHORT.format(
+      filename = in_toto.models.link.FILENAME_FORMAT_SHORT.format( # TODO: use full path...
           step_name=inspection.name)
       link.dump(filename)
 
@@ -1432,7 +1432,7 @@ def in_toto_verify(layout, layout_key_dict, link_dir_path=".",
     step_name (optional): A name assigned to the returned link. This is mostly
         useful during recursive sublayout verification.
 
-    persist_inspection_links: (optional) : A boolean that determines whether or
+    persist_inspection_links (optional): A boolean that determines whether or
         not link metadata files for inspection are written to cwd.
 
   Raises:

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -228,7 +228,7 @@ def run_all_inspections(layout, persist_inspection_links):
     # Dump the inspection link file for auditing
     # Keep in mind that this pollutes the verifier's (client's) filesystem.
     if persist_inspection_links:
-      filename = in_toto.models.link.FILENAME_FORMAT_SHORT.format( # TODO: use full path...
+      filename = in_toto.models.link.FILENAME_FORMAT_SHORT.format(
           step_name=inspection.name)
       link.dump(filename)
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -148,15 +148,16 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
     with self.assertRaises(BadReturnValueError):
       run_all_inspections(layout, True)
 
+  def test_inspection_persistence_false(self):
+    """Test metadata link file non-persistence"""
+    os.remove("touch-bar.link")
+    run_all_inspections(self.layout, False)
+    self.assertFalse(os.path.exists("touch-bar.link"))
+
   def test_inspection_persistence_true(self):
     """Test metadata link file persistence"""
     run_all_inspections(self.layout, True)
     self.assertTrue(os.path.exists("touch-bar.link"))
-
-  def test_inspection_persistence_false(self):
-    """Test metadata link file non-persistence"""
-    run_all_inspections(self.layout, False)
-    self.assertFalse(os.path.exists("touch-bar.link"))
 
 
 class TestVerifyCommandAlignment(unittest.TestCase):

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -88,7 +88,7 @@ class Test_RaiseOnBadRetval(unittest.TestCase):
 
 
 class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
-  """Test verifylib.run_all_inspections(layout)"""
+  """Test verifylib.run_all_inspections(layout, persist_inspection_links)"""
 
   @classmethod
   def setUpClass(self):
@@ -127,7 +127,7 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
       f.write("ignore foo")
     in_toto.settings.ARTIFACT_BASE_PATH = ignore_dir
 
-    run_all_inspections(self.layout)
+    run_all_inspections(self.layout, True)
     link = Metablock.load("touch-bar.link")
     self.assertListEqual(list(link.signed.materials.keys()), ["foo"])
     self.assertListEqual(sorted(list(link.signed.products.keys())), sorted(["foo", "bar"]))
@@ -146,7 +146,17 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
         }]
     })
     with self.assertRaises(BadReturnValueError):
-      run_all_inspections(layout)
+      run_all_inspections(layout, True)
+
+  def test_inspection_persistence_true(self):
+    """Test metadata link file persistence"""
+    run_all_inspections(self.layout, True)
+    self.assertTrue(os.path.exists("touch-bar.link"))
+
+  def test_inspection_persistence_false(self):
+    """Test metadata link file non-persistence"""
+    run_all_inspections(self.layout, False)
+    self.assertFalse(os.path.exists("touch-bar.link"))
 
 
 class TestVerifyCommandAlignment(unittest.TestCase):

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -150,12 +150,12 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
 
   def test_inspection_persistence_false(self):
     """Test metadata link file non-persistence"""
-    os.remove("touch-bar.link")
+    if os.path.exists("touch-bar.link"):
+      os.remove("touch-bar.link")
     run_all_inspections(self.layout, False)
     self.assertFalse(os.path.exists("touch-bar.link"))
 
-  def test_inspection_persistence_true(self):
-    """Test metadata link file persistence"""
+  def test_inspeciton_persistence_true(self):
     run_all_inspections(self.layout, True)
     self.assertTrue(os.path.exists("touch-bar.link"))
 


### PR DESCRIPTION
**Fixes issue #**: 260

**Description of the changes being introduced by the pull request**:
Picking up from ghost's PR, #380. Adds a parameter to `run_all_inspections` to indicate whether metadata link file is written.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


