### PR TITLE
Bump securesystemslib dependency to 0.18.0

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -35,6 +35,6 @@ pathspec==0.8.0
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
 python-dateutil==2.8.1
-securesystemslib[crypto,pynacl]==0.16.0
+securesystemslib[crypto,pynacl]==0.18.0
 six==1.15.0
 subprocess32==3.5.4       # via securesystemslib

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -35,6 +35,6 @@ pathspec==0.8.0
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
 python-dateutil==2.8.1
-git+https://github.com/lukpueh/securesystemslib@misc-interface-enhancements
+securesystemslib[crypto,pynacl]==0.16.0
 six==1.15.0
 subprocess32==3.5.4       # via securesystemslib


### PR DESCRIPTION
**Fixes issue #**:
In preparation for upcoming securesystemslib 0.18.0 release, currently blocked by https://github.com/secure-systems-lab/securesystemslib/pull/288

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


