### PR TITLE
Use sphinx built-in Napoleon with the upstream patch

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -41,9 +41,8 @@ master_doc = 'index'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-# FIXME: Use sphinx built-in Napoleon (coordinate with in-toto/in-toto#401)
-extensions = ['sphinx.ext.autodoc', 'sphinxcontrib.napoleon', 'sphinxarg.ext',
-    'argparse_epilog', 'recommonmark', 'sphinx.ext.todo', 'sphinx_rtd_theme']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinxarg.ext',
+    'argparse_epilog', 'recommonmark', 'sphinx.ext.todo', 'sphinx_rtd_theme',]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -72,3 +71,5 @@ html_favicon = 'in-toto-icon-color.png'
 # html_static_path = ['_static']
 
 todo_include_todos = True
+
+napoleon_custom_sections = [('Side Effects', 'returns_style')]

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,6 +4,4 @@
 # sphinx extensions
 sphinx-rtd-theme
 sphinx-argparse
-# FIXME: Use sphinx built-in Napoleon (coordinate with in-toto/in-toto#401)
-git+https://github.com/secure-systems-lab/napoleon.git@v0.7-1
 recommonmark


### PR DESCRIPTION
**Fixes issue #401**: 

**Description of the changes being introduced by the pull request**:

- Replace the napoleon fork with sphinx built-in Napoleon
- Update the sphinx setup to use the upstream patch

I submitted a patch to the Sphinx community to support our custom _Side Effect_ docstring section. This patch was merged and released in Sphinx v3.5.0, so we can now replace the temporary napoleon fork (PR #420) with the sphinx built in Napoleon extension.

See: https://github.com/sphinx-doc/sphinx/pull/8658

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


