### PR TITLE
Disable consider-using-f-string in pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -15,7 +15,7 @@ good-names=e, fn, fp
 # TODO: Enable W0703 (broad-except) with in-toto/in-toto#126 and consider
 # enabling C0411, C0412, C0413, R0401 (import related checkers) with
 # in-toto/in-toto#145.
-disable= fixme, logging-format-interpolation, logging-not-lazy, design, broad-except, wrong-import-order, ungrouped-imports, wrong-import-position, cyclic-import, len-as-condition, literal-comparison, useless-object-inheritance, consider-merging-isinstance, duplicate-code, inconsistent-return-statements, no-self-use, bad-classmethod-argument, super-with-arguments
+disable= fixme, logging-format-interpolation, logging-not-lazy, design, broad-except, wrong-import-order, ungrouped-imports, wrong-import-position, cyclic-import, len-as-condition, literal-comparison, useless-object-inheritance, consider-merging-isinstance, duplicate-code, inconsistent-return-statements, no-self-use, bad-classmethod-argument, super-with-arguments, consider-using-f-string
 
 [VARIABLES]
 dummy-variables-rgx= _+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_|junk


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A.

**Description of the changes being introduced by the pull request**:

Disables `consider-using-f-string` in pylint. Our style guideline recommends using both f-strings and the currently used `.format` mechanisms: https://github.com/secure-systems-lab/code-style-guidelines/blob/master/python.md#string-formatting, so IMO we shouldn't go and change the 94 (!) instances that the linter currently warns us about (https://github.com/in-toto/in-toto/pull/472/checks?check_run_id=3796490973).

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


