### PR TITLE
Implements #531 - allow setting command, byproducts, and environment …

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -855,7 +855,8 @@ def in_toto_record_start(step_name, material_list, signing_key=None,
 def in_toto_record_stop(step_name, product_list, signing_key=None,
     gpg_keyid=None, gpg_use_default=False, gpg_home=None,
     exclude_patterns=None, base_path=None, normalize_line_endings=False,
-    lstrip_paths=None, metadata_directory=None):
+    lstrip_paths=None, metadata_directory=None, command=None, byproducts=None,
+    environment=None):
   """Finalizes preliminary link metadata generated with in_toto_record_start.
 
   Loads preliminary link metadata file, verifies its signature, and records
@@ -903,6 +904,22 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
 
     metadata_directory (optional): A directory path to write the resulting link
         metadata file to. Default destination is the current working directory.
+
+    command (optional): A list consisting of a command and arguments executed
+        between in_toto_record_start() and in_toto_record_stop() to capture
+        the command ran in the resulting link metadata.
+
+    byproducts (optional): A dictionary that lists byproducts of the link
+        command execution. It should have at least the following entries
+        "stdout" (str), "stderr" (str) and "return-value" (int).
+
+    environment (optional): A dictionary to capture information about
+        the environment to be added in the resulting link metadata eg.::
+            {
+              "variables": "<list of env var KEY=value pairs>",
+              "filesystem": "<filesystem info>",
+              "workdir": "<CWD when executing link command>"
+            }
 
   Raises:
     securesystemslib.exceptions.FormatError: Passed arguments are malformed.
@@ -1033,6 +1050,15 @@ def in_toto_record_stop(step_name, product_list, signing_key=None,
       product_list, exclude_patterns=exclude_patterns, base_path=base_path,
       follow_symlink_dirs=True, normalize_line_endings=normalize_line_endings,
       lstrip_paths=lstrip_paths)
+
+  if command:
+    link.command = command
+
+  if byproducts:
+    link.byproducts = byproducts
+
+  if environment:
+    link.environment = environment
 
   if isinstance(link_metadata, Metablock):
     LOG.info("Generating link metadata using Metablock...")

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1023,6 +1023,24 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
     self.assertEqual(list(link.products.keys()), [self.test_product])
     os.remove(self.link_name)
 
+  def test_create_metadata_with_command_byproducts_environment(self):
+    """Test record stop records expected product. """
+    command = ["cp", "src", "dest"]
+    byproducts = {"stdout": "success", "stderr": "errors", "return-value": 0}
+    environment = {
+              "variables": "ENV_NAME=ENV_VALUE",
+              "filesystem": "<filesystem info>",
+              "workdir": "./"
+            }
+
+    in_toto_record_start(self.step_name, [], self.key, record_environment=True)
+    in_toto_record_stop(self.step_name, [self.test_product], self.key, command=command,
+      byproducts=byproducts, environment=environment)
+    link = Metablock.load(self.link_name)
+    self.assertEqual(link.signed.command, command)
+    self.assertDictEqual(link.signed.byproducts, byproducts)
+    self.assertDictEqual(link.signed.environment, environment)
+    os.remove(self.link_name)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
**Fixes issue #**: 

- #531

**Description of the changes being introduced by the pull request**:

- Allow setting command, byproducts, and environment with `in_toto_record_stop()`
- Added unittest to ensure command, byproducts, and environment are set correctly when passed into in_toto_record_stop()`
- squashed commits as suggested in PR #535 (Closed previous PR and created a new one).

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


