### PR TITLE
build: drop EOLed Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       # Run regular in-toto tests on each OS/Python combination, plus linters
       # on Linux/Python3.x only.
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
         include:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "in-toto"
 description = "A framework to define and secure the integrity of software supply chains"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 authors = [
     { name = "New York University: Secure Systems Lab", email = "in-toto-dev@googlegroups.com" },
 ]
@@ -26,7 +26,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 # To run an individual test environment run e.g. tox -e py38
 [tox]
 isolated_build = true
-envlist = lint,py{37,38,39,310,311}
+envlist = lint,py{38,39,310,311}
 skipsdist=True
 
 


### PR DESCRIPTION
Dependencies started to discontinue support:
- cffi (#633)
- coveralls (unnoticed, because not pinned)
- securesystemslib (v0.30.0 not yet PRed by dependabot)

Jumping through (conditional dependency) hoops to keep 3.7 alive here does not seem worth the effort.
