### PR TITLE
Fix bandit linter invocation in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,5 @@ commands =
 
     # Run bandit, a security linter from OpenStack Security
     # Exclude files that need special treatment and are tested below
-    bandit -r in_toto -x in_toto/util.py
-    # Ignore false positive "hardcoded password" warning
-    # NOTE: Should become obsolete with in-toto/in-toto#80
-    # https://bandit.readthedocs.io/en/latest/plugins/b107_hardcoded_password_funcdef.html
-    bandit in_toto/util.py --skip B107
+    bandit -r in_toto
+


### PR DESCRIPTION
We invoke bandit twice, once w/o util.py and once only for util.py, using different options. util.py was removed in #402. So this case handling is no longer relevant.
