### PR TITLE
Support layout and link metadata pretty print

### DIFF
--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -62,3 +62,50 @@ class Signable(ValidationMixin):
         return securesystemslib.formats.encode_canonical(
             attr.asdict(self)
         ).encode("UTF-8")
+
+
+class BeautifyMixin:
+    """The beautify mixin provides a method to represent in-toto's metadata 
+    object into a friendly and readable form as a string."""
+
+    def _beautify(self, data, level=0, width=4):
+        """Helper function for beautify method. This function recursively 
+        unpacks data in given dictionary object into a string.
+
+        Arguments:
+          data: dictionary object containing metadata key-value pairs. Keys 
+              are metadata field names and values are the metadata values.
+          level: integer representing level of nesting that determines 
+              indentation.
+          width: integer representing the size of single indentation.
+
+        Returns:
+          A string that presents in-toto metadata in a readable form.
+        """
+        indent = ' ' * (level * width)
+        s = []
+        for key, val in data.items():
+            if not val:
+                continue
+
+            s.append(f'{indent}{key}: ')
+
+            if isinstance(val, str) or isinstance(val, int):
+                s.append(f'{val}\n')
+
+            elif isinstance(val, list):
+                s.append('\n')
+                next_indent = indent + (' ' * width)
+                for item in val:
+                    s.append(f'{next_indent}{item}\n')
+            
+            elif isinstance(val, dict):
+                s.append(f'\n{self._beautify(val, level=level+1)}')
+            
+        return ''.join(s)
+
+    def beautify(self):
+        """Translates in-toto metadata object into audit-friendly string 
+        representation."""
+        data = self.get_beautify_dict()
+        return self._beautify(data).strip()

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -104,8 +104,31 @@ class BeautifyMixin:
             
         return ''.join(s)
 
-    def beautify(self):
+    def beautify(self, order=[]):
         """Translates in-toto metadata object into audit-friendly string 
-        representation."""
-        data = self.get_beautify_dict()
+        representation.
+        
+        Arguments:
+          order: list of string specifying fields to be included and the 
+              order in which they are to be arranged.
+
+        Returns:
+          A string that presents in-toto metadata in a readable form.
+        """
+        data = self.get_beautify_dict(order)
         return self._beautify(data).strip()
+
+
+class MetadataFields:
+    """Common in-toto metadata fields"""
+    TYPE = 'Type'
+    EXPIRATION = 'Expiration'
+    KEYS = 'Keys'
+    STEPS = 'Steps'
+    INSPECTIONS = 'Inspections'
+    EXPECTED_COMMAND = 'Expected Command'
+    EXPECTED_MATERIALS = 'Expected Materials'
+    EXPECTED_PRODUCTS = 'Expected Products'
+    PUBKEYS = 'Pubkeys'
+    THRESHOLD = 'Threshold'
+    RUN = 'Run'

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -65,17 +65,17 @@ class Signable(ValidationMixin):
 
 
 class BeautifyMixin:
-    """The beautify mixin provides a method to represent in-toto's metadata 
+    """The beautify mixin provides a method to represent in-toto's metadata
     object into a friendly and readable form as a string."""
 
     def _beautify(self, data, level=0, width=4):
-        """Helper function for beautify method. This function recursively 
+        """Helper function for beautify method. This function recursively
         unpacks data in given dictionary object into a string.
 
         Arguments:
-          data: dictionary object containing metadata key-value pairs. Keys 
+          data: dictionary object containing metadata key-value pairs. Keys
               are metadata field names and values are the metadata values.
-          level: integer representing level of nesting that determines 
+          level: integer representing level of nesting that determines
               indentation.
           width: integer representing the size of single indentation.
 
@@ -87,29 +87,29 @@ class BeautifyMixin:
 
         if isinstance(data, (str, int)):
             return str(data)
-        
+
         if isinstance(data, list):
             s.append("\n")
             for item in data:
                 s.append(f"{indent}{self._beautify(item, level)}\n")
-        
-        elif isinstance(data, dict):    # Includes OrderedDict - dict is superset
+
+        elif isinstance(data, dict):  # Includes OrderedDict - dict is superset
             s.append("\n")
             for key, val in data.items():
                 if not val:
                     continue
-                
+
                 s.append(f"{indent}{key}: ")
                 s.append(f"{self._beautify(val, level=level+1)}\n")
 
         return "".join(s).rstrip()
 
     def beautify(self, order=None):
-        """Translates in-toto metadata object into audit-friendly string 
+        """Translates in-toto metadata object into audit-friendly string
         representation.
-        
+
         Arguments:
-          order: list of string specifying fields to be included and the 
+          order: list of string specifying fields to be included and the
               order in which they are to be arranged.
 
         Returns:
@@ -121,6 +121,7 @@ class BeautifyMixin:
 
 class MetadataFields:
     """Common in-toto metadata fields"""
+
     TYPE = "Type"
     EXPIRATION = "Expiration"
     KEYS = "Keys"

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -84,25 +84,25 @@ class BeautifyMixin:
         """
         indent = ' ' * (level * width)
         s = []
-        for key, val in data.items():
-            if not val:
-                continue
 
-            s.append(f'{indent}{key}: ')
+        if isinstance(data, str) or isinstance(data, int):
+            return str(data)
+        
+        elif isinstance(data, list):
+            s.append('\n')
+            for item in data:
+                s.append(f'{indent}{self._beautify(item, level)}\n')
+        
+        elif isinstance(data, dict):    # Includes OrderedDict - dict is superset
+            s.append('\n')
+            for key, val in data.items():
+                if not val:
+                    continue
+                
+                s.append(f'{indent}{key}: ')
+                s.append(f'{self._beautify(val, level=level+1)}\n')
 
-            if isinstance(val, str) or isinstance(val, int):
-                s.append(f'{val}\n')
-
-            elif isinstance(val, list):
-                s.append('\n')
-                next_indent = indent + (' ' * width)
-                for item in val:
-                    s.append(f'{next_indent}{item}\n')
-            
-            elif isinstance(val, dict):
-                s.append(f'\n{self._beautify(val, level=level+1)}')
-            
-        return ''.join(s)
+        return ''.join(s).rstrip()
 
     def beautify(self, order=[]):
         """Translates in-toto metadata object into audit-friendly string 

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -86,9 +86,9 @@ class BeautifyMixin:
         s = []
 
         if isinstance(data, (str, int)):
-            return str(data)
+            s.append(str(data))
 
-        if isinstance(data, list):
+        elif isinstance(data, list):
             s.append("\n")
             for item in data:
                 s.append(f"{indent}{self._beautify(item, level)}\n")
