### PR TITLE
Adopt recent sslib key interface changes

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -40,11 +40,22 @@ Generate Key Pairs
 .. autofunction:: securesystemslib.interface.generate_and_write_ed25519_keypair_with_prompt
 .. autofunction:: securesystemslib.interface.generate_and_write_unencrypted_ed25519_keypair
 
+.. note::
+
+   ``securesystemslib`` does not provide functions to generate OpenPGP key
+   pairs. You can use `GnuPG <https://gnupg.org/>`_ for that.
+
 Load Signing Keys
 ^^^^^^^^^^^^^^^^^
 .. autofunction:: securesystemslib.interface.import_privatekey_from_file
 .. autofunction:: securesystemslib.interface.import_rsa_privatekey_from_file
 .. autofunction:: securesystemslib.interface.import_ed25519_privatekey_from_file
+
+.. note::
+
+   OpenPGP private keys do not need to be imported for signing. They remain in
+   the `GnuPG <https://gnupg.org/>`_ keyring and can be addressed by keyid
+   (see the :py:func:`in_toto.models.metadata.Metablock.sign_gpg` method).
 
 Load Verification Keys
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -53,3 +64,9 @@ Load Verification Keys
 .. autofunction:: securesystemslib.interface.import_rsa_publickey_from_file
 .. autofunction:: securesystemslib.gpg.functions.export_pubkey
 .. autofunction:: securesystemslib.gpg.functions.export_pubkeys
+
+ .. seealso::
+
+   The :py:func:`in_toto.models.layout.Layout` class also provides shortcuts to
+   load public functionary keys and directly assign them to an in-toto layout
+   (see ``add_functionary_key*`` methods).

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -34,7 +34,11 @@ are documented below.
 Generate Key Pairs
 ^^^^^^^^^^^^^^^^^^
 .. autofunction:: securesystemslib.interface.generate_and_write_rsa_keypair
+.. autofunction:: securesystemslib.interface.generate_and_write_rsa_keypair_with_prompt
+.. autofunction:: securesystemslib.interface.generate_and_write_unencrypted_rsa_keypair
 .. autofunction:: securesystemslib.interface.generate_and_write_ed25519_keypair
+.. autofunction:: securesystemslib.interface.generate_and_write_ed25519_keypair_with_prompt
+.. autofunction:: securesystemslib.interface.generate_and_write_unencrypted_ed25519_keypair
 
 Load Signing Keys
 ^^^^^^^^^^^^^^^^^

--- a/doc/source/layout-creation-example.md
+++ b/doc/source/layout-creation-example.md
@@ -23,7 +23,7 @@ from in_toto.models.metadata import Metablock
 # In this example Alice is the project owner, whose private key is used to sign
 # the layout. The corresponding public key will be used during final product
 # verification.
-alice_path = generate_and_write_rsa_keypair("alice", password="123")
+alice_path = generate_and_write_rsa_keypair(password="123", filepath="alice")
 alice_key = import_rsa_privatekey_from_file(alice_path, password="123")
 
 # Bob and Carl are both functionaries, i.e. they are authorized to carry out
@@ -32,8 +32,8 @@ alice_key = import_rsa_privatekey_from_file(alice_path, password="123")
 # Carl will generate when carrying out their respective tasks.
 # Bob and Carl will each require their private key when creating link metadata
 # for a step.
-bob_path = generate_and_write_rsa_keypair("bob", password="123")
-carl_path = generate_and_write_rsa_keypair("carl", password="123")
+bob_path = generate_and_write_rsa_keypair(password="123", filepath="bob")
+carl_path = generate_and_write_rsa_keypair(password="123", filepath="carl")
 
 
 # Create an empty layout

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -111,7 +111,7 @@ directory.
 def main():
   """
   First calls parse_args to parse the arguments, and then calls either
-  generate_and_write_rsa_keypair or generate_and_write_ed25519_keypair
+  _generate_and_write_rsa_keypair or _generate_and_write_ed25519_keypair
   depending upon the arguments. It then dumps the corresponding key files as:
   <filename> and <filename>.pub (Private key and Public key respectively)
   """
@@ -120,10 +120,10 @@ def main():
 
   try:
     if args.type == KEY_TYPE_RSA:
