### PR TITLE
Skip publishing coverage results on lint build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
           env: TOXENV=py38
         - python: "3.8"
           env: TOXENV=lint
+          after_success: skip
 
 install:
     - pip install -U tox


### PR DESCRIPTION
**Fixes issue #**:

**Description of the changes being introduced by the pull request**:
Update travis config to not send coverage results to coveralls
on a pure lint build.

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