@@ -101,6 +101,9 @@ class BeautifyMixin:
 
                 s.append(f"{indent}{key}: ")
                 s.append(f"{self._beautify(val, level=level+1)}\n")
+
+        else:
+            raise ValueError("Unsupported data type to beautify")
 
         return "".join(s).rstrip()
 

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -82,29 +82,29 @@ class BeautifyMixin:
         Returns:
           A string that presents in-toto metadata in a readable form.
         """
-        indent = ' ' * (level * width)
+        indent = " " * (level * width)
         s = []
 
-        if isinstance(data, str) or isinstance(data, int):
+        if isinstance(data, (str, int)):
             return str(data)
         
-        elif isinstance(data, list):
-            s.append('\n')
+        if isinstance(data, list):
+            s.append("\n")
             for item in data:
-                s.append(f'{indent}{self._beautify(item, level)}\n')
+                s.append(f"{indent}{self._beautify(item, level)}\n")
         
         elif isinstance(data, dict):    # Includes OrderedDict - dict is superset
-            s.append('\n')
+            s.append("\n")
             for key, val in data.items():
                 if not val:
                     continue
                 
-                s.append(f'{indent}{key}: ')
-                s.append(f'{self._beautify(val, level=level+1)}\n')
+                s.append(f"{indent}{key}: ")
+                s.append(f"{self._beautify(val, level=level+1)}\n")
 
-        return ''.join(s).rstrip()
+        return "".join(s).rstrip()
 
-    def beautify(self, order=[]):
+    def beautify(self, order=None):
         """Translates in-toto metadata object into audit-friendly string 
         representation.
         
@@ -121,14 +121,14 @@ class BeautifyMixin:
 
 class MetadataFields:
     """Common in-toto metadata fields"""
-    TYPE = 'Type'
-    EXPIRATION = 'Expiration'
-    KEYS = 'Keys'
-    STEPS = 'Steps'
-    INSPECTIONS = 'Inspections'
-    EXPECTED_COMMAND = 'Expected Command'
-    EXPECTED_MATERIALS = 'Expected Materials'
-    EXPECTED_PRODUCTS = 'Expected Products'
-    PUBKEYS = 'Pubkeys'
-    THRESHOLD = 'Threshold'
-    RUN = 'Run'
+    TYPE = "Type"
+    EXPIRATION = "Expiration"
+    KEYS = "Keys"
+    STEPS = "Steps"
+    INSPECTIONS = "Inspections"
+    EXPECTED_COMMAND = "Expected Command"
+    EXPECTED_MATERIALS = "Expected Materials"
+    EXPECTED_PRODUCTS = "Expected Products"
+    PUBKEYS = "Pubkeys"
+    THRESHOLD = "Threshold"
+    RUN = "Run"

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -128,8 +128,12 @@ class BeautifyMixin:
         return self._beautify(data).strip()
 
 
-class MetadataFields:
-    """Common in-toto metadata fields"""
+class LayoutMetadataFields:
+    """Layout metadata fields
+
+    The defined string constants are used as field headings
+    in the beautified metadata string.
+    """
 
     TYPE = "Type"
     EXPIRATION = "Expiration"
@@ -145,7 +149,11 @@ class MetadataFields:
 
 
 class LinkMetadataFields:
-    """Link metadata fields"""
+    """Link metadata fields
+
+    The defined string constants are used as field headings
+    in the beautified metadata string.
+    """
 
     TYPE = "Type"
     NAME = "Name"

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -107,9 +107,14 @@ class BeautifyMixin:
 
         return "".join(s).rstrip()
 
-    def beautify(self, order=None):
+    def beautify(self, order=None, **kwargs):
         """Translates in-toto metadata object into audit-friendly string
         representation.
+
+        Keyword arguments are passed downstream to metadata's
+        get_beautify_dict() method. To learn more about available keyword
+        arguments, refer to the metdata's get_beautify_dict() method
+        docstring.
 
         Arguments:
           order: list of string specifying fields to be included and the
@@ -118,7 +123,7 @@ class BeautifyMixin:
         Returns:
           A string that presents in-toto metadata in a readable form.
         """
-        data = self.get_beautify_dict(order)
+        data = self.get_beautify_dict(order=order, **kwargs)
         return self._beautify(data).strip()
 
 

--- a/in_toto/models/common.py
+++ b/in_toto/models/common.py
@@ -96,7 +96,8 @@ class BeautifyMixin:
         elif isinstance(data, dict):  # Includes OrderedDict - dict is superset
             s.append("\n")
             for key, val in data.items():
-                if not val:
+                # 0 can be an intentionally set non-empty value
+                if not val and not isinstance(val, int):
                     continue
 
                 s.append(f"{indent}{key}: ")
@@ -141,3 +142,15 @@ class MetadataFields:
     PUBKEYS = "Pubkeys"
     THRESHOLD = "Threshold"
     RUN = "Run"
+
+
+class LinkMetadataFields:
+    """Link metadata fields"""
+
+    TYPE = "Type"
+    NAME = "Name"
+    MATERIALS = "Materials"
+    PRODUCTS = "Products"
+    BYPRODUCTS = "Byproducts"
+    COMMAND = "Command"
+    ENVIRONMENT = "Environment"

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -51,7 +51,8 @@ import in_toto.rulelib
 from in_toto.models.common import (
     Signable, 
     ValidationMixin,
-    BeautifyMixin
+    BeautifyMixin,
+    MetadataFields
 )
 
 # Link metadata for sublayouts are expected to be found in a subdirectory
@@ -492,16 +493,33 @@ class Layout(Signable, BeautifyMixin):
                 )
             names_seen.add(inspection.name)
 
