### PR TITLE
Add cli tools support for ecdsa keys

### DIFF
--- a/in_toto/__init__.py
+++ b/in_toto/__init__.py
@@ -6,9 +6,9 @@ Configure base logger for in_toto (see in_toto.log for details).
 
 """
 import in_toto.log
-from securesystemslib import KEY_TYPE_RSA, KEY_TYPE_ED25519
+from securesystemslib import KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA
 
-SUPPORTED_KEY_TYPES = [KEY_TYPE_RSA, KEY_TYPE_ED25519]
+SUPPORTED_KEY_TYPES = [KEY_TYPE_RSA, KEY_TYPE_ED25519, KEY_TYPE_ECDSA]
 
 
 # in-toto version

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -30,7 +30,8 @@
 """
 import sys
 
-from in_toto import SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519
+from in_toto import (SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519,
+                    KEY_TYPE_ECDSA)
 
 EXCLUDE_ARGS = ["--exclude"]
 EXCLUDE_KWARGS = {
@@ -85,9 +86,11 @@ KEY_TYPE_KWARGS = {
   "choices": SUPPORTED_KEY_TYPES,
   "default": KEY_TYPE_RSA,
   "help": ("type of key specified by the '--key' option. '{rsa}' keys are"
-           " expected in a 'PEM' format and '{ed25519}' in a custom"
-           " 'securesystemslib/json' format. Default is '{rsa}'.".format(
-           rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519))
+           " expected in a 'PEM' format. '{ed25519}' and '{ecdsa}' are"
+           " expected to be in a custom 'securesystemslib/json' format."
+           " Default is '{rsa}'."
+           .format(rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519,
+                   ecdsa=KEY_TYPE_ECDSA))
 }
 
 KEY_PASSWORD_ARGS = ["-P", "--password"]

--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -35,7 +35,8 @@ import logging
 
 from in_toto.common_args import title_case_action_groups
 from in_toto import (
-    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519)
+    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519,
+    KEY_TYPE_ECDSA)
 from securesystemslib import interface
 
 # Command line interfaces should use in_toto base logger (c.f. in_toto.log)
@@ -89,10 +90,12 @@ directory.
                             choices=SUPPORTED_KEY_TYPES,
                             default=KEY_TYPE_RSA,
                             help="type of the key to be generated. '{rsa}'"
-                            " keys are written in a 'PEM' format and"
-                            " '{ed25519}' in a custom 'securesystemslib/json'"
-                            " format. Default is '{rsa}'.".format(
-                            rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519))
+                            " keys are written in a 'PEM' format. '{ed25519}'"
+                            " and '{ecdsa}' keys are written in a custom"
+                            " 'securesystemslib/json' format. Default is"
+                            " '{rsa}'.".format(rsa=KEY_TYPE_RSA,
+                                               ed25519=KEY_TYPE_ED25519,
+                                               ecdsa=KEY_TYPE_ECDSA))
 
 
   parser.add_argument("name", type=str, metavar="<filename>",
@@ -128,6 +131,9 @@ def main():
           filepath=args.name, bits=args.bits, prompt=args.prompt)
     elif args.type == KEY_TYPE_ED25519:
       interface._generate_and_write_ed25519_keypair( # pylint: disable=protected-access
+          filepath=args.name, prompt=args.prompt)
+    elif args.type == KEY_TYPE_ECDSA:
+      interface._generate_and_write_ecdsa_keypair( # pylint: disable=protected-access
           filepath=args.name, prompt=args.prompt)
     else:  # pragma: no cover
       LOG.error(

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -33,7 +33,8 @@ from in_toto.common_args import (GPG_HOME_ARGS, GPG_HOME_KWARGS, VERBOSE_ARGS,
     VERBOSE_KWARGS, QUIET_ARGS, QUIET_KWARGS, title_case_action_groups,
     sort_action_groups)
 from in_toto import (
-    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519)
+    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519,
+    KEY_TYPE_ECDSA)
 
 import securesystemslib.formats
 from securesystemslib import interface
