### PR TITLE
Changing expiration check to match TUF

### DIFF
--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -257,7 +257,7 @@ def verify_layout_expiration(layout):
 
   """
   expire_datetime = iso8601.parse_date(layout.expires)
-  if expire_datetime < datetime.datetime.now(tz.tzutc()):
+  if expire_datetime <= datetime.datetime.now(tz.tzutc()):
     raise LayoutExpiredError("Layout expired")
 
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue**: #417 

**Description of the changes being introduced by the pull request**:
Changing `expire_datetime <= datetime.datetime.now(tz.tzutc())`
to `expire_datetime <= datetime.datetime.now(tz.tzutc())` as discussed at #417 
**Please verify and check that the pull request fulfills the following
requirements**:

- ☑ The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- ☑ Tests have been added for the bug fix or new feature
- ☑ Docs have been added for the bug fix or new feature