-    def get_beautify_dict(self):
-        """Organize Layout's metadata attributes in key-value pairs 
+    def get_beautify_dict(self, order=[]):
+        """Organize Layout's metadata attributes as key-value pairs
+        
+        Arguments:
+          order: list of string specifying fields to be included and the 
+              order in which they are to be arranged.
+
+        Returns:
+          OrderedDict containing metadata field and value pairs arranged 
+          in the given order. If order is not defined, the full metadata 
+          fields are returned in the dafault order.
         """
-        return OrderedDict({
-            'Type': self._type,
-            'Expiration': self.expires,
-            'Keys': [keyid for keyid in self.keys],
-            'Steps': {step.name: step.get_beautify_dict() for step in self.steps},
-            'Inspections': {insp.name: insp.get_beautify_dict() for insp in self.inspect},
+        metadata = OrderedDict({
+            MetadataFields.TYPE: self._type,
+            MetadataFields.EXPIRATION: self.expires,
+            MetadataFields.KEYS: [keyid for keyid in self.keys],
+            MetadataFields.STEPS: {step.name: step.get_beautify_dict() for step in self.steps},
+            MetadataFields.INSPECTIONS: {insp.name: insp.get_beautify_dict() for insp in self.inspect},
         })
+
+        if not order:
+            return metadata
+        
+        ordered_metadata = OrderedDict()
+        for field in order:
+            ordered_metadata[field] = metadata[field]
+        return ordered_metadata
 
 
 @attr.s(repr=False, init=False)
@@ -689,14 +707,33 @@ class Step(SupplyChainItem):
                 "The expected command field is malformed!"
             )
 
-    def get_beautify_dict(self):
-        return OrderedDict({
-            'Expected Command': ' '.join(self.expected_command),
-            'Expected Materials': [' '.join(material) for material in self.expected_materials],
-            'Expected Products': [' '.join(product) for product in self.expected_products],
-            'Pubkeys': self.pubkeys,
-            'Threshold': self.threshold,
+    def get_beautify_dict(self, order=[]):
+        """Organize Step's metadata attributes as key-value pairs
+        
+        Arguments:
+          order: list of string specifying fields to be included and the 
+              order in which they are to be arranged.
+
+        Returns:
+          OrderedDict containing metadata field and value pairs arranged 
+          in the given order. If order is not defined, the full metadata 
+          fields are returned in the dafault order.
+        """
+        metadata = OrderedDict({
+            MetadataFields.EXPECTED_COMMAND: ' '.join(self.expected_command),
+            MetadataFields.EXPECTED_MATERIALS: [' '.join(material) for material in self.expected_materials],
+            MetadataFields.EXPECTED_PRODUCTS: [' '.join(product) for product in self.expected_products],
+            MetadataFields.PUBKEYS: self.pubkeys,
+            MetadataFields.THRESHOLD: self.threshold,
         })
+
+        if not order:
+            return metadata
+        
+        ordered_metadata = OrderedDict()
+        for field in order:
+            ordered_metadata[field] = metadata[field]
+        return ordered_metadata
 
 
 @attr.s(repr=False, init=False)
@@ -766,9 +803,28 @@ class Inspection(SupplyChainItem):
                 "The run field is malformed!"
             )
 
-    def get_beautify_dict(self):
-        return OrderedDict({
-            'Run': ' '.join(self.run),
-            'Expected Materials': [' '.join(material) for material in self.expected_materials],
-            'Expected Products': [' '.join(product) for product in self.expected_products],
+    def get_beautify_dict(self, order=[]):
+        """Organize Step's metadata attributes as key-value pairs
+        
+        Arguments:
+          order: list of string specifying fields to be included and the 
+              order in which they are to be arranged.
+
+        Returns:
+          OrderedDict containing metadata field and value pairs arranged 
+          in the given order. If order is not defined, the full metadata 
+          fields are returned in the dafault order.
+        """
+        metadata = OrderedDict({
+            MetadataFields.RUN: ' '.join(self.run),
+            MetadataFields.EXPECTED_MATERIALS: [' '.join(material) for material in self.expected_materials],
+            MetadataFields.EXPECTED_PRODUCTS: [' '.join(product) for product in self.expected_products],
         })
+
+        if not order:
+            return metadata
+        
+        ordered_metadata = OrderedDict()
+        for field in order:
+            ordered_metadata[field] = metadata[field]
+        return ordered_metadata

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -493,29 +493,43 @@ class Layout(Signable, BeautifyMixin):
                 )
             names_seen.add(inspection.name)
 
-    def get_beautify_dict(self, order=None):
+    def get_beautify_dict(self, order=None, **kwargs):
         """Organize Layout's metadata attributes as key-value pairs
 
         Arguments:
           order: list of string specifying fields to be included and the
               order in which they are to be arranged.
 
