### PR TITLE
Add SPDX identifier and copyright information

### DIFF
--- a/in_toto/__init__.py
+++ b/in_toto/__init__.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Configure base logger for in_toto (see in_toto.log for details).
 

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   common_args.py

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # TODO: Add module docstring and remove pylint exemption in in-toto/in-toto#126
 # pylint: disable=missing-docstring
 from securesystemslib.exceptions import Error

--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   formats.py

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_keygen.py

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_mock.py

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_record.py

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_run.py

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_sign.py

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   in_toto_verify.py

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   log.py

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   common.py

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   layout.py

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   link.py

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   metadata.py

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Module Name>
   in_toto/rulelib.py

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   runlib.py

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   settings.py

--- a/in_toto/user_settings.py
+++ b/in_toto/user_settings.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   user_settings.py

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   verifylib.py

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 import sys
 import logging
 import in_toto

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   common.py

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_common.py

--- a/tests/models/test_inspection.py
+++ b/tests/models/test_inspection.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_inspection.py

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_layout.py

--- a/tests/models/test_link.py
+++ b/tests/models/test_link.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_link.py

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_metadata.py

--- a/tests/models/test_step.py
+++ b/tests/models/test_step.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_step.py

--- a/tests/models/test_supply_chain_item.py
+++ b/tests/models/test_supply_chain_item.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_supply_chain_item.py

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   runtests.py

--- a/tests/test_common_args.py
+++ b/tests/test_common_args.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_common_args.py

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_in_toto_keygen.py

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_in_toto_mock.py

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_in_toto_record.py

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_in_toto_run.py

--- a/tests/test_in_toto_sign.py
+++ b/tests/test_in_toto_sign.py
@@ -1,3 +1,5 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
 
 """
 <Program Name>

--- a/tests/test_in_toto_verify.py
+++ b/tests/test_in_toto_verify.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_in_toto_verify.py

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_log.py

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_param_substitution.py

--- a/tests/test_rulelib.py
+++ b/tests/test_rulelib.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_rulelib.py

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 #coding=utf-8
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_runlib.py

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_settings.py

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,3 +1,6 @@
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_user_settings.py

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
 """
 <Program Name>
   test_verifylib.py


### PR DESCRIPTION
**Fixes issue #**: #439

**Description of the changes being introduced by the pull request**:

This PR includes a copyright statement and an SPDX license identifier to each source file of the reference implementation.

I skipped adding it to https://github.com/in-toto/in-toto/blob/develop/in_toto/models/__init__.py and https://github.com/in-toto/in-toto/blob/develop/tests/models/__init__.py to avoid a situation like http://trillian.mit.edu/~jc/humor/ATT_Copyright_true.html. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


