### PR TITLE
[W.I.P] Add new model: Provenance

### DIFF
--- a/in_toto/models/provenance.py
+++ b/in_toto/models/provenance.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+<Program Name>
+  provenance.py
+
+<Author>
+  Furkan Türkal <furkan.turkal@trendyol.com>
+
+<Started>
+  Aug 3, 2021
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provides a class for provenance metadata which is information gathered when a
+  step of the supply chain is performed.
+"""
+
+import attr
+import securesystemslib.formats
+from in_toto.models.common import Signable
+from in_toto.verifylib import _get_attribute
+
+FILENAME_FORMAT = "{step_name}.{keyid:.8}.provenance"
+FILENAME_FORMAT_SHORT = "{step_name}.provenance"
+UNFINISHED_FILENAME_FORMAT = ".{step_name}.{keyid:.8}.provenance-unfinished"
+UNFINISHED_FILENAME_FORMAT_GLOB = ".{step_name}.{pattern}.provenance-unfinished"
+
+
+@attr.s(repr=False, init=False)
+class Provenance(Signable):
+  """Evidence for a performed step or inspection of the supply chain.
+
+  SPEC: https://github.com/in-toto/attestation/blob/main/spec/predicates/provenance.md
+
+  Provenance is a claim that some entity (builder) produced one or more
+  software artifacts (Statement's subject) by executing some recipe,
+  using some other artifacts as input (materials).
+
+  Attributes:
+    builder: Identifies the entity that executed the recipe, which is
+        trusted to have correctly performed the operation and populated this
+        provenance.
+
+        {
+          "id": "<URI>"
+        }
+
+    recipe: Identifies the configuration used for the build. When combined with
+        materials, this SHOULD fully describe the build, such that re-running
+        this recipe results in bit-for-bit identical output (if the build is
+        reproducible).
+
+        {
+          "type": "<URI>",
+          "definedInMaterial": /* integer */,
+          "entryPoint": "<STRING>",
+          "arguments": { /* object */ },
+          "environment": { /* object */ }
+        }
+
+    metadata: Other properties of the build.
+
+            {
+              "buildInvocationId": "<STRING>",
+              "buildStartedOn": "<TIMESTAMP>",
+              "buildFinishedOn": "<TIMESTAMP>",
+              "completeness": {
+                "arguments": true/false,
+                "environment": true/false,
+                "materials": true/false
+              },
+              "reproducible": true/false
+            }
+
+    materials: The collection of artifacts that influenced the build
+        including sources, dependencies, build tools, base images,
+        and so on.
+
+            {
+              "uri": "<URI>",
+              "digest": { /* DigestSet */ }
+            }
+
+  """
+  _type = attr.ib()
+  builder = attr.ib()
+  recipe = attr.ib()
+  metadata = attr.ib()
+  materials = attr.ib()
+
+  def __init__(self, **kwargs):
+    super(Provenance, self).__init__()
+
+    self._type = "provenance"
+    self.builder = kwargs.get("builder", {"id": "foo://bar"})
+    self.recipe = kwargs.get("recipe", {"type": "foo://bar", "definedInMaterial": 0, "entryPoint": "", "arguments": {}, "environment": {}})
+    self.metadata = kwargs.get("metadata", {"buildInvocationId": "", "buildStartedOn": 1628017067, "buildFinishedOn": 1628017089, "reproducible": False, "completeness": {"arguments": False, "environment": False, "materials": False}})
+    self.materials = kwargs.get("materials", [{"uri": "foo://bar", "digest": {"md5": "8f961ea23d77b9b8c01a12b2818e1055"}}])
+
+    self.validate()
+
+  @property
+  def type_(self):
+    """The string "provenance" to identify the in-toto metadata type."""
+    # NOTE: We expose the type_ property in the API documentation instead of
+    # _type to protect it against modification.
+    # NOTE: Trailing underscore is used by convention (pep8) to avoid conflict
+    # with Python's type keyword.
+    return self._type
+
+  @staticmethod
+  def read(data):
+    """Creates a Provenance object from its dictionary representation.
+
+    Arguments:
+      data: A dictionary with provenance metadata fields.
+
+    Raises:
+      securesystemslib.exceptions.FormatError: Passed data is invalid.
+
+    Returns:
+      The created Provenance object.
+
+    """
+    return Provenance(**data)
+
+  def _validate_type(self):
+    """Private method to check that `_type` is set to "Provenance"."""
+    if self._type != "provenance":
+      raise securesystemslib.exceptions.FormatError(
+          "Invalid Link: field `_type` must be set to 'provenance', got: {}"
+          .format(self._type))
+
+    securesystemslib.formats.URL_SCHEMA.check_match(self._type)
+
+  def _validate_builder(self):
+    """Private method to check that `builder` is a `dict`."""
+    if not isinstance(self.builder, dict):
+      raise securesystemslib.exceptions.FormatError(
+          "Invalid Link: field `builder` must be of type dict, got: {}"
+          .format(type(self.builder)))
+
+    securesystemslib.formats.URL_SCHEMA.check_match(self.builder["id"])
+
+  def _validate_recipe(self):
+    """Private method to check that `builder` is a `dict`."""
+    if not isinstance(self.recipe, dict):
+      raise securesystemslib.exceptions.FormatError(
+          "Invalid Link: field `recipe` must be of type dict, got: {}"
+          .format(type(self.recipe)))
+
+    if self.recipe is not None:
+      assert _get_attribute(self.recipe, 'type')
+
+      securesystemslib.formats.URL_SCHEMA.check_match(self.recipe['type'])
+      # TODO: securesystemslib.formats.ANY_NUMBER_SCHEMA.check_match(self.recipe.type)
+
+      if _get_attribute(self.recipe, 'entryPoint'):
+        securesystemslib.formats.ANY_STRING_SCHEMA.check_match(self.recipe['entryPoint'])
+
+      if _get_attribute(self.recipe, 'arguments'):
+        if not isinstance(self.recipe['arguments'], dict):
+          raise securesystemslib.exceptions.FormatError(
+            "Invalid Link: field `recipe.arguments` must be of type dict, got: {}"
+              .format(type(self.recipe['arguments'])))
+
+      if _get_attribute(self.recipe, 'environment'):
+        if not isinstance(self.recipe['environment'], dict):
+          raise securesystemslib.exceptions.FormatError(
+            "Invalid Link: field `recipe.environment` must be of type dict, got: {}"
+              .format(type(self.recipe['environment'])))
+
+  def _validate_metadata(self):
+    """Private method to check that `builder` is a `dict`."""
+    if not isinstance(self.metadata, dict):
+      raise securesystemslib.exceptions.FormatError(
+        "Invalid Link: field `metadata` must be of type dict, got: {}"
+          .format(type(self.metadata)))
+
+    if _get_attribute(self.metadata, 'buildInvocationId'):
+      securesystemslib.formats.ANY_STRING_SCHEMA.check_match(self.metadata['buildInvocationId'])
+    if _get_attribute(self.metadata, 'buildStartedOn'):
+      securesystemslib.formats.UNIX_TIMESTAMP_SCHEMA.check_match(self.metadata['buildStartedOn'])
+    if _get_attribute(self.metadata, 'buildFinishedOn'):
+      securesystemslib.formats.UNIX_TIMESTAMP_SCHEMA.check_match(self.metadata['buildFinishedOn'])
+    if _get_attribute(self.metadata, 'reproducible'):
+      securesystemslib.formats.BOOLEAN_SCHEMA.check_match(self.metadata['reproducible'])
+
+    if _get_attribute(self.metadata, 'completeness'):
+      """Check that `completeness` is a `dict`."""
+      if not isinstance(self.metadata['completeness'], dict):
+        raise securesystemslib.exceptions.FormatError(
+          "Invalid Link: field `metadata.completeness` must be of type dict, got: {}"
+            .format(type(self.metadata.completeness)))
+
+      if _get_attribute(self.metadata['completeness'], 'arguments'):
+        securesystemslib.formats.BOOLEAN_SCHEMA.check_match(self.metadata['completeness']['arguments'])
+      if _get_attribute(self.metadata['completeness'], 'environment'):
+        securesystemslib.formats.BOOLEAN_SCHEMA.check_match(self.metadata['completeness']['environment'])
+      if _get_attribute(self.metadata['completeness'], 'materials'):
+        securesystemslib.formats.BOOLEAN_SCHEMA.check_match(self.metadata['completeness']['materials'])
+
+  def _validate_materials(self):
+    """Private method to check that `command` is a `list`."""
+    if not isinstance(self.materials, list):
+      raise securesystemslib.exceptions.FormatError(
+        "Invalid Link: field `materials` must be of type dict, got: {}"
+          .format(type(self.materials)))
+
+    for material in list(self.materials):
+      if _get_attribute(material, 'uri'):
+        securesystemslib.formats.URL_SCHEMA.check_match(material['uri'])
+      if _get_attribute(material, 'digest'):
+        securesystemslib.formats.HASHDICT_SCHEMA.check_match(material['digest'])

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -939,6 +939,15 @@ def verify_require_rule(filename, artifacts_queue):
         "in: {queue}\n{traceback}".format(filename=filename,
         queue=artifacts_queue, traceback=_get_artifact_rule_traceback()))
 
+def _get_attribute(data, key):
+  """To check whether given key is exist in data"""
+  try:
+    buf = data[key]
+  except KeyError:
+    return False
+
+  return True
+
 
 def _get_artifact_rule_traceback():
   """Build and return string form global `RULE_TRACE` which may be used as

--- a/tests/models/test_provenance.py
+++ b/tests/models/test_provenance.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+# Copyright New York University and the in-toto contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+<Program Name>
+  test_provenance.py
+
+<Author>
+  Furkan Türkal <furkan.turkal@trendyol.com>
+
+<Started>
+  Aug 3, 2021
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test provenance class functions.
+
+"""
+
+import unittest
+from in_toto.models.provenance import Provenance
+from securesystemslib.exceptions import FormatError
+
+
+class TestProvenanceValidator(unittest.TestCase):
+  """Test provenance format validators """
+
+  def test_validate_type(self):
+    """Test `_type` field. Must be "provenance" """
+    test = Provenance()
+
+    # Good type
+    test._type = "provenance"
+    test.validate()
+
+    # Bad type
+    test._type = "bad link"
+    with self.assertRaises(FormatError):
+      test.validate()
+
+  def test_validate_builder(self):
+    """Test `builder` field. Must be a `dict`"""
+    test = Provenance()
+
+    # Good builder
+    test.builder = {"id": "https://foo.bar/baz"}
+    test.validate()
+
+    # Bad builder 1
+    test.builder = "not a dict"
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad builder 2
+    test.builder = {"id": 15}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+  def test_validate_recipe(self):
+    """Test `recipe` field. Must be a `dict`"""
+    test = Provenance()
+
+    # Good products
+    test.recipe = {"type": "foo", "definedInMaterial": 0, "entryPoint": "", "arguments": {}, "environment": {}}
+    test.validate()
+
+    # Bad recipe 1
+    test = Provenance()
+    test.recipe = "not a dict"
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad recipe 2: non-exist required type field
+    test.recipe = {"not": "type must exist"}
+    with self.assertRaises(AssertionError):
+      test.validate()
+
+    # Bad recipe 3: non-string entryPoint
+    test.recipe = {"type": "foo", "definedInMaterial": 0, "entryPoint": 15, "arguments": {}, "environment": {}}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad recipe 4: non-obj arguments
+    test.recipe = {"type": "foo", "definedInMaterial": 0, "entryPoint": "", "arguments": [], "environment": {}}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad recipe 5: non-obj environment
+    test.recipe = {"type": "foo", "definedInMaterial": 0, "entryPoint": "", "arguments": {}, "environment": []}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+  def test_validate_metadata(self):
+    """Test `metadata` field. Must be a `list`"""
+    test = Provenance()
+
+    # Good metadata 1
+    test.metadata = {"buildInvocationId": "", "buildStartedOn": 1628017067, "buildFinishedOn": 1628017089, "reproducible": False, "completeness": {"arguments": False, "environment": False, "materials": False}}
+    test.validate()
+
+    # Good metadata 2: all optional
+    test.metadata = {}
+    test.validate()
+
+    # Bad metadata 1
+    test.metadata = "not a obj"
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 2: non-string buildInvocationId
+    test.metadata = {"buildInvocationId": 15}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 3: non-unix-format buildStartedOn
+    test.metadata = {"buildStartedOn": -707}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 4: non-unix-format buildFinishedOn
+    test.metadata = {"buildFinishedOn": -707}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 5: non-bool reproducible
+    test.metadata = {"reproducible": "foo"}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 6: non-obj completeness
+    test.metadata = {"completeness": []}
+    with self.assertRaises(AttributeError):
+      test.validate()
+
+    # Bad metadata 7: non-bool completeness.arguments
+    test.metadata = {"completeness": {"arguments": "foo"}}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 8: non-bool completeness.environment
+    test.metadata = {"completeness": {"environment": "foo"}}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad metadata 9: non-bool completeness.materials
+    test.metadata = {"completeness": {"materials": "foo"}}
+    with self.assertRaises(FormatError):
+      test.validate()
+
+  def test_validate_materials(self):
+    """Test `materials` field. Must be a `list`"""
+    test = Provenance()
+
+    # Good materials
+    test.materials = [{"uri": "foo", "digest": {"md5": "8f961ea23d77b9b8c01a12b2818e1055"}}]
+    test.validate()
+
+    # Bad materials 1
+    test.materials = "not a list"
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad materials 2: non-string uri, optional digest
+    test.materials = [{"uri": 15}]
+    with self.assertRaises(FormatError):
+      test.validate()
+
+    # Bad materials 3: bad digest format
+    test.materials = [{"uri": "bar", "digest": "baz"}]
+    with self.assertRaises(FormatError):
+      test.validate()


### PR DESCRIPTION
Fixes #464

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

For the `TODO` line:
```python
# TODO: securesystemslib.formats.ANY_NUMBER_SCHEMA.check_match(self.recipe.type)
```

I already created an issue: https://github.com/secure-systems-lab/securesystemslib/issues/367

I created a small function called `_get_attribute` in order to pass `(OPTIONAL)` variables. (I followed the [spec](https://github.com/in-toto/attestation/blob/main/spec/predicates/provenance.md))

I implemented a bare model and tests, but couldn't figure it out how to make it work. It seems most `in_toto_*` entry points uses the `link` type for the running, generating and validating. Shouldn't we make that `run`, `sign`, `verify`, etc. more generic in order to parse and read different predicate types? Should I create a new for parser for this? What is the way out? Thanks! (I just wanted to learn project's internal domain :) )

Feed free to edit! Waiting your feedback!

---

**Description of the changes being introduced by the pull request**:

See the issue.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [X] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


