### PR TITLE
Create CLI arg for assigning timeout value

### DIFF
--- a/doc/source/settings.rst
+++ b/doc/source/settings.rst
@@ -7,4 +7,4 @@ globals directly in source code or at runtime. This method is discouraged. Inste
 CLI/API arguments should be used.
 
 .. note::
-  The globals ``DEBUG`` and ``LINK_CMD_EXEC_TIMEOUT`` can only be configured directly.
+  The global ``DEBUG`` can only be configured directly.

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -36,6 +36,7 @@ from in_toto import (
     KEY_TYPE_RSA,
     SUPPORTED_KEY_TYPES,
 )
+from in_toto.settings import LINK_CMD_EXEC_TIMEOUT
 
 EXCLUDE_ARGS = ["--exclude"]
 EXCLUDE_KWARGS = {
@@ -193,6 +194,19 @@ DSSE_KWARGS = {
     "default": False,
     "action": "store_true",
     "help": ("generate metadata using dsse (experimental)."),
+}
+
+RUN_TIMEOUT_ARGS = ["--run-timeout"]
+RUN_TIMEOUT_KWARGS = {
+    "dest": "run_timeout",
+    "default": LINK_CMD_EXEC_TIMEOUT,
+    "help": (
+        "integer that represents the max timeout in seconds for the "
+        "   in-toto-run command."
+        "   Default is '{timeout}' seconds.".format(
+            timeout=LINK_CMD_EXEC_TIMEOUT
+        )
+    ),
 }
 
 

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -57,6 +57,8 @@ from in_toto.common_args import (
     OPTS_TITLE,
     QUIET_ARGS,
     QUIET_KWARGS,
+    RUN_TIMEOUT_ARGS,
+    RUN_TIMEOUT_KWARGS,
     VERBOSE_ARGS,
     VERBOSE_KWARGS,
     parse_password_and_prompt_args,
@@ -216,6 +218,7 @@ e.g. 'document.pdf'.
     parser.add_argument(*LSTRIP_PATHS_ARGS, **LSTRIP_PATHS_KWARGS)
     parser.add_argument(*METADATA_DIRECTORY_ARGS, **METADATA_DIRECTORY_KWARGS)
     parser.add_argument(*DSSE_ARGS, **DSSE_KWARGS)
+    parser.add_argument(*RUN_TIMEOUT_ARGS, **RUN_TIMEOUT_KWARGS)
 
     verbosity_args = parser.add_mutually_exclusive_group(required=False)
     verbosity_args.add_argument(*VERBOSE_ARGS, **VERBOSE_KWARGS)
@@ -307,6 +310,7 @@ def main():
             lstrip_paths=args.lstrip_paths,
             metadata_directory=args.metadata_directory,
             use_dsse=args.use_dsse,
+            timeout=args.run_timeout,
         )
 
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -279,7 +279,7 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
     return proc.poll(), streams["out"], streams["err"]
 
 
-def execute_link(link_cmd_args, record_streams):
+def execute_link(link_cmd_args, record_streams, timeout):
     """
     <Purpose>
       Executes the passed command plus arguments in a subprocess and returns
@@ -301,8 +301,7 @@ def execute_link(link_cmd_args, record_streams):
               The given command is not present or non-executable
 
       subprocess.TimeoutExpired:
-              The execution of the given command times (see
-              in_toto.settings.LINK_CMD_EXEC_TIMEOUT).
+              The execution of the given command times.
 
     <Side Effects>
       Executes passed command in a subprocess and redirects stdout and stderr
@@ -316,14 +315,14 @@ def execute_link(link_cmd_args, record_streams):
     """
     if record_streams:
         return_code, stdout_str, stderr_str = _subprocess_run_duplicate_streams(
-            link_cmd_args, timeout=float(in_toto.settings.LINK_CMD_EXEC_TIMEOUT)
+            link_cmd_args, timeout=timeout
         )
 
     else:
         process = subprocess.run(
             link_cmd_args,
             check=False,  # nosec
-            timeout=float(in_toto.settings.LINK_CMD_EXEC_TIMEOUT),
+            timeout=timeout,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -411,6 +410,7 @@ def in_toto_run(
     lstrip_paths=None,
     metadata_directory=None,
     use_dsse=False,
+    timeout=in_toto.settings.LINK_CMD_EXEC_TIMEOUT,
 ):
     """Performs a supply chain step or inspection generating link metadata.
 
@@ -474,6 +474,9 @@ def in_toto_run(
 
     use_dsse (optional): A boolean indicating if DSSE should be used to
         generate metadata.
+
+    timeout (optional): An integer indicating the max timeout in seconds 
+        for this command. Default is 10 seconds.
 
   Raises:
     securesystemslib.exceptions.FormatError: Passed arguments are malformed.
@@ -543,7 +546,7 @@ def in_toto_run(
             link_cmd_args
         )
         LOG.info("Running command '%s'...", " ".join(link_cmd_args))
-        byproducts = execute_link(link_cmd_args, record_streams)
+        byproducts = execute_link(link_cmd_args, record_streams, timeout)
     else:
         byproducts = {}
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -622,32 +622,25 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
                 record_artifacts_as_dict(["."])
 
 
-class TestLinkCmdExecTimeoutSetting(unittest.TestCase):
-    """Tests LINK_CMD_EXEC_TIMEOUT setting in settings.py file."""
+class TestLinkCmdExecTimeout(unittest.TestCase):
+    """Tests execute_link timing out correctly."""
 
-    def test_timeout_setting(self):
-        # Save the old timeout and make sure it's saved properly
-        timeout_old = in_toto.settings.LINK_CMD_EXEC_TIMEOUT
-
-        # Modify timeout
-        in_toto.settings.LINK_CMD_EXEC_TIMEOUT = 0.1
+    def test_timeout(self):
+        timeout = 1
 
         # check if exception is raised
         with self.assertRaises(subprocess.TimeoutExpired):
             # Call execute_link to see if new timeout is respected
             in_toto.runlib.execute_link(
-                [sys.executable, "-c", "while True: pass"], True
+                [sys.executable, "-c", "while True: pass"], True, timeout
             )
 
         # check if exception is raised
         with self.assertRaises(subprocess.TimeoutExpired):
             # Call execute_link to see if new timeout is respected
             in_toto.runlib.execute_link(
-                [sys.executable, "-c", "while True: pass"], False
+                [sys.executable, "-c", "while True: pass"], False, timeout
             )
-
-        # Restore original timeout
-        in_toto.settings.LINK_CMD_EXEC_TIMEOUT = timeout_old
 
 
 class TestSubprocess(unittest.TestCase):


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:
https://github.com/in-toto/in-toto/issues/603

**Description of the changes being introduced by the pull request**:
    - Add `--run-timeout` CLI option to `in-toto-run` that enables user to
    specify a timeout in seconds for subprocess executions.
    - Modify function signature of `execute_link` to include `timeout` and
    function contents which uses that value in order to replace the previous
    behavior of only using the `LINK_CMD_EXEC_TIMEOUT` setting.


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
