### PR TITLE
Add --signing-key (pkcs8) arg to in-toto-record

### DIFF
--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -523,6 +523,59 @@ class TestInTotoRecordToolWithDSSE(
             0,
         )
 
+    def test_pkcs8_signing_key(self):
+        """Test in-toto-record, sign link with pkcs8 key file for each algo."""
+        pems_dir = Path(__file__).parent / "pems"
+        args = ["-n", "foo", "--use-dsse", "--signing-key"]
+        for algo, short_keyid in [
+            ("rsa", "2f685fa7"),
+            ("ecdsa", "50d7e110"),
+            ("ed25519", "c6d8bf2e"),
+        ]:
+            link_path = Path(f"foo.{short_keyid}.link")
+            unfinished_link_path = Path(f".foo.{short_keyid}.link-unfinished")
+
+            # Use unencrypted key
+            pem_path = pems_dir / f"{algo}_private_unencrypted.pem"
+            self.assert_cli_sys_exit(["start"] + args + [str(pem_path)], 0)
+            self.assertTrue(unfinished_link_path.exists())
+            self.assert_cli_sys_exit(["stop"] + args + [str(pem_path)], 0)
+            self.assertFalse(unfinished_link_path.exists())
+            self.assertTrue(link_path.exists())
+            link_path.unlink()
+
+            # Fail with encrypted key, but no pw
+            pem_path = pems_dir / f"{algo}_private_encrypted.pem"
+            self.assert_cli_sys_exit(["start"] + args + [str(pem_path)], 1)
+            self.assertFalse(unfinished_link_path.exists())
+
+            # Use encrypted key, passing pw
+            self.assert_cli_sys_exit(
+                ["start"] + args + [str(pem_path), "-P", "hunter2"], 0
+            )
+            self.assertTrue(unfinished_link_path.exists())
+            self.assert_cli_sys_exit(
+                ["stop"] + args + [str(pem_path), "-P", "hunter2"], 0
+            )
+            self.assertFalse(unfinished_link_path.exists())
+            self.assertTrue(link_path.exists())
+            link_path.unlink()
+
+            # Use encrypted key, mocking pw enter on prompt
+            with mock.patch(
+                "in_toto.in_toto_record.getpass", return_value="hunter2"
+            ):
+                self.assert_cli_sys_exit(
+                    ["start"] + args + [str(pem_path), "-P"], 0
+                )
+                self.assertTrue(unfinished_link_path.exists())
+                self.assert_cli_sys_exit(
+                    ["stop"] + args + [str(pem_path), "-P"], 0
+                )
+                self.assertFalse(unfinished_link_path.exists())
+                self.assertTrue(link_path.exists())
+                link_path.unlink()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -360,6 +360,59 @@ class TestInTotoRecordTool(
         ]
         self.assert_cli_sys_exit(["stop"] + args, 1)
 
+    def test_pkcs8(self):
+        """Test in-toto-record, sign link with pkcs8 key file for each algo."""
+        pems_dir = Path(__file__).parent / "pems"
+        args = ["-n", "foo", "--pkcs8"]
+        for algo, short_keyid in [
+            ("rsa", "2f685fa7"),
+            ("ecdsa", "50d7e110"),
+            ("ed25519", "c6d8bf2e"),
+        ]:
+            link_path = Path(f"foo.{short_keyid}.link")
+            unfinished_link_path = Path(f".foo.{short_keyid}.link-unfinished")
+
+            # Use unencrypted key
+            pem_path = pems_dir / f"{algo}_private_unencrypted.pem"
+            self.assert_cli_sys_exit(["start"] + args + [str(pem_path)], 0)
+            self.assertTrue(unfinished_link_path.exists())
+            self.assert_cli_sys_exit(["stop"] + args + [str(pem_path)], 0)
+            self.assertFalse(unfinished_link_path.exists())
+            self.assertTrue(link_path.exists())
+            link_path.unlink()
+
+            # Fail with encrypted key, but no pw
+            pem_path = pems_dir / f"{algo}_private_encrypted.pem"
+            self.assert_cli_sys_exit(["start"] + args + [str(pem_path)], 1)
+            self.assertFalse(unfinished_link_path.exists())
+
+            # Use encrypted key, passing pw
+            self.assert_cli_sys_exit(
+                ["start"] + args + [str(pem_path), "-P", "hunter2"], 0
+            )
+            self.assertTrue(unfinished_link_path.exists())
+            self.assert_cli_sys_exit(
+                ["stop"] + args + [str(pem_path), "-P", "hunter2"], 0
+            )
+            self.assertFalse(unfinished_link_path.exists())
+            self.assertTrue(link_path.exists())
+            link_path.unlink()
+
+            # Use encrypted key, mocking pw enter on prompt
+            with mock.patch(
+                "in_toto.in_toto_record.getpass", return_value="hunter2"
+            ):
+                self.assert_cli_sys_exit(
+                    ["start"] + args + [str(pem_path), "-P"], 0
+                )
+                self.assertTrue(unfinished_link_path.exists())
+                self.assert_cli_sys_exit(
+                    ["stop"] + args + [str(pem_path), "-P"], 0
+                )
+                self.assertFalse(unfinished_link_path.exists())
+                self.assertTrue(link_path.exists())
+                link_path.unlink()
+
 
 class TestInTotoRecordToolWithDSSE(
     CliTestCase, TmpDirMixin, GPGKeysMixin, GenKeysMixin

--- a/tests/test_in_toto_record.py
+++ b/tests/test_in_toto_record.py
@@ -360,10 +360,10 @@ class TestInTotoRecordTool(
         ]
         self.assert_cli_sys_exit(["stop"] + args, 1)
 
-    def test_pkcs8(self):
+    def test_pkcs8_signing_key(self):
         """Test in-toto-record, sign link with pkcs8 key file for each algo."""
         pems_dir = Path(__file__).parent / "pems"
-        args = ["-n", "foo", "--pkcs8"]
+        args = ["-n", "foo", "--signing-key"]
         for algo, short_keyid in [
             ("rsa", "2f685fa7"),
             ("ecdsa", "50d7e110"),


### PR DESCRIPTION
*EDIT 2023/12/05: rename --pkcs8 to --signing-key, and test with --use-dsse*

Change details in #649, which adds the same feature to in-toto-run.

Fixes #533 together with #649.