### PR TITLE
Add interface for generic artifact resolvers and file implementation

### DIFF
--- a/in_toto/resolver/__init__.py
+++ b/in_toto/resolver/__init__.py
@@ -1,0 +1,7 @@
+"""Artifact resolver API.
+
+Extensible interface to hash artifacts based on URIs.
+
+"""
+
+from in_toto.resolver._resolver import FileResolver

--- a/in_toto/resolver/__init__.py
+++ b/in_toto/resolver/__init__.py
@@ -2,6 +2,21 @@
 
 Extensible interface to hash artifacts based on URIs.
 
+Example usage::
+
+    from in_toto.resolver import Resolver, RESOLVER_FOR_URI_SCHEME
+
+    # Register resolver instances for schemes
+    RESOLVER_FOR_URI_SCHEME["myscheme"] = MyResolver()
+
+    # Resolve arbitrary URIs with registered resolvers
+    resolver = Resolver.for_uri(uri)
+    artifact_hashes = resolver.hash_artifacts(uris)
+
 """
 
-from in_toto.resolver._resolver import FileResolver
+from in_toto.resolver._resolver import (
+  RESOLVER_FOR_URI_SCHEME,
+  FileResolver,
+  Resolver,
+)

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -26,9 +26,9 @@ class Resolver(metaclass=ABCMeta):
     @classmethod
     def for_uri(cls, uri):
         """Return registered resolver instance for passed URI."""
-        scheme, _, _ = uri.partition(":")
+        scheme, match, _ = uri.partition(":")
 
-        if scheme not in RESOLVER_FOR_URI_SCHEME:
+        if not match or scheme not in RESOLVER_FOR_URI_SCHEME:
             scheme = FileResolver.SCHEME
 
         return RESOLVER_FOR_URI_SCHEME[scheme]

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -1,0 +1,169 @@
+"""Resolver interface and default file resolver implementation. """
+import logging
+import os
+from itertools import combinations
+from os.path import exists, isdir, isfile, join, normpath
+
+from pathspec import GitIgnoreSpec
+from securesystemslib.exceptions import FormatError
+from securesystemslib.hash import digest_filename
+
+from in_toto.exceptions import PrefixError
+
+logger = logging.getLogger(__name__)
+
+_HASH_ALGORITHM = "sha256"
+
+
+class FileResolver:
+    """File resolver implementation.
+
+    Provides a ``hash_artifacts`` method to generate hashes for passed file
+    paths. The resolver is configurable via its constructor.
+
+    """
+
+    def __init__(
+        self,
+        exclude_patterns=None,
+        base_path=None,
+        follow_symlink_dirs=False,
+        normalize_line_endings=False,
+        lstrip_paths=None,
+    ):
+        if exclude_patterns is None:
+            exclude_patterns = []
+
+        if not lstrip_paths:
+            lstrip_paths = []
+
+        for name, val in [
+            ("exclude_patterns", exclude_patterns),
+            ("lstrip_paths", lstrip_paths),
+        ]:
+            if not isinstance(val, list) or not all(
+                isinstance(i, str) for i in val
+            ):
+                # FIXME: FormatError for backwards-compat; should be ValueError
+                raise FormatError(f"'{name}' must be list of strings")
+
+        for _a, _b in combinations(lstrip_paths, 2):
+            if _a.startswith(_b) or _b.startswith(_a):
+                raise PrefixError(
+                    f"'{_a}' and '{_b}' triggered a left substring error"
+                )
+
+        # Compile gitignore-style patterns
+        self._exclude_filter = GitIgnoreSpec.from_lines(
+            "gitwildmatch", exclude_patterns
+        )
+        self._base_path = base_path
+        self._follow_symlink_dirs = follow_symlink_dirs
+        self._normalize_line_endings = normalize_line_endings
+        self._lstrip_paths = lstrip_paths
+
+    def _exclude(self, path):
+        """Helper to check, if path matches pre-compiled exclude patterns."""
+        return self._exclude_filter.match_file(path)
+
+    def _hash(self, path):
+        """Helper to generate hash dictionary for path."""
+        digest = digest_filename(
+            path,
+            algorithm=_HASH_ALGORITHM,
+            normalize_line_endings=self._normalize_line_endings,
+        )
+        return {_HASH_ALGORITHM: digest.hexdigest()}
+
+    def _mangle(self, path, existing_paths):
+        """Helper for path mangling."""
+
+        # Normalize slashes for cross-platform metadata consistency
+        path = path.replace("\\", "/")
+
+        # Left-strip names using configured path prefixes
+        for lstrip_path in self._lstrip_paths:
+            if path.startswith(lstrip_path):
+                path = path[len(lstrip_path) :]
+                break
+
+        # Fail if left-stripping above results in duplicates
+        if self._lstrip_paths and path in existing_paths:
+            raise PrefixError(
+                "Prefix selection has resulted in non unique dictionary key "
+                f"'{path}'"
+            )
+
+        return path
+
+    def hash_artifacts(self, uris):
+        """Return hash dictionary for passed list of artifact URIs."""
+        hashes = {}
+
+        if self._base_path:
+            original_cwd = os.getcwd()
+            # FIXME: Re-raise for backwards-compat; should remove try/except
+            try:
+                os.chdir(self._base_path)
+            except Exception as e:
+                raise ValueError(
+                    f"Could not use '{self._base_path}' as base path: '{e}'"
+                ) from e
+
+        for path in uris:
+            # Normalize URI before filtering and returning them
+            # FIXME: Is this expected behavior? Does this make exclude patterns
+            # with slashes platform-dependent? Check how 'gitwildmatch' treats
+            # dots and slashes!
+            path = normpath(path)
+
+            if self._exclude(path):
+                continue
+
+            if not exists(path):
+                logger.info("path: %s does not exist, skipping..", path)
+                continue
+
+            if isfile(path):
+                _name = self._mangle(path, hashes)
+                _hashes = self._hash(path)
+                hashes[_name] = _hashes
+
+            if isdir(path):
+                for base, dirs, names in os.walk(
+                    path, followlinks=self._follow_symlink_dirs
+                ):
+                    # Filter directories to avoid unnecessary recursion below
+                    # NOTE: Normalize to filter on directory paths without
+                    # their dot-slash prefix, if path was dot.
+                    dirs[:] = [
+                        dirname
+                        for dirname in dirs
+                        if not self._exclude(normpath(join(base, dirname)))
+                    ]
+
+                    for filename in names:
+                        # NOTE: Normalize to filter on and return file paths
+                        # without their dot-slash prefix, if path was dot.
+                        filepath = normpath(join(base, filename))
+
+                        if self._exclude(filepath):
+                            continue
+
+                        if not isfile(filepath):
+                            logger.info(
+                                "File '%s' appears to be a broken symlink. "
+                                "Skipping...",
+                                filepath,
+                            )
+                            continue
+
+                        _name = self._mangle(filepath, hashes)
+                        _hashes = self._hash(filepath)
+                        hashes[_name] = _hashes
+
+        # Change back to original current working dir
+        if self._base_path:
+            os.chdir(original_cwd)
+
+        return hashes

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -1,4 +1,6 @@
 """Resolver interface and default file resolver implementation. """
+# TODO: Remove with in-toto/in-toto#580
+# pylint: disable=bad-indentation
 import logging
 import os
 from abc import ABCMeta, abstractmethod

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -156,8 +156,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
     exclude_patterns = in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS
 
   # Configure resolver with resolver specific arguments
-  # FIXME: This could happen closer to the user boundary, where
-  # resolver-specific config arguments are passed.
+  # FIXME: This should happen closer to the user boundary, where
+  # resolver-specific config arguments are passed and global state is managed.
   RESOLVER_FOR_URI_SCHEME[FileResolver.SCHEME] = FileResolver(exclude_patterns,
       base_path, follow_symlink_dirs, normalize_line_endings, lstrip_paths)
 
@@ -173,6 +173,11 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
   # artifacts hashed in one batch.
   for resolver, uris in resolver_for_uris.items():
     artifact_hashes.update(resolver.hash_artifacts(uris))
+
+  # Clear resolvers to not preserve global state change beyond this function.
+  # FIXME: This also clears resolver registered elsewhere. For now we
+  # assume that we only modify RESOLVER_FOR_URI_SCHEME in this function.
+  RESOLVER_FOR_URI_SCHEME.clear()
 
   return artifact_hashes
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -30,14 +30,11 @@
 import glob
 import logging
 import os
-import itertools
 import io
 import subprocess  # nosec
 import sys
 import tempfile
 import time
-
-from pathspec import PathSpec
 
 import in_toto.settings
 import in_toto.exceptions
@@ -46,6 +43,7 @@ from in_toto.models._signer import GPGSigner
 from in_toto.models.link import (UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT,
     FILENAME_FORMAT_SHORT, UNFINISHED_FILENAME_FORMAT_GLOB)
 from in_toto.models.metadata import (Metadata, Envelope, Metablock)
+from in_toto.resolver import FileResolver
 
 import securesystemslib.formats
 import securesystemslib.hash
@@ -59,63 +57,6 @@ from securesystemslib.signer import SSlibSigner, Signature
 LOG = logging.getLogger(__name__)
 
 
-
-
-
-def _hash_artifact(filepath, hash_algorithms=None,
-      normalize_line_endings=False):
-  """Internal helper that takes a filename and hashes the respective file's
-  contents using the passed hash_algorithms and returns a hashdict conformant
-  with securesystemslib.formats.HASHDICT_SCHEMA. """
-  if not hash_algorithms:
-    hash_algorithms = ['sha256']
-
-  securesystemslib.formats.HASHALGORITHMS_SCHEMA.check_match(hash_algorithms)
-  hash_dict = {}
-
-  for algorithm in hash_algorithms:
-    digest_object = securesystemslib.hash.digest_filename(filepath, algorithm,
-        normalize_line_endings=normalize_line_endings)
-    hash_dict.update({algorithm: digest_object.hexdigest()})
-
-  securesystemslib.formats.HASHDICT_SCHEMA.check_match(hash_dict)
-
-  return hash_dict
-
-
-def _apply_exclude_patterns(names, exclude_filter):
-  """Exclude matched patterns from passed names."""
-  included = set(names)
-
-  # Assume old way for easier testing
-  if hasattr(exclude_filter, '__iter__'):
-    exclude_filter = PathSpec.from_lines('gitwildmatch', exclude_filter)
-
-  for excluded in exclude_filter.match_files(names):
-    included.discard(excluded)
-
-  return sorted(included)
-
-
-def _apply_left_strip(artifact_filepath, artifacts_dict, lstrip_paths=None):
-  """ Internal helper function to left strip dictionary keys based on
-  prefixes passed by the user. """
-  if lstrip_paths:
-    # If a prefix is passed using the argument --lstrip-paths,
-    # that prefix is left stripped from the filepath passed.
-    # Note: if the prefix doesn't include a trailing /, the dictionary key
-    # may include an unexpected /.
-    for prefix in lstrip_paths:
-      if artifact_filepath.startswith(prefix):
-        artifact_filepath = artifact_filepath[len(prefix):]
-        break
-
-    if artifact_filepath in artifacts_dict:
-      raise in_toto.exceptions.PrefixError("Prefix selection has "
-          "resulted in non unique dictionary key '{}'"
-          .format(artifact_filepath))
-
-  return artifact_filepath
 
 
 def record_artifacts_as_dict(artifacts, exclude_patterns=None,
@@ -200,133 +141,26 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
 
   <Returns>
     A dictionary with file paths as keys and the files' hashes as values.
-  """
 
