### PR TITLE
Update security policy to use new reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,12 @@
-# Security Policy
+# Security Issues and Bugs
 
-Security issues can be reported by emailing torresariass@gmail.com.
+Security issues can be reported to maintainers [privately via
+GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
 
-At a minimum, the report must contain the following:
+- [**Report new
+  vulnerability**](https://github.com/in-toto/in-toto/security/advisories/new)
 
-- Description of the vulnerability.
-- Steps to reproduce the issue.
-
-Optionally, reports that are emailed can be encrypted with PGP. You should use
-PGP key fingerprint 903B AB73 640E B6D6 5533 EFF3 468F 122C E816 2295.
-
-Please do not use the GitHub issue tracker to submit vulnerability reports. The
-issue tracker is intended for bug reports and to make feature requests.
+Please do not use the GitHub issue tracker to submit vulnerability reports. The issue
+tracker is intended for bug reports and to make feature requests. Major feature
+requests, such as design changes to the specification, should be proposed via [in-toto
+Enhancement](https://github.com/in-toto/ITE/blob/master/ITE/1/README.adoc) (ITE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,13 @@
 # Security Issues and Bugs
 
-Security issues can be reported to maintainers [privately via
-GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
+Please **report security issues confidentially** via GitHub [**"Report new
+vulnerability"**](https://github.com/in-toto/in-toto/security/advisories/new) form.
 
-- [**Report new
-  vulnerability**](https://github.com/in-toto/in-toto/security/advisories/new)
+Alternatively, you can email reports to torresariass@gmail.com, optionally encrypted
+with PGP using this key (fingerprint):
+> 903B AB73 640E B6D6 5533 EFF3 468F 122C E816 2295
 
-Please do not use the GitHub issue tracker to submit vulnerability reports. The issue
+Please **do not use the GitHub issue tracker** to submit vulnerability reports. The issue
 tracker is intended for bug reports and to make feature requests. Major feature
 requests, such as design changes to the specification, should be proposed via [in-toto
 Enhancement](https://github.com/in-toto/ITE/blob/master/ITE/1/README.adoc) (ITE).


### PR DESCRIPTION
- Enabled new GitHub feature (beta) via GitHub Web UI to privately report security issues to all maintainers.
- Updated security policy document to instruct reporters to use the new reporting mechanism instead of email+pgp.

closes #566


