### PR TITLE
build: split test and lint dependencies and pin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,9 @@
 # in a test environment, so that we can run the test suite or individual tests
 # directly in the development environment as well.
 tox
--r requirements-tox.txt
+-r requirements-test.txt
+-r requirements-lint.txt
+-r requirements-docs.txt
 
 # Install in-toto in editable mode
 -e .

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -2,8 +2,7 @@
 -r requirements-pinned.txt
 
 # Test tools for linting and test coverage measurement
-pylint
-bandit
-coverage
-black
-isort
+pylint==2.17.4
+bandit==1.7.5
+black==23.9.1
+isort==5.12.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+# in-toto runtime dependencies
+-r requirements-pinned.txt
+
+# Test tools for coverage measurement
+coverage==7.3.2

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ skipsdist=True
 
 [testenv]
 deps =
-    -rrequirements-tox.txt
+    -rrequirements-test.txt
 
 commands =
     # Run unittests with coverage
@@ -34,6 +34,9 @@ commands =
 [testenv:lint]
 # NOTE: As opposed to above pyXY environments, which run in pythonX.Y, this
 # environment uses the `python` available on the path.
+deps =
+    -rrequirements-lint.txt
+
 commands =
     black --check --diff .
     isort --check --diff .


### PR DESCRIPTION
* Split requirements-tox into requirements-test and requirements-lint, and update tox.ini. There is no need to install lint requirements when running tests, and vice versa.

* Pin test dependencies to detect update issues with Dependabot.

* unrelated: include doc requirements with dev requirements 