@@ -268,12 +269,12 @@ Verify layout with a gpg key identified by keyid '...439F3C2'.
       type=str, choices=SUPPORTED_KEY_TYPES,
       nargs="+", help=(
       "types of keys specified by the '--key' option. '{rsa}' keys are"
-      " expected in a 'PEM' format and '{ed25519}' in a custom"
-      " 'securesystemslib/json' format. If multiple keys are passed via"
+      " expected in a 'PEM' format. '{ed25519}' and '{ecdsa} are expected in a"
+      " custom 'securesystemslib/json' format. If multiple keys are passed via"
       " '--key' the same amount of key types must be passed. Key"
       " types are then associated with keys by index. If '--key-type' is"
       " omitted, the default of '{rsa}' is used for all keys.".format(
-      rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519)))
+      rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519, ecdsa=KEY_TYPE_ECDSA)))
 
   parser.add_argument("-p", "--prompt", action="store_true",
       help="prompt for signing key decryption password")

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -35,7 +35,8 @@ from in_toto.common_args import (GPG_HOME_ARGS, GPG_HOME_KWARGS, VERBOSE_ARGS,
     sort_action_groups, OPTS_TITLE)
 from in_toto.models.metadata import Metablock
 from in_toto import (
-    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519)
+    __version__, SUPPORTED_KEY_TYPES, KEY_TYPE_RSA, KEY_TYPE_ED25519,
+    KEY_TYPE_ECDSA)
 from securesystemslib import interface
 from securesystemslib.gpg import functions as gpg_interface
 
@@ -123,12 +124,13 @@ for which the public part can be found in the GPG keyring at '~/.gnupg'.
       type=str, choices=SUPPORTED_KEY_TYPES,
       nargs="+", help=(
       "types of keys specified by the '--layout-keys' option. '{rsa}' keys are"
-      " expected in a 'PEM' format and '{ed25519}' in a custom"
-      " 'securesystemslib/json' format. If multiple keys are passed via"
-      " '--layout-keys' the same amount of key types must be passed. Key"
-      " types are then associated with keys by index. If '--key-types' is"
-      " omitted, the default of '{rsa}' is used for all keys.".format(
-      rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519)))
+      " expected in a 'PEM' format. '{ed25519}' and '{ecdsa}' are expected"
+      " in a custom 'securesystemslib/json' format. If multiple keys are"
+      " passed via '--layout-keys' the same amount of key types must be"
+      " passed. Key types are then associated with keys by index. If"
+      " '--key-types' is omitted, the default of '{rsa}' is used for all"
+      " keys.".format(
+      rsa=KEY_TYPE_RSA, ed25519=KEY_TYPE_ED25519, ecdsa=KEY_TYPE_ECDSA)))
 
   named_args.add_argument("-g", "--gpg", nargs="+", metavar="<id>",
       help=(

--- a/tests/common.py
+++ b/tests/common.py
@@ -35,7 +35,9 @@ from securesystemslib.interface import (
     generate_and_write_rsa_keypair,
     generate_and_write_unencrypted_rsa_keypair,
     generate_and_write_ed25519_keypair,
-    generate_and_write_unencrypted_ed25519_keypair)
+    generate_and_write_unencrypted_ed25519_keypair,
+    generate_and_write_ecdsa_keypair,
+    generate_and_write_unencrypted_ecdsa_keypair)
 
 import unittest
 from unittest.mock import patch
@@ -104,12 +106,18 @@ class GenKeysMixin():
     cls.ed25519_key_path = generate_and_write_unencrypted_ed25519_keypair()
     cls.ed25519_key_id = os.path.basename(cls.ed25519_key_path)
 
+    cls.ecdsa_key_path = generate_and_write_unencrypted_ecdsa_keypair()
+    cls.ecdsa_key_id = os.path.basename(cls.ecdsa_key_path)
+
     # Generate encrypted keys
     cls.rsa_key_enc_path = generate_and_write_rsa_keypair(password=cls.key_pw)
     cls.rsa_key_enc_id = os.path.basename(cls.rsa_key_enc_path)
 
     cls.ed25519_key_enc_path = generate_and_write_ed25519_keypair(password=cls.key_pw)
     cls.ed25519_key_enc_id = os.path.basename(cls.ed25519_key_enc_path)
+
+    cls.ecdsa_key_enc_path = generate_and_write_ecdsa_keypair(password=cls.key_pw)
+    cls.ecdsa_key_enc_id = os.path.basename(cls.ecdsa_key_enc_path)
 
 
 class CliTestCase(unittest.TestCase):

--- a/tests/test_in_toto_keygen.py
+++ b/tests/test_in_toto_keygen.py
@@ -59,6 +59,9 @@ class TestInTotoKeyGenTool(unittest.TestCase, TmpDirMixin):
     with patch.object(sys, 'argv', args + ["-t", "ed25519", "bob"]), \
       self.assertRaises(SystemExit):
       in_toto_keygen_main()
+    with patch.object(sys, 'argv', args + ["-t", "ecdsa", "bob"]), \
+      self.assertRaises(SystemExit):
+      in_toto_keygen_main()
     with patch.object(sys, 'argv', args + ["-p", "-t", "ed25519", "bob"]), \
       patch("getpass.getpass", return_value=password), self.assertRaises(
       SystemExit):

--- a/tests/test_in_toto_run.py
+++ b/tests/test_in_toto_run.py
@@ -56,10 +56,14 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin, GenKeysMixin):
         step_name=self.test_step, keyid=self.rsa_key_id)
     self.test_link_ed25519 = FILENAME_FORMAT.format(
         step_name=self.test_step, keyid=self.ed25519_key_id)
