### PR TITLE
docs: update security contacts and policy location

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,17 +149,7 @@ You can read more about how in-toto works by taking a look at the [specification
 
 
 ## Security Issues and Bugs
-Security issues can be reported by emailing justincappos@gmail.com.
-
-At a minimum, the report must contain the following:
-* Description of the vulnerability.
-* Steps to reproduce the issue.
-
-Optionally, reports that are emailed can be encrypted with PGP. You should use
-PGP key fingerprint E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A.
-
-Please do not use the GitHub issue tracker to submit vulnerability reports. The
-issue tracker is intended for bug reports and to make feature requests.
+See [SECURITY.md](https://github.com/in-toto/in-toto/blob/develop/SECURITY.md)
 
 ## Instructions for Contributors
 Development of in-toto occurs on the "develop" branch of this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+Security issues can be reported by emailing torresariass@gmail.com.
+
+At a minimum, the report must contain the following:
+
+- Description of the vulnerability.
+- Steps to reproduce the issue.
+
+Optionally, reports that are emailed can be encrypted with PGP. You should use
+PGP key fingerprint 903B AB73 640E B6D6 5533 EFF3 468F 122C E816 2295.
+
+Please do not use the GitHub issue tracker to submit vulnerability reports. The
+issue tracker is intended for bug reports and to make feature requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+# Security Policy
+
 Security issues can be reported by emailing torresariass@gmail.com.
 
 At a minimum, the report must contain the following:


### PR DESCRIPTION
**Fixes issue #**: https://github.com/in-toto/in-toto/issues/506

**Description of the changes being introduced by the pull request**: Security policy separation from the README.md, update contacts to be @SantiagoTorres 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

I wonder if we still need to go through steps 1-4 of setting up [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
