### PR TITLE
Add >=Py3.5 constraint for bandit test dependency

### DIFF
--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -6,5 +6,5 @@
 
 # Test tools for linting and test coverage measurement
 pylint
-bandit
+bandit; python_version >= "3.5"
 coverage


### PR DESCRIPTION
**Fixes issue #**:

**Description of the changes being introduced by the pull request**:
Bandit just dropped support for Python <3.5. This PR adds a corresponding constraint to requirements-test.txt.

Note, we run bandit in a dedicated 'lint' tox environment, which uses Python3.8 on Travis.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


