### PR TITLE
fix: key size argument silently ignored in in-toto-keygen

### DIFF
--- a/in_toto/in_toto_keygen.py
+++ b/in_toto/in_toto_keygen.py
@@ -125,6 +125,12 @@ def main():
   parser = create_parser()
   args = parser.parse_args()
 
+  if args.type != KEY_TYPE_RSA:
+    if args.bits is not None:
+      parser.print_help()
+      parser.error("wrong arguments: bits specified,"
+        " only Type RSA supports Bits as a parameter")
+
   try:
     if args.type == KEY_TYPE_RSA:
       interface._generate_and_write_rsa_keypair( # pylint: disable=protected-access


### PR DESCRIPTION
**Fixes issue #568**

**Description of the changes being introduced by the pull request**:
If the type is not RSA, then returning error if bits are specified, since they're not used.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)