-  artifacts_dict = {}
+  """
+  artifact_hashes = {}
 
   if not artifacts:
-    return artifacts_dict
+    return artifact_hashes
 
-  if base_path:
-    LOG.info("Overriding setting ARTIFACT_BASE_PATH with passed"
-        " base path.")
-  else:
+  if not base_path:
     base_path = in_toto.settings.ARTIFACT_BASE_PATH
 
-
-  # Temporarily change into base path dir if set
-  if base_path:
-    original_cwd = os.getcwd()
-    try:
-      os.chdir(base_path)
-
-    except Exception as e:
-      raise ValueError("Could not use '{}' as base path: '{}'".format(
-          base_path, e)) from  e
-
-  # Normalize passed paths
-  norm_artifacts = []
-  for path in artifacts:
-    norm_artifacts.append(os.path.normpath(path))
-
-  # Passed exclude patterns take precedence over exclude pattern settings
-  if exclude_patterns:
-    LOG.info("Overriding setting ARTIFACT_EXCLUDE_PATTERNS with passed"
-        " exclude patterns.")
-  else:
-    # TODO: Do we want to keep the exclude pattern setting?
+  if not exclude_patterns:
     exclude_patterns = in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS
 
-  # Apply exclude patterns on the passed artifact paths if available
-  if exclude_patterns:
-    securesystemslib.formats.NAMES_SCHEMA.check_match(exclude_patterns)
-    norm_artifacts = _apply_exclude_patterns(norm_artifacts, exclude_patterns)
+  resolver = FileResolver(exclude_patterns, base_path, follow_symlink_dirs,
+      normalize_line_endings, lstrip_paths)
 
-  # Check if any of the prefixes passed for left stripping is a left substring
-  # of another
-  if lstrip_paths:
-    for prefix_one, prefix_two in itertools.combinations(lstrip_paths, 2):
-      if prefix_one.startswith(prefix_two) or \
-          prefix_two.startswith(prefix_one):
-        raise in_toto.exceptions.PrefixError("'{}' and '{}' "
-            "triggered a left substring error".format(prefix_one, prefix_two))
+  artifact_hashes = resolver.hash_artifacts(artifacts)
 
-  # Compile the gitignore-style patterns
-  exclude_filter = PathSpec.from_lines('gitwildmatch', exclude_patterns or [])
+  return artifact_hashes
 
-  # Iterate over remaining normalized artifact paths
-  for artifact in norm_artifacts:
-    if os.path.isfile(artifact):
-      # FIXME: this is necessary to provide consisency between windows
-      # filepaths and *nix filepaths. A better solution may be in order
-      # though...
-      artifact = artifact.replace('\\', '/')
-      key = _apply_left_strip(artifact, artifacts_dict, lstrip_paths)
-      artifacts_dict[key] = _hash_artifact(artifact,
-          normalize_line_endings=normalize_line_endings)
-
-    elif os.path.isdir(artifact):
-      for root, dirs, files in os.walk(artifact,
-          followlinks=follow_symlink_dirs):
-        # Create a list of normalized dirpaths
-        dirpaths = []
-        for dirname in dirs:
-          norm_dirpath = os.path.normpath(os.path.join(root, dirname))
-          dirpaths.append(norm_dirpath)
-
-        # Applying exclude patterns on the directory paths returned by walk
-        # allows to exclude a subdirectory 'sub' with a pattern 'sub'.
-        # If we only applied the patterns below on the subdirectory's
-        # containing file paths, we'd have to use a wildcard, e.g.: 'sub*'
-        if exclude_patterns:
-          dirpaths = _apply_exclude_patterns(dirpaths, exclude_filter)
-
-        # Reset and refill dirs with remaining names after exclusion
-        # Modify (not reassign) dirnames to only recurse into remaining dirs
-        dirs[:] = []
-        for dirpath in dirpaths:
-          # Dirs only contain the basename and not the full path
-          name = os.path.basename(dirpath)
-          dirs.append(name)
-
-        # Create a list of normalized filepaths
-        filepaths = []
-        for filename in files:
-          norm_filepath = os.path.normpath(os.path.join(root, filename))
-
-          # `os.walk` could also list dead symlinks, which would
-          # result in an error later when trying to read the file
-          if os.path.isfile(norm_filepath):
-            filepaths.append(norm_filepath)
-
-          else:
-            LOG.info("File '{}' appears to be a broken symlink. Skipping..."
-                .format(norm_filepath))
-
-        # Apply exlcude patterns on the normalized file paths returned by walk
-        if exclude_patterns:
-          filepaths = _apply_exclude_patterns(filepaths, exclude_filter)
-
-        for filepath in filepaths:
-          # FIXME: this is necessary to provide consisency between windows
-          # filepaths and *nix filepaths. A better solution may be in order
-          # though...
-          normalized_filepath = filepath.replace("\\", "/")
-          key = _apply_left_strip(
-              normalized_filepath, artifacts_dict, lstrip_paths)
-          artifacts_dict[key] = _hash_artifact(filepath,
-              normalize_line_endings=normalize_line_endings)
-
-    # Path is no file and no directory
-    else:
-      LOG.info("path: {} does not exist, skipping..".format(artifact))
-
-
-  # Change back to where original current working dir
-  if base_path:
-    os.chdir(original_cwd)
-
-  return artifacts_dict
 
 def _subprocess_run_duplicate_streams(cmd, timeout):
   """Helper to run subprocess and both print and capture standards streams.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,89 @@