+        Keyword Arguments:
+          step_order: list of string specifying step metadata fields to be
+              included and the order in which they are to be arranged
+          inspection_order: list of string specifying inspection metadata
+              fields to be included and the order in which they are to be
+              arranged
+
         Returns:
           OrderedDict containing metadata field and value pairs arranged
           in the given order. If order is not defined, the full metadata
           fields are returned in the dafault order.
         """
+        step_order = kwargs.get("step_order")
+        inspection_order = kwargs.get("inspection_order")
         metadata = OrderedDict(
             {
                 MetadataFields.TYPE: self._type,
                 MetadataFields.EXPIRATION: self.expires,
                 MetadataFields.KEYS: list(self.keys),
                 MetadataFields.STEPS: OrderedDict(
-                    {step.name: step.get_beautify_dict() for step in self.steps}
+                    {
+                        step.name: step.get_beautify_dict(order=step_order)
+                        for step in self.steps
+                    }
                 ),
                 MetadataFields.INSPECTIONS: OrderedDict(
                     {
-                        insp.name: insp.get_beautify_dict()
+                        insp.name: insp.get_beautify_dict(
+                            order=inspection_order
+                        )
                         for insp in self.inspect
                     }
                 ),

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -527,6 +527,8 @@ class Layout(Signable, BeautifyMixin):
 
         ordered_metadata = OrderedDict()
         for field in order:
+            if field not in metadata:
+                continue
             ordered_metadata[field] = metadata[field]
         return ordered_metadata
 
@@ -749,6 +751,8 @@ class Step(SupplyChainItem):
 
         ordered_metadata = OrderedDict()
         for field in order:
+            if field not in metadata:
+                continue
             ordered_metadata[field] = metadata[field]
         return ordered_metadata
 
@@ -849,5 +853,7 @@ class Inspection(SupplyChainItem):
 
         ordered_metadata = OrderedDict()
         for field in order:
+            if field not in metadata:
+                continue
             ordered_metadata[field] = metadata[field]
         return ordered_metadata

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -49,10 +49,10 @@ from dateutil.relativedelta import relativedelta
 import in_toto.exceptions
 import in_toto.rulelib
 from in_toto.models.common import (
-    Signable,
-    ValidationMixin,
     BeautifyMixin,
     MetadataFields,
+    Signable,
+    ValidationMixin,
 )
 
 # Link metadata for sublayouts are expected to be found in a subdirectory

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -494,7 +494,7 @@ class Layout(Signable, BeautifyMixin):
             names_seen.add(inspection.name)
 
     def get_beautify_dict(self, order=None, **kwargs):
-        """Organize Layout's metadata attributes as key-value pairs
+        """Organize Layout metadata attributes as key-value pairs
 
         Arguments:
           order: list of string specifying fields to be included and the

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -509,8 +509,8 @@ class Layout(Signable, BeautifyMixin):
             MetadataFields.TYPE: self._type,
             MetadataFields.EXPIRATION: self.expires,
             MetadataFields.KEYS: [keyid for keyid in self.keys],
-            MetadataFields.STEPS: {step.name: step.get_beautify_dict() for step in self.steps},
-            MetadataFields.INSPECTIONS: {insp.name: insp.get_beautify_dict() for insp in self.inspect},
+            MetadataFields.STEPS: OrderedDict({step.name: step.get_beautify_dict() for step in self.steps}),
+            MetadataFields.INSPECTIONS: OrderedDict({insp.name: insp.get_beautify_dict() for insp in self.inspect}),
         })
 
         if not order:

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -50,7 +50,7 @@ import in_toto.exceptions
 import in_toto.rulelib
 from in_toto.models.common import (
     BeautifyMixin,
-    MetadataFields,
+    LayoutMetadataFields,
     Signable,
     ValidationMixin,
 )
@@ -516,16 +516,16 @@ class Layout(Signable, BeautifyMixin):
         inspection_order = kwargs.get("inspection_order")
         metadata = OrderedDict(
             {
-                MetadataFields.TYPE: self._type,
-                MetadataFields.EXPIRATION: self.expires,
-                MetadataFields.KEYS: list(self.keys),
-                MetadataFields.STEPS: OrderedDict(
+                LayoutMetadataFields.TYPE: self._type,
+                LayoutMetadataFields.EXPIRATION: self.expires,
+                LayoutMetadataFields.KEYS: list(self.keys),
+                LayoutMetadataFields.STEPS: OrderedDict(
                     {
                         step.name: step.get_beautify_dict(order=step_order)
                         for step in self.steps
                     }
                 ),
-                MetadataFields.INSPECTIONS: OrderedDict(
+                LayoutMetadataFields.INSPECTIONS: OrderedDict(
                     {
                         insp.name: insp.get_beautify_dict(
                             order=inspection_order
@@ -746,17 +746,17 @@ class Step(SupplyChainItem):
         """
         metadata = OrderedDict(
             {
-                MetadataFields.EXPECTED_COMMAND: " ".join(
+                LayoutMetadataFields.EXPECTED_COMMAND: " ".join(
                     self.expected_command
                 ),
-                MetadataFields.EXPECTED_MATERIALS: [
+                LayoutMetadataFields.EXPECTED_MATERIALS: [
                     " ".join(material) for material in self.expected_materials
                 ],
-                MetadataFields.EXPECTED_PRODUCTS: [
+                LayoutMetadataFields.EXPECTED_PRODUCTS: [
                     " ".join(product) for product in self.expected_products
                 ],
-                MetadataFields.PUBKEYS: self.pubkeys,
-                MetadataFields.THRESHOLD: self.threshold,
+                LayoutMetadataFields.PUBKEYS: self.pubkeys,
+                LayoutMetadataFields.THRESHOLD: self.threshold,
             }
         )
 
@@ -852,11 +852,11 @@ class Inspection(SupplyChainItem):
         """
         metadata = OrderedDict(
             {
-                MetadataFields.RUN: " ".join(self.run),
-                MetadataFields.EXPECTED_MATERIALS: [
+                LayoutMetadataFields.RUN: " ".join(self.run),
+                LayoutMetadataFields.EXPECTED_MATERIALS: [
                     " ".join(material) for material in self.expected_materials
                 ],
-                MetadataFields.EXPECTED_PRODUCTS: [
+                LayoutMetadataFields.EXPECTED_PRODUCTS: [
                     " ".join(product) for product in self.expected_products
                 ],
             }

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -493,7 +493,7 @@ class Layout(Signable, BeautifyMixin):
                 )
             names_seen.add(inspection.name)
 
-    def get_beautify_dict(self, order=[]):
+    def get_beautify_dict(self, order=None):
         """Organize Layout's metadata attributes as key-value pairs
         
         Arguments:
@@ -508,7 +508,7 @@ class Layout(Signable, BeautifyMixin):
         metadata = OrderedDict({
             MetadataFields.TYPE: self._type,
             MetadataFields.EXPIRATION: self.expires,
-            MetadataFields.KEYS: [keyid for keyid in self.keys],
+            MetadataFields.KEYS: list(self.keys),
             MetadataFields.STEPS: OrderedDict({step.name: step.get_beautify_dict() for step in self.steps}),
             MetadataFields.INSPECTIONS: OrderedDict({insp.name: insp.get_beautify_dict() for insp in self.inspect}),
         })
@@ -707,7 +707,7 @@ class Step(SupplyChainItem):
                 "The expected command field is malformed!"
             )
 
-    def get_beautify_dict(self, order=[]):
+    def get_beautify_dict(self, order=None):
         """Organize Step's metadata attributes as key-value pairs
         
         Arguments:
@@ -720,9 +720,9 @@ class Step(SupplyChainItem):
           fields are returned in the dafault order.
         """
         metadata = OrderedDict({
-            MetadataFields.EXPECTED_COMMAND: ' '.join(self.expected_command),
-            MetadataFields.EXPECTED_MATERIALS: [' '.join(material) for material in self.expected_materials],
-            MetadataFields.EXPECTED_PRODUCTS: [' '.join(product) for product in self.expected_products],
+            MetadataFields.EXPECTED_COMMAND: " ".join(self.expected_command),
+            MetadataFields.EXPECTED_MATERIALS: [" ".join(material) for material in self.expected_materials],
+            MetadataFields.EXPECTED_PRODUCTS: [" ".join(product) for product in self.expected_products],
             MetadataFields.PUBKEYS: self.pubkeys,
             MetadataFields.THRESHOLD: self.threshold,
         })
@@ -803,7 +803,7 @@ class Inspection(SupplyChainItem):
                 "The run field is malformed!"
             )
 
-    def get_beautify_dict(self, order=[]):
+    def get_beautify_dict(self, order=None):
         """Organize Step's metadata attributes as key-value pairs
         
         Arguments:
@@ -816,9 +816,9 @@ class Inspection(SupplyChainItem):
           fields are returned in the dafault order.
         """
         metadata = OrderedDict({
-            MetadataFields.RUN: ' '.join(self.run),
-            MetadataFields.EXPECTED_MATERIALS: [' '.join(material) for material in self.expected_materials],
-            MetadataFields.EXPECTED_PRODUCTS: [' '.join(product) for product in self.expected_products],
+            MetadataFields.RUN: " ".join(self.run),
+            MetadataFields.EXPECTED_MATERIALS: [" ".join(material) for material in self.expected_materials],
+            MetadataFields.EXPECTED_PRODUCTS: [" ".join(product) for product in self.expected_products],
         })
 
         if not order:

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -49,10 +49,10 @@ from dateutil.relativedelta import relativedelta
 import in_toto.exceptions
 import in_toto.rulelib
 from in_toto.models.common import (
-    Signable, 
+    Signable,
     ValidationMixin,
     BeautifyMixin,
-    MetadataFields
+    MetadataFields,
 )
 
 # Link metadata for sublayouts are expected to be found in a subdirectory
@@ -495,27 +495,36 @@ class Layout(Signable, BeautifyMixin):
 
     def get_beautify_dict(self, order=None):
         """Organize Layout's metadata attributes as key-value pairs
-        
+
         Arguments:
-          order: list of string specifying fields to be included and the 
+          order: list of string specifying fields to be included and the
               order in which they are to be arranged.
 
         Returns:
-          OrderedDict containing metadata field and value pairs arranged 
-          in the given order. If order is not defined, the full metadata 
+          OrderedDict containing metadata field and value pairs arranged
+          in the given order. If order is not defined, the full metadata
           fields are returned in the dafault order.
         """
-        metadata = OrderedDict({
-            MetadataFields.TYPE: self._type,
-            MetadataFields.EXPIRATION: self.expires,
-            MetadataFields.KEYS: list(self.keys),
-            MetadataFields.STEPS: OrderedDict({step.name: step.get_beautify_dict() for step in self.steps}),
-            MetadataFields.INSPECTIONS: OrderedDict({insp.name: insp.get_beautify_dict() for insp in self.inspect}),
-        })
+        metadata = OrderedDict(
+            {
+                MetadataFields.TYPE: self._type,
+                MetadataFields.EXPIRATION: self.expires,
+                MetadataFields.KEYS: list(self.keys),
+                MetadataFields.STEPS: OrderedDict(
+                    {step.name: step.get_beautify_dict() for step in self.steps}
+                ),
+                MetadataFields.INSPECTIONS: OrderedDict(
+                    {
+                        insp.name: insp.get_beautify_dict()
+                        for insp in self.inspect
+                    }
+                ),
+            }
+        )
 
         if not order:
             return metadata
-        
+
         ordered_metadata = OrderedDict()
         for field in order:
             ordered_metadata[field] = metadata[field]
@@ -709,27 +718,35 @@ class Step(SupplyChainItem):
 
     def get_beautify_dict(self, order=None):
         """Organize Step's metadata attributes as key-value pairs
-        
+
         Arguments:
-          order: list of string specifying fields to be included and the 
+          order: list of string specifying fields to be included and the
               order in which they are to be arranged.
 
         Returns:
-          OrderedDict containing metadata field and value pairs arranged 
-          in the given order. If order is not defined, the full metadata 
+          OrderedDict containing metadata field and value pairs arranged
+          in the given order. If order is not defined, the full metadata
           fields are returned in the dafault order.
         """
-        metadata = OrderedDict({
-            MetadataFields.EXPECTED_COMMAND: " ".join(self.expected_command),
-            MetadataFields.EXPECTED_MATERIALS: [" ".join(material) for material in self.expected_materials],
-            MetadataFields.EXPECTED_PRODUCTS: [" ".join(product) for product in self.expected_products],
-            MetadataFields.PUBKEYS: self.pubkeys,
-            MetadataFields.THRESHOLD: self.threshold,
-        })
+        metadata = OrderedDict(
+            {
+                MetadataFields.EXPECTED_COMMAND: " ".join(
+                    self.expected_command
+                ),
+                MetadataFields.EXPECTED_MATERIALS: [
+                    " ".join(material) for material in self.expected_materials
+                ],
+                MetadataFields.EXPECTED_PRODUCTS: [
+                    " ".join(product) for product in self.expected_products
+                ],
+                MetadataFields.PUBKEYS: self.pubkeys,
+                MetadataFields.THRESHOLD: self.threshold,
+            }
+        )
 
         if not order:
             return metadata
-        
+
         ordered_metadata = OrderedDict()
         for field in order:
             ordered_metadata[field] = metadata[field]
@@ -805,25 +822,31 @@ class Inspection(SupplyChainItem):
 
     def get_beautify_dict(self, order=None):
         """Organize Step's metadata attributes as key-value pairs
-        
+
         Arguments:
-          order: list of string specifying fields to be included and the 
+          order: list of string specifying fields to be included and the
               order in which they are to be arranged.
 
         Returns:
-          OrderedDict containing metadata field and value pairs arranged 
-          in the given order. If order is not defined, the full metadata 
+          OrderedDict containing metadata field and value pairs arranged
+          in the given order. If order is not defined, the full metadata
           fields are returned in the dafault order.
         """
-        metadata = OrderedDict({
-            MetadataFields.RUN: " ".join(self.run),
-            MetadataFields.EXPECTED_MATERIALS: [" ".join(material) for material in self.expected_materials],
-            MetadataFields.EXPECTED_PRODUCTS: [" ".join(product) for product in self.expected_products],
-        })
+        metadata = OrderedDict(
+            {
+                MetadataFields.RUN: " ".join(self.run),
+                MetadataFields.EXPECTED_MATERIALS: [
+                    " ".join(material) for material in self.expected_materials
+                ],
+                MetadataFields.EXPECTED_PRODUCTS: [
+                    " ".join(product) for product in self.expected_products
+                ],
+            }
+        )
 
         if not order:
             return metadata
-        
+
         ordered_metadata = OrderedDict()
         for field in order:
             ordered_metadata[field] = metadata[field]

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -27,11 +27,7 @@ from collections import OrderedDict
 import attr
 import securesystemslib.formats
 
-from in_toto.models.common import (
-    Signable,
-    LinkMetadataFields,
-    BeautifyMixin,
-)
+from in_toto.models.common import BeautifyMixin, LinkMetadataFields, Signable
 
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
 FILENAME_FORMAT_SHORT = "{step_name}.link"

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -26,10 +26,7 @@ import textwrap
 import unittest
 from collections import OrderedDict
 
-from in_toto.models.common import (
-    Signable,
-    BeautifyMixin,
-)
+from in_toto.models.common import BeautifyMixin, Signable
 
 
 class TestSignable(unittest.TestCase):

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -45,28 +45,31 @@ class TestBeautifyMixin(unittest.TestCase):
 
     class ExampleMetadata(BeautifyMixin):
         """Metadata class to mock real metadata instances for testing"""
+
         def get_beautify_dict(self, order=None):
             """Organize Layout's metadata attributes as key-value pairs"""
-            metadata = OrderedDict({
-                "field_string": "value",
-                "field_integer": 1,
-                "field_list_string": ["value1", "value2", "value3"],
-                "field_list_integer": [1, 2, 3],
-                "field_dict": {
+            metadata = OrderedDict(
+                {
                     "field_string": "value",
                     "field_integer": 1,
-                    "field_list": ["value"],
-                    "field_nested_dict": {
+                    "field_list_string": ["value1", "value2", "value3"],
+                    "field_list_integer": [1, 2, 3],
+                    "field_dict": {
                         "field_string": "value",
                         "field_integer": 1,
                         "field_list": ["value"],
-                    }
+                        "field_nested_dict": {
+                            "field_string": "value",
+                            "field_integer": 1,
+                            "field_list": ["value"],
+                        },
+                    },
                 }
-            })
+            )
 
             if not order:
                 return metadata
-            
+
             ordered_metadata = {}
             for field in order:
                 ordered_metadata[field] = metadata[field]

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -41,22 +41,25 @@ class TestSignable(unittest.TestCase):
 
 
 class TestBeautifyMixin(unittest.TestCase):
+    """Tests BeautifyMixin's beautify method"""
 
     class ExampleMetadata(BeautifyMixin):
-        def get_beautify_dict(self, order=[]):
+        """Metadata class to mock real metadata instances for testing"""
+        def get_beautify_dict(self, order=None):
+            """Organize Layout's metadata attributes as key-value pairs"""
             metadata = OrderedDict({
-                'field_string': 'value',
-                'field_integer': 1,
-                'field_list_string': ['value1', 'value2', 'value3'],
-                'field_list_integer': [1, 2, 3],
-                'field_dict': {
-                    'field_string': 'value',
-                    'field_integer': 1,
-                    'field_list': ['value'],
-                    'field_nested_dict': {
-                        'field_string': 'value',
-                        'field_integer': 1,
-                        'field_list': ['value'],
+                "field_string": "value",
+                "field_integer": 1,
+                "field_list_string": ["value1", "value2", "value3"],
+                "field_list_integer": [1, 2, 3],
+                "field_dict": {
+                    "field_string": "value",
+                    "field_integer": 1,
+                    "field_list": ["value"],
+                    "field_nested_dict": {
+                        "field_string": "value",
+                        "field_integer": 1,
+                        "field_list": ["value"],
                     }
                 }
             })
@@ -100,7 +103,7 @@ class TestBeautifyMixin(unittest.TestCase):
 
     def test_beautify_with_order(self):
         metadata = self.ExampleMetadata()
-        order = ['field_dict', 'field_integer', 'field_string']
+        order = ["field_dict", "field_integer", "field_string"]
         beautified_metadata = metadata.beautify(order)
         expected = textwrap.dedent(
             """

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -78,9 +78,19 @@ class TestBeautifyMixin(unittest.TestCase):
     class UnsupportedMetadata(BeautifyMixin):
         """Metadata class to test unsupported metadata data type"""
 
-        def get_beautify_dict(self):
+        def get_beautify_dict(self, order=None):
             """Organize Layout's metadata attributes as key-value pairs"""
-            return OrderedDict({"field_set": {"item1"}})
+            metadata = OrderedDict({"field_set": {"item1"}})
+
+            if not order:
+                return metadata
+
+            ordered_metadata = {}
+            for field in order:
+                if field not in metadata:
+                    continue
+                ordered_metadata[field] = metadata[field]
+            return ordered_metadata
 
     def test_beautify(self):
         metadata = self.ExampleMetadata()
@@ -114,7 +124,7 @@ class TestBeautifyMixin(unittest.TestCase):
     def test_beautify_with_order(self):
         metadata = self.ExampleMetadata()
         order = ["field_dict", "field_integer", "field_string"]
-        beautified_metadata = metadata.beautify(order)
+        beautified_metadata = metadata.beautify(order=order)
         expected = textwrap.dedent(
             """
             field_dict: 

--- a/tests/models/test_common.py
+++ b/tests/models/test_common.py
@@ -61,6 +61,7 @@ class TestBeautifyMixin(unittest.TestCase):
                             "field_list": ["value"],
                         },
                     },
+                    "field_none": None,
                 }
             )
 
@@ -69,8 +70,17 @@ class TestBeautifyMixin(unittest.TestCase):
 
             ordered_metadata = {}
             for field in order:
+                if field not in metadata:
+                    continue
                 ordered_metadata[field] = metadata[field]
             return ordered_metadata
+
+    class UnsupportedMetadata(BeautifyMixin):
+        """Metadata class to test unsupported metadata data type"""
+
+        def get_beautify_dict(self):
+            """Organize Layout's metadata attributes as key-value pairs"""
+            return OrderedDict({"field_set": {"item1"}})
 
     def test_beautify(self):
         metadata = self.ExampleMetadata()
@@ -122,6 +132,11 @@ class TestBeautifyMixin(unittest.TestCase):
             """
         ).strip()
         self.assertEqual(beautified_metadata, expected)
+
+    def test_beautify_unsupported_data_type(self):
+        metadata = self.UnsupportedMetadata()
+        with self.assertRaises(ValueError):
+            metadata.beautify()
 
 
 if __name__ == "__main__":

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -283,27 +283,38 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
             MetadataFields.EXPIRATION,
             MetadataFields.TYPE,
             MetadataFields.RUN,
+            MetadataFields.INSPECTIONS,
         ]
+        step_order = [
+            MetadataFields.THRESHOLD,
+            MetadataFields.EXPECTED_COMMAND,
+            MetadataFields.RUN,
+        ]
+        inspection_order = [MetadataFields.RUN, MetadataFields.PUBKEYS]
         expected = OrderedDict(
             {
                 "Steps": OrderedDict(
                     {
                         "step-1": OrderedDict(
                             {
-                                "Expected Command": "echo step-1",
-                                "Expected Materials": [],
-                                "Expected Products": [],
-                                "Pubkeys": [],
                                 "Threshold": 1,
+                                "Expected Command": "echo step-1",
                             }
                         )
                     }
                 ),
                 "Expiration": "2023-09-23T00:00:00Z",
                 "Type": "layout",
+                "Inspections": OrderedDict(
+                    {"inspection-1": OrderedDict({"Run": "echo inspection-1"})}
+                ),
             }
         )
-        metadata_dict = layout.get_beautify_dict(order=order)
+        metadata_dict = layout.get_beautify_dict(
+            order=order,
+            step_order=step_order,
+            inspection_order=inspection_order,
+        )
 
         # Verify order of the metadata fields
         self.assertEqual(list(metadata_dict.keys()), list(expected.keys()))
@@ -313,7 +324,7 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
             self.assertEqual(metadata_dict[field], expected[field])
 
         # Verify nested metadata objects
-        for field in [MetadataFields.STEPS]:
+        for field in [MetadataFields.STEPS, MetadataFields.INSPECTIONS]:
             for name, link_metadata in metadata_dict[field].items():
                 expected_link_metadata = expected[field][name]
                 self.assertEqual(

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -200,46 +200,46 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
         layout = Layout(
             steps=[
                 Step(
-                    name='step-1',
-                    expected_command=['echo', 'step-1'],
+                    name="step-1",
+                    expected_command=["echo", "step-1"],
                     threshold=1
                 )
             ],
             inspect=[
                 Inspection(
-                    name='inspection-1',
-                    run=['echo', 'inspection-1']
+                    name="inspection-1",
+                    run=["echo", "inspection-1"]
                 )
             ],
-            expires='2023-09-23T00:00:00Z'
+            expires="2023-09-23T00:00:00Z"
         )
         metadata_dict = layout.get_beautify_dict()
         expected = OrderedDict({
-            'Type': 'layout',
-            'Expiration': '2023-09-23T00:00:00Z',
-            'Keys': [],
-            'Steps': OrderedDict({
-                'step-1': OrderedDict({
-                    'Expected Command': 'echo step-1',
-                    'Expected Materials': [],
-                    'Expected Products': [],
-                    'Pubkeys': [],
-                    'Threshold': 1
+            "Type": "layout",
+            "Expiration": "2023-09-23T00:00:00Z",
+            "Keys": [],
+            "Steps": OrderedDict({
+                "step-1": OrderedDict({
+                    "Expected Command": "echo step-1",
+                    "Expected Materials": [],
+                    "Expected Products": [],
+                    "Pubkeys": [],
+                    "Threshold": 1
                 })
             }),
-            'Inspections': OrderedDict({
-                'inspection-1': OrderedDict({
-                    'Run': 'echo inspection-1',
-                    'Expected Materials': [],
-                    'Expected Products': [],
+            "Inspections": OrderedDict({
+                "inspection-1": OrderedDict({
+                    "Run": "echo inspection-1",
+                    "Expected Materials": [],
+                    "Expected Products": [],
                 })
             })
         })
 
-        for field in ['Type', 'Expiration', 'Keys']:
+        for field in ["Type", "Expiration", "Keys"]:
             self.assertEqual(metadata_dict[field], expected[field])
 
-        for field in ['Steps', 'Inspections']:
+        for field in ["Steps", "Inspections"]:
             for name, link_metadata in metadata_dict[field].items():
                 expected_link_metadata = expected[field][name]
                 self.assertEqual(

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -32,7 +32,7 @@ import securesystemslib.exceptions
 import in_toto.exceptions
 import in_toto.models.link
 import in_toto.verifylib
-from in_toto.models.common import MetadataFields
+from in_toto.models.common import LayoutMetadataFields
 from in_toto.models.layout import Inspection, Layout, Step
 from in_toto.models.metadata import Metablock
 from tests.common import GPGKeysMixin, TmpDirMixin
@@ -249,14 +249,17 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
 
         # Verify integer and string type metadata
         for field in [
-            MetadataFields.TYPE,
-            MetadataFields.EXPIRATION,
-            MetadataFields.KEYS,
+            LayoutMetadataFields.TYPE,
+            LayoutMetadataFields.EXPIRATION,
+            LayoutMetadataFields.KEYS,
         ]:
             self.assertEqual(metadata_dict[field], expected[field])
 
         # Verify nested metadata objects
-        for field in [MetadataFields.STEPS, MetadataFields.INSPECTIONS]:
+        for field in [
+            LayoutMetadataFields.STEPS,
+            LayoutMetadataFields.INSPECTIONS,
+        ]:
             for name, link_metadata in metadata_dict[field].items():
                 expected_link_metadata = expected[field][name]
                 self.assertEqual(
@@ -279,18 +282,21 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
             expires="2023-09-23T00:00:00Z",
         )
         order = [
-            MetadataFields.STEPS,
-            MetadataFields.EXPIRATION,
-            MetadataFields.TYPE,
-            MetadataFields.RUN,
-            MetadataFields.INSPECTIONS,
+            LayoutMetadataFields.STEPS,
+            LayoutMetadataFields.EXPIRATION,
+            LayoutMetadataFields.TYPE,
+            LayoutMetadataFields.RUN,
+            LayoutMetadataFields.INSPECTIONS,
         ]
         step_order = [
-            MetadataFields.THRESHOLD,
-            MetadataFields.EXPECTED_COMMAND,
-            MetadataFields.RUN,
+            LayoutMetadataFields.THRESHOLD,
+            LayoutMetadataFields.EXPECTED_COMMAND,
+            LayoutMetadataFields.RUN,
         ]
-        inspection_order = [MetadataFields.RUN, MetadataFields.PUBKEYS]
+        inspection_order = [
+            LayoutMetadataFields.RUN,
+            LayoutMetadataFields.PUBKEYS,
+        ]
         expected = OrderedDict(
             {
                 "Steps": OrderedDict(
@@ -320,11 +326,17 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
         self.assertEqual(list(metadata_dict.keys()), list(expected.keys()))
 
         # Verify integer and string type metadata
-        for field in [MetadataFields.TYPE, MetadataFields.EXPIRATION]:
+        for field in [
+            LayoutMetadataFields.TYPE,
+            LayoutMetadataFields.EXPIRATION,
+        ]:
             self.assertEqual(metadata_dict[field], expected[field])
 
         # Verify nested metadata objects
-        for field in [MetadataFields.STEPS, MetadataFields.INSPECTIONS]:
+        for field in [
+            LayoutMetadataFields.STEPS,
+            LayoutMetadataFields.INSPECTIONS,
+        ]:
             for name, link_metadata in metadata_dict[field].items():
                 expected_link_metadata = expected[field][name]
                 self.assertEqual(
@@ -333,7 +345,7 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
                 )
 
         # Verify unsupported fields are excluded
-        self.assertFalse(MetadataFields.RUN in metadata_dict)
+        self.assertFalse(LayoutMetadataFields.RUN in metadata_dict)
 
 
 class TestLayoutValidator(unittest.TestCase):

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -25,6 +25,7 @@
 import os
 import shutil
 import unittest
+from collections import OrderedDict
 
 import securesystemslib.exceptions
 
@@ -194,6 +195,57 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
             layout.add_functionary_keys_from_gpg_keyids(None)
         with self.assertRaises(securesystemslib.exceptions.FormatError):
             layout.add_functionary_keys_from_gpg_keyids(["abcdefg"])
+
+    def test_get_beautify_dict(self):
+        layout = Layout(
+            steps=[
+                Step(
+                    name='step-1',
+                    expected_command=['echo', 'step-1'],
+                    threshold=1
+                )
+            ],
+            inspect=[
+                Inspection(
+                    name='inspection-1',
+                    run=['echo', 'inspection-1']
+                )
+            ],
+            expires='2023-09-23T00:00:00Z'
+        )
+        metadata_dict = layout.get_beautify_dict()
+        expected = OrderedDict({
+            'Type': 'layout',
+            'Expiration': '2023-09-23T00:00:00Z',
+            'Keys': [],
+            'Steps': OrderedDict({
+                'step-1': OrderedDict({
+                    'Expected Command': 'echo step-1',
+                    'Expected Materials': [],
+                    'Expected Products': [],
+                    'Pubkeys': [],
+                    'Threshold': 1
+                })
+            }),
+            'Inspections': OrderedDict({
+                'inspection-1': OrderedDict({
+                    'Run': 'echo inspection-1',
+                    'Expected Materials': [],
+                    'Expected Products': [],
+                })
+            })
+        })
+
+        for field in ['Type', 'Expiration', 'Keys']:
+            self.assertEqual(metadata_dict[field], expected[field])
+
+        for field in ['Steps', 'Inspections']:
+            for name, link_metadata in metadata_dict[field].items():
+                expected_link_metadata = expected[field][name]
+                self.assertEqual(
+                    list(link_metadata.items()), 
+                    list(expected_link_metadata.items())
+                )
 
 
 class TestLayoutValidator(unittest.TestCase):

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -202,39 +202,46 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
                 Step(
                     name="step-1",
                     expected_command=["echo", "step-1"],
-                    threshold=1
+                    threshold=1,
                 )
             ],
             inspect=[
-                Inspection(
-                    name="inspection-1",
-                    run=["echo", "inspection-1"]
-                )
+                Inspection(name="inspection-1", run=["echo", "inspection-1"])
             ],
-            expires="2023-09-23T00:00:00Z"
+            expires="2023-09-23T00:00:00Z",
         )
         metadata_dict = layout.get_beautify_dict()
-        expected = OrderedDict({
-            "Type": "layout",
-            "Expiration": "2023-09-23T00:00:00Z",
-            "Keys": [],
-            "Steps": OrderedDict({
-                "step-1": OrderedDict({
-                    "Expected Command": "echo step-1",
-                    "Expected Materials": [],
-                    "Expected Products": [],
-                    "Pubkeys": [],
-                    "Threshold": 1
-                })
-            }),
-            "Inspections": OrderedDict({
-                "inspection-1": OrderedDict({
-                    "Run": "echo inspection-1",
-                    "Expected Materials": [],
-                    "Expected Products": [],
-                })
-            })
-        })
+        expected = OrderedDict(
+            {
+                "Type": "layout",
+                "Expiration": "2023-09-23T00:00:00Z",
+                "Keys": [],
+                "Steps": OrderedDict(
+                    {
+                        "step-1": OrderedDict(
+                            {
+                                "Expected Command": "echo step-1",
+                                "Expected Materials": [],
+                                "Expected Products": [],
+                                "Pubkeys": [],
+                                "Threshold": 1,
+                            }
+                        )
+                    }
+                ),
+                "Inspections": OrderedDict(
+                    {
+                        "inspection-1": OrderedDict(
+                            {
+                                "Run": "echo inspection-1",
+                                "Expected Materials": [],
+                                "Expected Products": [],
+                            }
+                        )
+                    }
+                ),
+            }
+        )
 
         for field in ["Type", "Expiration", "Keys"]:
             self.assertEqual(metadata_dict[field], expected[field])
@@ -243,8 +250,8 @@ class TestLayoutMethods(unittest.TestCase, TmpDirMixin, GPGKeysMixin):
             for name, link_metadata in metadata_dict[field].items():
                 expected_link_metadata = expected[field][name]
                 self.assertEqual(
-                    list(link_metadata.items()), 
-                    list(expected_link_metadata.items())
+                    list(link_metadata.items()),
+                    list(expected_link_metadata.items()),
                 )
 
 

--- a/tests/models/test_link.py
+++ b/tests/models/test_link.py
@@ -134,7 +134,8 @@ class TestLinkValidator(unittest.TestCase):
 
     def test_get_beautify_dict(self):
         with open(
-            os.path.join(self.demo_files, self.package_link_file)
+            os.path.join(self.demo_files, self.package_link_file),
+            encoding="utf8",
         ) as fptr:
             raw_json = json.load(fptr)
             link = Link().read(raw_json.get("signed"))
@@ -173,7 +174,8 @@ class TestLinkValidator(unittest.TestCase):
 
     def test_get_beautify_dict_with_order(self):
         with open(
-            os.path.join(self.demo_files, self.package_link_file)
+            os.path.join(self.demo_files, self.package_link_file),
+            encoding="utf8",
         ) as fptr:
             raw_json = json.load(fptr)
             link = Link().read(raw_json.get("signed"))


### PR DESCRIPTION
**Fixes issue #**:
Metadata Pretty Print #18 

**Description of the changes being introduced by the pull request**:
* Add `BeautifyMixin` that provides functionality to translate metadata object into a readable string.
    * The metadata class should implement `get_beautify_dict()` method to properly make use of `BeautifyMixin`'s `beautify()` method. `get_beautify_dict()` returns a dictionary that contains metadata's field names and their values. `beautify()` method formats this dictionary into a readable string.
* Support selecting and ordering of metadata's data fields when beautifying the metadata object.
* Add `LayoutMetadataFields` and `LinkMetadataFields` classes to define constant string literals for each metadata data field. This is used as headings for the fields when beautifying the metadata into readable string.

To quickly test metadata pretty printing, run the following code on project root directory as a script or in REPL
```py
import json
from in_toto.models.layout import Layout

with open("tests/demo_files/demo.layout.template") as fptr:
    raw = json.load(fptr)
    lo = Layout.read(raw["signed"])
    print(lo.beautify())

```
```py
import json
from in_toto.models.link import Link

with open("tests/demo_files/package.2f89b927.link") as fptr:
    raw = json.load(fptr)
    li = Link.read(raw["signed"])
    print(li.beautify())

```

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