+    self.test_link_ecdsa = FILENAME_FORMAT.format(
+        step_name=self.test_step, keyid=self.ecdsa_key_id)
     self.test_link_rsa_enc = FILENAME_FORMAT.format(
         step_name=self.test_step, keyid=self.rsa_key_enc_id)
     self.test_link_ed25519_enc = FILENAME_FORMAT.format(
         step_name=self.test_step, keyid=self.ed25519_key_enc_id)
+    self.test_link_ecdsa_enc = FILENAME_FORMAT.format(
+        step_name=self.test_step, keyid=self.ecdsa_key_enc_id)
 
     self.test_artifact = "test_artifact"
     Path(self.test_artifact).touch()
@@ -152,13 +156,23 @@ class TestInTotoRunTool(CliTestCase, TmpDirMixin, GPGKeysMixin, GenKeysMixin):
     self.assert_cli_sys_exit(args, 0)
     self.assertTrue(os.path.exists(self.test_link_ed25519))
 
+  def test_main_with_unencrypted_ecdsa_key(self):
+    """Test CLI command with ecdsa key. """
+    args = ["-n", self.test_step,
+        "--key", self.ecdsa_key_path,
+        "--key-type", "ecdsa", "--", "ls"]
+
+    self.assert_cli_sys_exit(args, 0)
+    self.assertTrue(os.path.exists(self.test_link_ecdsa))
+
 
   def test_main_with_encrypted_keys(self):
     """Test CLI command with encrypted ed25519 key. """
 
     for key_type, key_path, link_path in [
         ("rsa", self.rsa_key_enc_path, self.test_link_rsa_enc),
-        ("ed25519", self.ed25519_key_enc_path, self.test_link_ed25519_enc)]:
+        ("ed25519", self.ed25519_key_enc_path, self.test_link_ed25519_enc),
+        ("ecdsa", self.ecdsa_key_enc_path, self.test_link_ecdsa_enc)]:
 
 
       # Define common arguments passed to in in-toto-run below


### PR DESCRIPTION
**Fixes issue #519**:

**Description of the changes being introduced by the pull request**:
This commit adds command line tool support for ecdsa key types.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