+"""Test cases for resolver.py."""
+# TODO: Remove with in-toto/in-toto#580
+# pylint: disable=bad-indentation
+from pathlib import Path
+from unittest import TestCase, main
+
+from in_toto.resolver import RESOLVER_FOR_URI_SCHEME, FileResolver, Resolver
+from tests.common import TmpDirMixin
+
+
+class TestResolver(TestCase):
+    """Test default and custom resolver registration and dispatch."""
+
+    def test_register(self):
+        self.assertFalse(RESOLVER_FOR_URI_SCHEME)  # assert empty
+
+        class Default(Resolver):
+            def hash_artifacts(self, uris):
+                pass
+
+        class Custom(Resolver):
+            def hash_artifacts(self, uris):
+                pass
+
+        # uris with: default scheme, non-registered scheme, no scheme
+        uris = ["file:path/to/file", "C:\\path\\to\\file", "path/to/file"]
+
+        # Raise if no scheme is registered (default must be registered too)
+        for uri in uris:
+            with self.assertRaises(KeyError, msg=f"uri={uri}"):
+                Resolver.for_uri(uri)
+
+        RESOLVER_FOR_URI_SCHEME["file"] = Default()
+        RESOLVER_FOR_URI_SCHEME["custom"] = Custom()
+
+        # Once registered, all uris w/o (registered) scheme resolve to default.
+        for uri in uris:
+            self.assertIsInstance(Resolver.for_uri(uri), Default, f"uri={uri}")
+
+        self.assertIsInstance(Resolver.for_uri("custom:path"), Custom)
+        self.assertIsInstance(Resolver.for_uri("custom"), Default)  # no scheme
+
+        RESOLVER_FOR_URI_SCHEME.clear()
+
+
+class TestFileResolver(TmpDirMixin, TestCase):
+    """Test hash_artifacts with and without scheme.
+
+    See 'test_runlib' for comprehensive tests of file hash recording.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.set_up_test_dir()  # tear_down_test_dir is called implicitly
+        Path("foo").touch()
+        Path("bar").mkdir()
+        Path("bar/baz").touch()
+        Path("bar/foo").touch()
+
+    def test_hash_artifacts_scheme_no_scheme(self):
+        """Assert that hashes are the same with and without scheme."""
+        resolver = FileResolver()
+        uris = {"foo", "file:foo"}
+        result = resolver.hash_artifacts(uris)
+        self.assertEqual(result.keys(), uris)
+        # pylint: disable=no-value-for-parameter
+        self.assertEqual(*result.values())
+
+    def test_hash_artifacts_kwags(self):
+        """Assert return values for hash_artifacts with different config."""
+        # Test data: kwargs, uris, expected return value (dict keys)
+        test_data = [
+            ({"base_path": "bar"}, {"file:baz"}, {"file:baz"}),
+            ({"lstrip_paths": ["bar/"]}, {"file:bar/baz"}, {"file:baz"}),
+            (
+                {"exclude_patterns": ["file*", "baz"]},
+                {"file:foo", "file:bar"},
+                {"file:foo", "file:bar/foo"},
+            ),
+        ]
+
+        for kwargs, uris, expected_keys in test_data:
+            resolver = FileResolver(**kwargs)
+            result = resolver.hash_artifacts(uris)
+            self.assertEqual(result.keys(), expected_keys)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1109,7 +1109,7 @@ class TestInTotoMatchProducts(TmpDirMixin, unittest.TestCase):
       ),
       (
         {
-          "paths": [Path("baz").absolute()],
+          "paths": [str(Path("baz").absolute())],
           "lstrip_paths": [
               # NOTE: normalize lstrip path to match normalized artifact path
               # (see in-toto/in-toto#565)

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -35,19 +35,29 @@ from in_toto.models.metadata import Envelope, Metablock
 from in_toto.models.link import Link
 from in_toto.exceptions import SignatureVerificationError
 from in_toto.runlib import (in_toto_run, in_toto_record_start,
-    in_toto_record_stop, record_artifacts_as_dict, _apply_exclude_patterns,
-    _hash_artifact, _subprocess_run_duplicate_streams, in_toto_match_products)
+    in_toto_record_stop, record_artifacts_as_dict,
+    _subprocess_run_duplicate_streams, in_toto_match_products)
 from securesystemslib.interface import (
     generate_and_write_unencrypted_rsa_keypair,
     import_rsa_privatekey_from_file,
     import_rsa_publickey_from_file)
 from in_toto.models.link import UNFINISHED_FILENAME_FORMAT, FILENAME_FORMAT
 
+from in_toto.resolver import FileResolver
+
 import securesystemslib.formats
 import securesystemslib.exceptions
 
 from tests.common import TmpDirMixin
 from pathlib import Path
+
+def _apply_exclude_patterns(names, patterns):
+  """Temporary bridge from old `runlib._apply_exclude_patterns` with new
+ `FileResolver._exclude`.
+
+  TODO: Replace tist once resolver interface evolves
+  """
+  return [n for n in names if not FileResolver(exclude_patterns=patterns)._exclude(n)]
 
 
 class Test_ApplyExcludePatterns(unittest.TestCase):
@@ -494,10 +504,6 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
       in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = setting
       with self.assertRaises(securesystemslib.exceptions.FormatError):
         record_artifacts_as_dict(["."])
-
-  def test_hash_artifact_passing_algorithm(self):
-    """Test _hash_artifact passing hash algorithm. """
-    self.assertTrue("sha256" in list(_hash_artifact("foo", ["sha256"])))
 
 
 class TestLinkCmdExecTimeoutSetting(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,11 @@ commands =
 commands =
     # Run pylint, using the Secure System Lab's pylintrc as base config
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
-    pylint in_toto
+    pylint in_toto --ignore resolver
+
+    # TODO: Consolidate indentation with #580
+    pylint in_toto/resolver --indent-string="    "
+
     # Run pylint on tests with required exemptions to allow protected member
     # access (W0212) and test methods that don't use self (R0201). Also be less
     # strict about naming (C0103, C0202), docs (C0111) and line length (C0301).

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,7 @@ commands =
 commands =
     # Run pylint, using the Secure System Lab's pylintrc as base config
     # https://github.com/secure-systems-lab/sample-documents/blob/master/pylintrc
-    pylint in_toto --ignore resolver
-
-    # TODO: Consolidate indentation with #580
-    pylint in_toto/resolver --indent-string="    "
-
+    pylint in_toto
     # Run pylint on tests with required exemptions to allow protected member
     # access (W0212) and test methods that don't use self (R0201). Also be less
     # strict about naming (C0103, C0202), docs (C0111) and line length (C0301).


### PR DESCRIPTION
EDIT 2023/5/5 checked off todo
- added tests in this branch
- issues documented (see #586, #587)
- design seems to work (see #585)

----

In preparation for generic artifact URI support ([ITE-4](https://github.com/in-toto/ITE/blob/master/ITE/4/README.adoc)) this PR adds:
- a `Resolver` interface, which defines a `hash_artifacts` method and can be used to register and load arbitrary resolvers based on URI schemes, and
- a concrete `FileResolver`, which is a modern and simplified version of the previous implementation in runlib.

The new interface is used in runlib in a fully backwards-compatible manner.

See the first two commits for how a resolver can be used independently and the last commit for how to register and dispatch to them via the resolver interface. Details in the commit messages.

---

~TODO:~
- [x] Add Tests -- most of FileResolver is tested in existing tests, but not new features, i.e.:
   - the "file" scheme,
   - registering new resolvers and dispatching based on scheme.
- [x] Document existing file resolver issues -- while refactoring record_artifacts_as_dict I discovered some odd behavior, which I'll document separately.
- [x] Finalize design -- I'm quite happy with the architecture. It looks generic enough to work for ITE-4 without requiring `**kwargs`. Still, I suggest to consider this experimental until we see how it works with other resolvers.

This PR supersedes https://github.com/in-toto/in-toto/pull/578. Thanks for the solid groundwork, @alanssitis and @adityasaky!
