### PR TITLE
Citation.bib: add in-toto paper citation

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,12 @@
+@inproceedings {236322,
+    author = {Santiago Torres-Arias and Hammad Afzali and Trishank Karthik Kuppusamy and Reza Curtmola and Justin Cappos},
+    title = {in-toto: Providing farm-to-table guarantees for bits and bytes},
+    booktitle = {28th USENIX Security Symposium (USENIX Security 19)},
+    year = {2019},
+    isbn = {978-1-939133-06-9},
+    address = {Santa Clara, CA},
+    pages = {1393--1410},
+    url = {https://www.usenix.org/conference/usenixsecurity19/presentation/torres-arias},
+    publisher = {USENIX Association},
+    month = aug,
+}


### PR DESCRIPTION
Apparently, you can just commit a bib file, according to this:

    https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#other-citation-files

It took me this long because I didn't know how to add affiliations with
cff...


**Fixes issue #**: N/A see above

**Description of the changes being introduced by the pull request**:

Adds a citation file so people cite the paper and not the repository

**Please verify and check that the pull request fulfills the following
requirements**:

- [N/A] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [N/A] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


