### PR TITLE
Updating the Consensus Builder

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,7 +11,7 @@ review GitHub pull requests and (2) open issues or [submit vulnerability
 reports](https://github.com/in-toto/in-toto#security-issues-and-bugs).
 A maintainer has the authority to approve or reject pull requests submitted by
 contributors.  The project's Consensus Builder (CB) is
-Justin Cappos <jcappos@nyu.edu, @JustinCappos>.
+Santiago Torres-Arias <santiagotorres@purdue.edu, @santiagotorres>.
 
 ## Contributions
 A contributor can submit GitHub pull requests to the project's repositories.

--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -1,12 +1,12 @@
-The project is currently managed by Justin Cappos at New York University.
+The project is currently managed by Santiago Torres at Purdue.
 Please see GOVERNANCE.md for the project's governance and maintainership.
 
 Consensus Builder:
 
-  Justin Cappos
-    Email: jcappos@nyu.edu
-    GitHub username: @JustinCappos
-    PGP fingerprint: E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A
+  Santiago Torres
+    Email: santiagotorres@purdue.edu
+    GitHub username: @SantiagoTorres
+    PGP fingerprint: 903B AB73 640E B6D6 5533  EFF3 468F 122C E816 2295
 
 Maintainers:
   Lukas Puehringer
@@ -14,10 +14,10 @@ Maintainers:
     GitHub username: @lukpueh
     PGP fingerprint: 8BA6 9B87 D43B E294 F23E  8120 89A2 AD3C 07D9 62E8
 
-  Santiago Torres
-    Email: santiagotorres@purdue.edu
-    GitHub username: @SantiagoTorres
-    PGP fingerprint: 903B AB73 640E B6D6 5533  EFF3 468F 122C E816 2295
+  Justin Cappos
+    Email: jcappos@nyu.edu
+    GitHub username: @JustinCappos
+    PGP fingerprint: E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A
 
   Marina Moore
     Email: mm9693@nyu.edu


### PR DESCRIPTION
This moves Santiago to be consensus builder to reflect his role as the lead of the project.  I will be continuing to stay active after this as a maintainer and will always work hard for the project.  

Looking forward to having this long overdue PR approved and merged!  


