### PR TITLE
resolver: change exceptions from file resolver

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -130,12 +130,8 @@ def record_artifacts_as_dict(artifacts, exclude_patterns=None,
             the path of every artifact that contains the prefix.
 
   <Exceptions>
-    in_toto.exceptions.ValueError,
-        if we cannot change to base path directory
-
-    in_toto.exceptions.FormatError,
-        if the list of exlcude patterns does not match format
-        securesystemslib.formats.NAMES_SCHEMA
+    OSError: cannot change to base path directory.
+    ValueError: arguments are malformed.
 
   <Side Effects>
     Calls functions to generate cryptographic hashes.
@@ -439,7 +435,7 @@ def in_toto_run(name, material_list, product_list, link_cmd_args,
   Raises:
     securesystemslib.exceptions.FormatError: Passed arguments are malformed.
 
-    ValueError: Cannot change to base path directory.
+    OSError: Cannot change to base path directory.
 
     securesystemslib.exceptions.StorageError: Cannot hash artifacts.
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -157,11 +157,11 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
     """Raise exception with bogus base path settings. """
     for base_path in ["path/does/not/exist", 12345, True]:
       in_toto.settings.ARTIFACT_BASE_PATH = base_path
-      with self.assertRaises(ValueError):
+      with self.assertRaises((OSError, ValueError)):
         record_artifacts_as_dict(["."])
       in_toto.settings.ARTIFACT_BASE_PATH = None
 
-      with self.assertRaises(ValueError):
+      with self.assertRaises((OSError, ValueError)):
         record_artifacts_as_dict(["."], base_path=base_path)
 
 
@@ -502,7 +502,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
     """Raise exception with bogus artifact exclude patterns settings. """
     for setting in ["not a list of settings", 12345, True]:
       in_toto.settings.ARTIFACT_EXCLUDE_PATTERNS = setting
-      with self.assertRaises(securesystemslib.exceptions.FormatError):
+      with self.assertRaises(ValueError):
         record_artifacts_as_dict(["."])
 
 


### PR DESCRIPTION
resolver: change exceptions from file resolver

* Now raises ValueError instead of custom FormatError for invalid args.
  This does not affect calling API (`runlib.in_toto_{run, record}`),
  which still raises FormatError.

* No longer re-raises any error from `os.chdir` as ValueError.  Instead,
  only raises ValueError in FileResolver constructor, if base_path
  argument is malformed, and passes on any other error that happens in
  `os.chdir` (base class should be OSError).
  This is strictly speaking an API break, but seems negligible.

The reason for this change is to make the new resolver API more idiomatic
(use error types according to their purpose), and succinct (remove
unnecessary try/except block).

NOTE: This change does not fix incomplete exception documentation.


closes #587