### PR TITLE
CI: Run lint on oldest supported Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
         include:
-          - python-version: '3.x'
+          - python-version: '3.8'
             os: ubuntu-latest
             toxenv: lint
           - python-version: 3.x


### PR DESCRIPTION
Do as python-tuf does:
https://github.com/theupdateframework/python-tuf/pull/2506



