### PR TITLE
Add argcomplete for autocompletion

### DIFF
--- a/in_toto/in_toto_match_products.py
+++ b/in_toto/in_toto_match_products.py
@@ -9,6 +9,8 @@ import argparse
 import logging
 import sys
 
+import argcomplete
+
 from in_toto.common_args import (
     LSTRIP_PATHS_ARGS,
     LSTRIP_PATHS_KWARGS,
@@ -69,6 +71,7 @@ def create_parser():
 def main():
     """CLI."""
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     metadata = Metadata.load(args.link)

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -29,6 +29,8 @@ import argparse
 import logging
 import sys
 
+import argcomplete
+
 import in_toto.runlib
 from in_toto import __version__
 from in_toto.common_args import (
@@ -124,6 +126,7 @@ Generate unsigned link metadata 'foo.link' for the activity of creating file
 def main():
     """Parse arguments and call in_toto_mock."""
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     # in-toto-mock should not be used to secure the supply chain but only to try

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -31,6 +31,7 @@ import logging
 import sys
 from getpass import getpass
 
+import argcomplete
 from securesystemslib import interface
 
 import in_toto.runlib
@@ -234,6 +235,7 @@ def main():
     on the specified subcommand."""
 
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -31,6 +31,7 @@ import logging
 import sys
 from getpass import getpass
 
+import argcomplete
 from securesystemslib import interface
 
 from in_toto import __version__, runlib
@@ -258,6 +259,7 @@ def main():
     """Parse arguments, load key from disk (prompts for password if key is
     encrypted) and call in_toto_run."""
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -27,6 +27,8 @@ import logging
 import sys
 from getpass import getpass
 
+import argcomplete
+from securesystemslib import interface
 from securesystemslib.gpg import functions as gpg_interface
 
 from in_toto import __version__, exceptions
@@ -366,6 +368,7 @@ def main():
     metadata file or verify its signatures."""
 
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -29,6 +29,7 @@ import argparse
 import logging
 import sys
 
+import argcomplete
 from securesystemslib import interface
 from securesystemslib.gpg import functions as gpg_interface
 
@@ -237,6 +238,7 @@ for which the public part can be found in the GPG keyring at '~/.gnupg'.
 def main():
     """Parse arguments and call in_toto_verify."""
     parser = create_parser()
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     LOG.setLevelVerboseOrQuiet(args.verbose, args.quiet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Topic :: Software Development",
 ]
 dependencies = [
+    "argcomplete",
     "attrs",
     "iso8601",
     "pathspec",

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements-pinned.txt requirements.txt
 #
+argcomplete==3.1.4
+    # via -r requirements.txt
 attrs==23.1.0
     # via -r requirements.txt
 cffi==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 # 'requirements-pinned.txt' is updated on GitHub with Dependabot, which
 # triggers CI/CD builds to automatically test against updated dependencies.
 securesystemslib[crypto,pynacl]>=0.28.0
+argcomplete
 attrs
 python-dateutil
 iso8601


### PR DESCRIPTION
**Fixes issue #**: #115

**Description of the changes being introduced by the pull request**:

For all CLIs in this repo, added autocompletion with the `argcomplete` package.

**Other Tasks:**

- [ ] Add `bash` autocompletion files to the repo
- [ ] Update Debian package to install autocompletion
- [ ] Make gh workflow check for updates in auto-completion scripts

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

