### PR TITLE
Fix type for --run-timeout

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -198,6 +198,7 @@ DSSE_KWARGS = {
 
 RUN_TIMEOUT_ARGS = ["--run-timeout"]
 RUN_TIMEOUT_KWARGS = {
+    "type": int,
     "dest": "run_timeout",
     "default": LINK_CMD_EXEC_TIMEOUT,
     "help": (


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: https://github.com/in-toto/in-toto/issues/624#issuecomment-1713248159

**Description of the changes being introduced by the pull request**:

Sets the type of `--run-timeout` to int in the CLI. I poked a little at testing this but the way we're mocking CLI invocations seems to make this difficult?

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