-      interface.generate_and_write_rsa_keypair(
+      interface._generate_and_write_rsa_keypair( # pylint: disable=protected-access
           filepath=args.name, bits=args.bits, prompt=args.prompt)
     elif args.type == KEY_TYPE_ED25519:
-      interface.generate_and_write_ed25519_keypair(
+      interface._generate_and_write_ed25519_keypair( # pylint: disable=protected-access
           filepath=args.name, prompt=args.prompt)
     else:  # pragma: no cover
       LOG.error(

--- a/tests/common.py
+++ b/tests/common.py
@@ -27,8 +27,11 @@ import sys
 import inspect
 import shutil
 import tempfile
-from securesystemslib.interface import (generate_and_write_rsa_keypair,
-    generate_and_write_ed25519_keypair)
+from securesystemslib.interface import (
+    generate_and_write_rsa_keypair,
+    generate_and_write_unencrypted_rsa_keypair,
+    generate_and_write_ed25519_keypair,
+    generate_and_write_unencrypted_ed25519_keypair)
 
 import unittest
 if sys.version_info >= (3, 3):
@@ -94,10 +97,10 @@ class GenKeysMixin():
   @classmethod
   def set_up_keys(cls):
     # Generated unencrypted keys
-    cls.rsa_key_path = generate_and_write_rsa_keypair()
+    cls.rsa_key_path = generate_and_write_unencrypted_rsa_keypair()
     cls.rsa_key_id = os.path.basename(cls.rsa_key_path)
 
-    cls.ed25519_key_path = generate_and_write_ed25519_keypair()
+    cls.ed25519_key_path = generate_and_write_unencrypted_ed25519_keypair()
     cls.ed25519_key_id = os.path.basename(cls.ed25519_key_path)
 
     # Generate encrypted keys

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -32,8 +32,10 @@ from in_toto.exceptions import SignatureVerificationError
 from in_toto.runlib import (in_toto_run, in_toto_record_start,
     in_toto_record_stop, record_artifacts_as_dict, _apply_exclude_patterns,
     _hash_artifact)
-from securesystemslib.interface import (generate_and_write_rsa_keypair,
-    import_rsa_privatekey_from_file, import_rsa_publickey_from_file)
+from securesystemslib.interface import (
+    generate_and_write_unencrypted_rsa_keypair,
+    import_rsa_privatekey_from_file,
+    import_rsa_publickey_from_file)
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT
 
 import securesystemslib.formats
@@ -489,7 +491,7 @@ class TestInTotoRun(unittest.TestCase, TmpDirMixin):
 
     self.step_name = "test_step"
     self.key_path = "test_key"
-    generate_and_write_rsa_keypair(self.key_path)
+    generate_and_write_unencrypted_rsa_keypair(self.key_path)
     self.key = import_rsa_privatekey_from_file(self.key_path)
     self.key_pub = import_rsa_publickey_from_file(self.key_path + ".pub")
 
@@ -673,7 +675,7 @@ class TestInTotoRecordStart(unittest.TestCase, TmpDirMixin):
     self.set_up_test_dir()
 
     self.key_path = "test_key"
-    generate_and_write_rsa_keypair(self.key_path)
+    generate_and_write_unencrypted_rsa_keypair(self.key_path)
     self.key = import_rsa_privatekey_from_file(self.key_path)
 
     self.step_name = "test_step"
@@ -725,8 +727,8 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
 
     self.key_path = "test-key"
     self.key_path2 = "test-key2"
-    generate_and_write_rsa_keypair(self.key_path)
-    generate_and_write_rsa_keypair(self.key_path2)
+    generate_and_write_unencrypted_rsa_keypair(self.key_path)
+    generate_and_write_unencrypted_rsa_keypair(self.key_path2)
     self.key = import_rsa_privatekey_from_file(self.key_path)
     self.key2 = import_rsa_privatekey_from_file(self.key_path2)
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: #80
(Follows up on #402 to address recent changes in pending secure-systems-lab/securesystemslib#288)

**Description of the changes being introduced by the pull request**:
PR #402 adopted key interface changes from the pending secure-systems-lab/securesystemslib#288 PR and was merged prematurely. The sslib PR now has further evolved, in order to follow the principle of secure defaults in regards to private key encryption, which requires the following adoptions in in-toto:

- The not secure by default `generate_and_write_*_keypair` function is now protected (`_generate_and_write_*_keypair`), and only used for the keygen cli utility, where it is really convenient.

- In other cases we use either `generate_and_write_*_keypair` (for encrypted keys only) or `generate_and_write_unencrypted_*_keypair`.

Furthermore, the newly added sslib key generation interface functions are added to the in-toto API docs, including additional notes and cross-references relevant for key handling.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


