### PR TITLE
Allow running in_toto_verify with prerecorded inspection results

### DIFF
--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -150,6 +150,54 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
     with self.assertRaises(BadReturnValueError):
       run_all_inspections(layout)
 
+  def test_inspection_prerecorded(self):
+    """Use pre-recorded inspection results."""
+
+    prerecorded_inspections = {
+        "touch-bar": {
+            "materials": {
+                "foo": {
+                    "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+                },
+            },
+            "products": {
+                "foo": {
+                    "sha256": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+                },
+                "bar": {
+                    "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                },
+            },
+        },
+    }
+    link_dict = run_all_inspections(
+            self.layout,
+            prerecorded_inspections=prerecorded_inspections)
+    link = link_dict['touch-bar']
+    self.assertListEqual(list(link.signed.materials.keys()), ["foo"])
+    self.assertListEqual(sorted(list(link.signed.products.keys())), sorted(["foo", "bar"]))
+    # the actual file should not be created
+    self.assertFalse(os.path.exists("bar"))
+
+    # now try to really execute the inspection and compare the result
+    link_dict_real = run_all_inspections(self.layout)
+    self.assertEqual(link_dict, link_dict_real)
+
+  def test_inspection_prerecorded_empty(self):
+    """Use pre-recorded inspection results."""
+
+    prerecorded_inspections = {
+        "touch-bar": {},
+    }
+    link_dict = run_all_inspections(
+            self.layout,
+            prerecorded_inspections=prerecorded_inspections)
+    link = link_dict['touch-bar']
+    self.assertListEqual(list(link.signed.materials.keys()), [])
+    self.assertListEqual(sorted(list(link.signed.products.keys())), [])
+    # the actual file should not be created
+    self.assertFalse(os.path.exists("bar"))
+
 
 class TestVerifyCommandAlignment(unittest.TestCase):
   """Test verifylib.verify_command_alignment(command, expected_command)"""

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -91,11 +91,12 @@ class Test_RaiseOnBadRetval(unittest.TestCase):
 class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
   """Test verifylib.run_all_inspections(layout)"""
 
-  @classmethod
-  def setUpClass(self):
+  def setUp(self):
     """
     Create layout with dummy inpsection.
     Create and change into temp test directory with dummy artifact."""
+
+    super(TestRunAllInspections, self).setUp()
 
     # find where the scripts directory is located.
     scripts_directory = os.path.join(
@@ -116,9 +117,9 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
     with open("foo", "w") as f:
       f.write("foo")
 
-  @classmethod
-  def tearDownClass(self):
+  def tearDown(self):
     self.tear_down_test_dir()
+    super(TestRunAllInspections, self).tearDown()
 
   def test_inpsection_artifacts_with_base_path_ignored(self):
     """Create new dummy test dir and set as base path, must ignore. """


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:

**Description of the changes being introduced by the pull request**:

Allow to verify the layout using pre-recorded inspection results. In
practice, this is very useful with a dummy steps ("/usr/bin/true"
command) when integrating with package managers (apt, dnf, etc) when the
file hashes are already known from repository metadata. This allows to
verify the packages based on links produced by rebuilders, before
actually downloading the packages (do not waste bandwidth for invalid
packages). The package manager will later verify if downloaded
packages actually matches expected hashes.
This is especially useful for DNF (Fedora package manager), where rejecting a package based on its hash (before downloading it), is relatively easy, while rejecting already downloaded package is much harder and prone to accidentally re-use previously rejected package.

Implement this as an extra argument ("prerecorded_inspections") to the in_toto_verify() function, which consists of materials and products hashes for each step. Steps execution included in this dict will be skipped and materials/products hashes from the argument will be used
instead.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


