### PR TITLE
Add explicit utf8 encoding to "open" calls

### DIFF
--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -109,7 +109,7 @@ class Metablock(ValidationMixin):
       object.
 
     """
-    with open(path, "r") as fp:
+    with open(path, "r", encoding="utf8") as fp:
       data = json.load(fp)
 
     signatures = data.get("signatures", [])

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -125,7 +125,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         "subdir/foosub2", "subdir/subsubdir/foosubsub"]
 
     for path in self.full_file_path_list:
-      with open(path, "w") as fp:
+      with open(path, "w", encoding="utf8") as fp:
         fp.write(path)
 
 
@@ -789,7 +789,8 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
     in_toto_record_start(self.step_name, [], self.key)
     in_toto_record_stop(self.step_name, [], self.key)
     with self.assertRaises(IOError):
-      open(self.link_name_unfinished, "r") # pylint: disable=consider-using-with
+      # pylint: disable-next=consider-using-with
+      open(self.link_name_unfinished, "r", encoding="utf8")
     self.assertTrue(os.path.isfile(self.link_name))
     os.remove(self.link_name)
 
@@ -798,7 +799,8 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
     with self.assertRaises(IOError):
       in_toto_record_stop(self.step_name, [], self.key)
     with self.assertRaises(IOError):
-      open(self.link_name, "r") # pylint: disable=consider-using-with
+      # pylint: disable-next=consider-using-with
+      open(self.link_name, "r", encoding="utf8")
 
   def test_wrong_signature_in_unfinished_metadata(self):
     """Test record stop exits on wrong signature, no link recorded. """
@@ -811,7 +813,8 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
     with self.assertRaises(SignatureVerificationError):
       in_toto_record_stop(self.step_name, [], self.key2)
     with self.assertRaises(IOError):
-      open(self.link_name, "r") # pylint: disable=consider-using-with
+      # pylint: disable-next=consider-using-with
+      open(self.link_name, "r", encoding="utf8")
     os.rename(changed_link_name, link_name)
     os.remove(self.link_name_unfinished)
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -112,7 +112,7 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
 
     # Create directory where the verification will take place
     self.set_up_test_dir()
-    with open("foo", "w") as f:
+    with open("foo", "w", encoding="utf8") as f:
       f.write("foo")
 
   @classmethod
@@ -123,7 +123,7 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
     """Create new dummy test dir and set as base path, must ignore. """
     ignore_dir = os.path.realpath(tempfile.mkdtemp())
     ignore_foo = os.path.join(ignore_dir, "ignore_foo")
-    with open(ignore_foo, "w") as f:
+    with open(ignore_foo, "w", encoding="utf8") as f:
       f.write("ignore foo")
     in_toto.settings.ARTIFACT_BASE_PATH = ignore_dir
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

Our linter is unhappy that we don't provide an explicit encoding when opening files in `Metablock.load`. This PR sets the encoding to utf8.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


