### PR TITLE
build: test against securesystemslib main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           - python-version: '3.x'
             os: ubuntu-latest
             toxenv: lint
+          - python-version: 3.x
+            os: ubuntu-latest
+            toxenv: with-sslib-main
 
     runs-on: ${{ matrix.os }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,17 @@ commands =
     coverage report -m --fail-under 99
 
 
+# Develop test env to run tests against securesystemslib's main branch
+# Must to be invoked explicitly with, e.g. `tox -e with-sslib-main`
+[testenv:with-sslib-main]
+commands_pre =
+    pip install --force-reinstall git+https://github.com/secure-systems-lab/securesystemslib.git@main#egg=securesystemslib[crypto,pynacl]
+
+commands =
+    coverage run tests/runtests.py
+    coverage report -m
+
+
 [testenv:lint]
 # NOTE: As opposed to above pyXY environments, which run in pythonX.Y, this
 # environment uses the `python` available on the path.


### PR DESCRIPTION
Add tox env to run tests against securesystemslib main branch and include in CI.

Fixes #560
