### PR TITLE
runlib: retry file removal to workaround #547

### DIFF
--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -267,8 +267,13 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
 
     finally:
         # The work is done or was interrupted, the temp files can be removed
-        os.remove(stdout_name)
-        os.remove(stderr_name)
+        # FIXME: retry failed file removal once to maybe work around #547
+        for name in (stdout_name, stderr_name):
+            try:
+                os.remove(name)
+            except PermissionError:  # pragma: no cover
+                time.sleep(0.01)
+                os.remove(name)
 
     # Return process exit code and captured streams
     return proc.poll(), _std["out"], _std["err"]


### PR DESCRIPTION
As documented in #547 Windows regularly fails to remove a temporary file used in a subprocess, and so has every attempt to debug the issue.

Since this issue occurs at least once on almost every CI run, I propose this hacky workaround.

I don't like it, but if it makes our CI not fail all the time, I can live with it.

Alternatively, I suggest to disable the feature on Windows.

