### PR TITLE
Add backwards-compatible SCHEMA replacement

### DIFF
--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -133,3 +133,13 @@ def _check_public_keys(arg):
     for k, v in arg.items():
         _check_hex(k)
         _check_public_key(v)
+
+
+def _check_signing_key(arg):
+    """Check legacy signing key dict format.
+
+    NOTE: signing key dict is deprecated, this check will be removed with it
+    """
+    _check_public_key(arg)
+    if not arg["keyval"].get("private"):
+        raise _err(arg, "private key data")

--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -16,22 +16,120 @@
   See LICENSE for licensing information.
 
 <Purpose>
-  Format schemas for in-toto metadata, based on securesystemslib.schema.
-
-  The schemas can be verified using the following methods inherited from
-  securesystemslib.schema:
-
-  in_toto.formats.<SCHEMA>.check_match(<object to verify>)
-  in_toto.formats.<SCHEMA>.matches(<object to verify>)
-
-  `check_match` raises a securesystemslib.exceptions.FormatError and `matches`
-  returns False if the verified object does not match the schema (True
-  otherwise).
+  Helpers to validate API inputs and metadata model objects.
 
 """
+from copy import deepcopy
+from re import fullmatch
+
 import securesystemslib.schema as ssl_schema
+from securesystemslib.exceptions import FormatError
+from securesystemslib.signer import Key, Signature
+
+from in_toto.models._signer import GPGKey, GPGSignature
 
 PARAMETER_DICTIONARY_KEY = ssl_schema.RegularExpression(r"[a-zA-Z0-9_-]+")
 PARAMETER_DICTIONARY_SCHEMA = ssl_schema.DictOf(
     key_schema=PARAMETER_DICTIONARY_KEY, value_schema=ssl_schema.AnyString()
 )
+
+
+def _err(arg, expected):
+    return FormatError(f"expected {expected}, got '{arg} ({type(arg)})'")
+
+
+def _check_int(arg):
+    if not isinstance(arg, int):
+        raise _err(arg, "int")
+
+
+def _check_str(arg):
+    if not isinstance(arg, str):
+        raise _err(arg, "str")
+
+
+def _check_hex(arg):
+    _check_str(arg)
+    if fullmatch(r"^[0-9a-fA-F]+$", arg) is None:
+        raise _err(arg, "hex string")
+
+
+def _check_list(arg):
+    if not isinstance(arg, list):
+        raise _err(arg, "list")
+
+
+def _check_dict(arg):
+    if not isinstance(arg, dict):
+        raise _err(arg, "dict")
+
+
+def _check_str_list(arg):
+    _check_list(arg)
+    for e in arg:
+        _check_str(e)
+
+
+def _check_hex_list(arg):
+    _check_list(arg)
+    for e in arg:
+        _check_hex(e)
+
+
+def _check_iso8601(arg):
+    """Check iso8601 date format."""
+    _check_str(arg)
+    if fullmatch(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", arg) is None:
+        raise _err(arg, "'YYYY-MM-DDTHH:MM:SSZ'")
+
+
+def _check_hash_dict(arg):
+    """Check artifact hash dict."""
+    _check_dict(arg)
+    for k, v in arg.items():
+        _check_str(k)
+        _check_hex(v)
+
+
+def _check_parameter_dict(arg):
+    """Check verifylib parameter dict."""
+    _check_dict(arg)
+    for k, v in arg.items():
+        _check_str(k)
+        if fullmatch(r"^[a-zA-Z0-9_-]+$", k) is None:
+            raise _err(arg, "'a-zA-Z0-9_-'")
+        _check_str(v)
+
+
+def _check_signature(arg):
+    """Check signature dict."""
+    _check_dict(arg)
+    # NOTE: `GPGSignature` and `Signature` serialization formats are incompatible
+    try:
+        GPGSignature.from_dict(arg)
+    except KeyError:
+        try:
+            Signature.from_dict(deepcopy(arg))
+        except KeyError as e:
+            raise _err(arg, "signature dict") from e
+
+
+def _check_public_key(arg):
+    """Check public key dict."""
+    _check_dict(arg)
+    # NOTE: `GPGKey` and `Key` serialization formats are incompatible
+    try:
+        GPGKey.from_dict(arg["keyid"], arg)
+    except (KeyError, TypeError):
+        try:
+            Key.from_dict(arg["keyid"], deepcopy(arg))
+        except KeyError as e:
+            raise _err(arg, "public key dict") from e
+
+
+def _check_public_keys(arg):
+    """Check dict of public key dicts."""
+    _check_dict(arg)
+    for k, v in arg.items():
+        _check_hex(k)
+        _check_public_key(v)

--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -22,16 +22,10 @@
 from copy import deepcopy
 from re import fullmatch
 
-import securesystemslib.schema as ssl_schema
 from securesystemslib.exceptions import FormatError
 from securesystemslib.signer import Key, Signature
 
 from in_toto.models._signer import GPGKey, GPGSignature
-
-PARAMETER_DICTIONARY_KEY = ssl_schema.RegularExpression(r"[a-zA-Z0-9_-]+")
-PARAMETER_DICTIONARY_SCHEMA = ssl_schema.DictOf(
-    key_schema=PARAMETER_DICTIONARY_KEY, value_schema=ssl_schema.AnyString()
-)
 
 
 def _err(arg, expected):

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -50,6 +50,7 @@ from in_toto.common_args import (
     sort_action_groups,
     title_case_action_groups,
 )
+from in_toto.formats import _check_hex
 from in_toto.models._signer import GPGSigner
 from in_toto.models.link import FILENAME_FORMAT
 from in_toto.models.metadata import Metadata
@@ -94,7 +95,7 @@ def _sign_and_dump_metadata(metadata, args):
 
             # Otherwise we sign with each passed keyid
             for keyid in args.gpg:
-                securesystemslib.formats.KEYID_SCHEMA.check_match(keyid)
+                _check_hex(keyid)
                 signature = metadata.create_signature(
                     GPGSigner(keyid, homedir=args.gpg_home)
                 )

--- a/in_toto/models/_signer.py
+++ b/in_toto/models/_signer.py
@@ -117,8 +117,7 @@ class GPGSigner(Signer):
           payload: The bytes to be signed.
         Raises:
           securesystemslib.exceptions.FormatError:
-            If the keyid was passed and does not match
-            securesystemslib.formats.KEYID_SCHEMA.
+            If the keyid is invalid.
           ValueError: the gpg command failed to create a valid signature.
           OSError: the gpg command is not present or non-executable.
           securesystemslib.exceptions.UnsupportedLibraryError: the gpg command is

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -299,7 +299,7 @@ class Layout(Signable):
         """Adds key as functionary key to layout.
 
         Arguments:
-          key: A public key. Format is securesystemslib.formats.ANY_PUBKEY_SCHEMA.
+          key: A public key.
 
         Raises:
           securesystemslib.exceptions.FormatError: Argument is malformed.
@@ -317,8 +317,7 @@ class Layout(Signable):
         """Loads key from disk and adds as functionary key to layout.
 
         Arguments:
-          key_path: A path to a PEM-formatted RSA public key. Format is
-              securesystemslib.formats.PATH_SCHEMA.
+          key_path: A path to a PEM-formatted RSA public key.
 
         Raises:
           securesystemslib.exceptions.FormatError: Argument is malformed.
@@ -367,8 +366,7 @@ class Layout(Signable):
         """Loads keys from disk and adds as functionary keys to layout.
 
         Arguments:
-          key_path_list: A list of paths to PEM-formatted RSA public keys. Format
-              of each path is securesystemslib.formats.PATH_SCHEMA.
+          key_path_list: A list of paths to PEM-formatted RSA public keys.
 
         Raises:
           securesystemslib.exceptions.FormatError: Argument is malformed.
@@ -428,7 +426,7 @@ class Layout(Signable):
         """Private method to verify if the expiration field has the right format
         and can be parsed."""
         try:
-            # We do both 'parse' and 'check_match' because the format check does not
+            # We do both 'parse' and '_check_iso8601' because the format check does not
             # detect bogus dates (e.g. Jan 35th) and parse can do more formats.
             parse(self.expires)
             _check_iso8601(self.expires)

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -25,6 +25,7 @@
 import attr
 import securesystemslib.formats
 
+from in_toto.formats import _check_hash_dict
 from in_toto.models.common import Signable
 
 FILENAME_FORMAT = "{step_name}.{keyid:.8}.link"
@@ -147,7 +148,7 @@ class Link(Signable):
             )
 
         for material in list(self.materials.values()):
-            securesystemslib.formats.HASHDICT_SCHEMA.check_match(material)
+            _check_hash_dict(material)
 
     def _validate_products(self):
         """Private method to check that `products` is a `dict` of `HASHDICTs`."""
@@ -159,7 +160,7 @@ class Link(Signable):
             )
 
         for product in list(self.products.values()):
-            securesystemslib.formats.HASHDICT_SCHEMA.check_match(product)
+            _check_hash_dict(product)
 
     def _validate_byproducts(self):
         """Private method to check that `byproducts` is a `dict`."""

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -129,8 +129,7 @@ class Metadata:
         """Verifies a signature over signable in signatures with verification_key.
 
         Arguments:
-          verification_key: A verification key. The format is
-              securesystemslib.formats.ANY_VERIFICATION_KEY_SCHEMA.
+          verification_key: A verification key.
 
         Raises:
           securesystemslib.exceptions.FormatError: The passed key is malformed.
@@ -305,7 +304,7 @@ class Metablock(Metadata, ValidationMixin):
     attribute to create signatures deterministically.
 
     Attributes:
-      key: A signing key. The format is securesystemslib.formats.KEY_SCHEMA.
+      key: A signing key.
 
     Raises:
       securesystemslib.exceptions.FormatError: Key argument is malformed.
@@ -314,7 +313,7 @@ class Metablock(Metadata, ValidationMixin):
           Signing errors.
 
     Returns:
-      The signature. Format is securesystemslib.formats.SIGNATURE_SCHEMA.
+      The signature.
 
     .. deprecated:: 2.2.0
         Please use ``Metablock.create_signature()`` instead.
@@ -352,7 +351,7 @@ class Metablock(Metadata, ValidationMixin):
       Calls system gpg command in a subprocess.
 
     Returns:
-      The signature. Format is securesystemslib.formats.GPG_SIGNATURE_SCHEMA.
+      The signature.
 
     """
         signature = securesystemslib.gpg.functions.create_signature(
@@ -371,12 +370,10 @@ class Metablock(Metadata, ValidationMixin):
 
         NOTE: Only the first signature in the signatures attribute, whose keyid
         matches the verification_key keyid, is verified. If the verification_key
-        format is securesystemslib.formats.GPG_PUBKEY_SCHEMA, subkey keyids are
-        considered too.
+        is a gpg key, subkey keyids are considered too.
 
         Arguments:
-          verification_key: A verification key. The format is
-              securesystemslib.formats.ANY_VERIFICATION_KEY_SCHEMA.
+          verification_key: A verification key.
 
         Raises:
           securesystemslib.exceptions.FormatError: The passed key is malformed.
@@ -451,9 +448,7 @@ class Metablock(Metadata, ValidationMixin):
         self.signed.validate()
 
     def _validate_signatures(self):
-        """Private method to check that the 'signatures' attribute is a list of
-        signatures in the format 'securesystemslib.formats.ANY_SIGNATURE_SCHEMA'.
-        """
+        """Private method to check that the 'signatures' attribute is valid."""
 
         if not isinstance(self.signatures, list):
             raise securesystemslib.exceptions.FormatError(

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -23,6 +23,8 @@
 import securesystemslib.exceptions
 import securesystemslib.formats
 
+from in_toto.formats import _check_str, _check_str_list
+
 GENERIC_RULES = {
     "create",
     "modify",
@@ -82,7 +84,7 @@ def unpack_rule(rule):
       }
 
     """
-    securesystemslib.formats.LIST_OF_ANY_STRING_SCHEMA.check_match(rule)
+    _check_str_list(rule)
 
     # Create all lower rule copy to case insensitively parse out tokens whose
     # position we don't know yet
@@ -261,8 +263,8 @@ def pack_rule(
       Note that REQUIRE is somewhat of a weird animal that does not use patterns
       but rather single filenames (for now).
     """
-    securesystemslib.formats.ANY_STRING_SCHEMA.check_match(rule_type)
-    securesystemslib.formats.ANY_STRING_SCHEMA.check_match(pattern)
+    _check_str(rule_type)
+    _check_str(pattern)
 
     if rule_type.lower() not in ALL_RULES:
         raise securesystemslib.exceptions.FormatError(
@@ -273,9 +275,7 @@ def pack_rule(
         )
 
     if rule_type.upper() == "MATCH":
-        if not securesystemslib.formats.ANY_STRING_SCHEMA.matches(
-            dest_type
-        ) or not (
+        if not isinstance(dest_type, str) or not (
             dest_type.lower() == "materials" or dest_type.lower() == "products"
         ):
             raise securesystemslib.exceptions.FormatError(
@@ -286,10 +286,7 @@ def pack_rule(
                 )
             )
 
-        if not (
-            securesystemslib.formats.ANY_STRING_SCHEMA.matches(dest_name)
-            and dest_name
-        ):
+        if not (isinstance(dest_name, str) and dest_name):
             raise securesystemslib.exceptions.FormatError(
                 "'{}' is not a valid"
                 " 'dest_name'. Rules of type 'MATCH' require a step name as a"
@@ -300,15 +297,14 @@ def pack_rule(
         rule = ["MATCH", pattern]
 
         if source_prefix:
-            securesystemslib.formats.ANY_STRING_SCHEMA.check_match(
-                source_prefix
-            )
+            _check_str(source_prefix)
+
             rule += ["IN", source_prefix]
 
         rule += ["WITH", dest_type.upper()]
 
         if dest_prefix:
-            securesystemslib.formats.ANY_STRING_SCHEMA.check_match(dest_prefix)
+            _check_str(dest_prefix)
             rule += ["IN", dest_prefix]
 
         rule += ["FROM", dest_name]

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -462,8 +462,7 @@ def in_toto_run(
         standard error of the link command should be recorded in the link
         metadata in addition to being displayed while the command is executed.
 
-    signing_key (optional): A key used to sign the resulting link metadata. The
-        format is securesystemslib.formats.KEY_SCHEMA.
+    signing_key (optional): A key used to sign the resulting link metadata.
 
         .. deprecated:: 2.2.0
            Please pass a ``signer`` instead.
@@ -681,8 +680,7 @@ def in_toto_record_start(
     material_list: A list of artifact paths to be recorded as materials.
         Directories are traversed recursively.
 
-    signing_key (optional): A key used to sign the resulting link metadata. The
-        format is securesystemslib.formats.KEY_SCHEMA.
+    signing_key (optional): A key used to sign the resulting link metadata.
 
         .. deprecated:: 2.2.0
            Please pass a ``signer`` instead.
@@ -867,8 +865,7 @@ def in_toto_record_stop(
     product_list: A list of artifact paths to be recorded as products.
         Directories are traversed recursively.
 
-    signing_key (optional): A key used to sign the resulting link metadata. The
-        format is securesystemslib.formats.KEY_SCHEMA.
+    signing_key (optional): A key used to sign the resulting link metadata.
 
         .. deprecated:: 2.2.0
            Please pass a ``signer`` instead.

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -45,7 +45,12 @@ from securesystemslib.signer import Key, Signature, Signer, SSlibSigner
 
 import in_toto.exceptions
 import in_toto.settings
-from in_toto.formats import _check_signing_key
+from in_toto.formats import (
+    _check_hex,
+    _check_signing_key,
+    _check_str,
+    _check_str_list,
+)
 from in_toto.models._signer import GPGSigner
 from in_toto.models.link import (
     FILENAME_FORMAT,
@@ -547,16 +552,16 @@ def in_toto_run(
         _check_signing_key(signing_key)
 
     if gpg_keyid:
-        securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+        _check_hex(gpg_keyid)
 
     if exclude_patterns:
-        securesystemslib.formats.NAMES_SCHEMA.check_match(exclude_patterns)
+        _check_str_list(exclude_patterns)
 
     if base_path:
-        securesystemslib.formats.PATH_SCHEMA.check_match(base_path)
+        _check_str(base_path)
 
     if metadata_directory:
-        securesystemslib.formats.PATH_SCHEMA.check_match(metadata_directory)
+        _check_str(metadata_directory)
 
     if material_list:
         LOG.info("Recording materials '%s'...", ", ".join(material_list))
@@ -571,16 +576,14 @@ def in_toto_run(
     )
 
     if link_cmd_args:
-        securesystemslib.formats.LIST_OF_ANY_STRING_SCHEMA.check_match(
-            link_cmd_args
-        )
+        _check_str_list(link_cmd_args)
         LOG.info("Running command '%s'...", " ".join(link_cmd_args))
         byproducts = execute_link(link_cmd_args, record_streams, timeout)
     else:
         byproducts = {}
 
     if product_list:
-        securesystemslib.formats.PATHS_SCHEMA.check_match(product_list)
+        _check_str_list(product_list)
         LOG.info("Recording products '%s'...", ", ".join(product_list))
 
     products_dict = record_artifacts_as_dict(
@@ -759,13 +762,13 @@ def in_toto_record_start(
         _check_signing_key(signing_key)
 
     if gpg_keyid:
-        securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+        _check_str(gpg_keyid)
 
     if exclude_patterns:
-        securesystemslib.formats.NAMES_SCHEMA.check_match(exclude_patterns)
+        _check_str_list(exclude_patterns)
 
     if base_path:
-        securesystemslib.formats.PATH_SCHEMA.check_match(base_path)
+        _check_str(base_path)
 
     if material_list:
         LOG.info("Recording materials '%s'...", ", ".join(material_list))
@@ -961,16 +964,16 @@ def in_toto_record_stop(
         _check_signing_key(signing_key)
 
     if gpg_keyid:
-        securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+        _check_hex(gpg_keyid)
 
     if exclude_patterns:
-        securesystemslib.formats.NAMES_SCHEMA.check_match(exclude_patterns)
+        _check_str_list(exclude_patterns)
 
     if base_path:
-        securesystemslib.formats.PATH_SCHEMA.check_match(base_path)
+        _check_str(base_path)
 
     if metadata_directory:
-        securesystemslib.formats.PATH_SCHEMA.check_match(metadata_directory)
+        _check_str(metadata_directory)
 
     # Load preliminary link file
     # If we have a signing key we can use the keyid to construct the name

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -45,6 +45,7 @@ from securesystemslib.signer import Key, Signature, Signer, SSlibSigner
 
 import in_toto.exceptions
 import in_toto.settings
+from in_toto.formats import _check_signing_key
 from in_toto.models._signer import GPGSigner
 from in_toto.models.link import (
     FILENAME_FORMAT,
@@ -389,18 +390,6 @@ def in_toto_mock(name, link_cmd_args, use_dsse=False):
     return link_metadata
 
 
-def _check_match_signing_key(signing_key):
-    """Helper method to check if the signing_key has securesystemslib's
-    KEY_SCHEMA and the private part is not empty.
-    # FIXME: Add private key format check to formats
-    """
-    securesystemslib.formats.KEY_SCHEMA.check_match(signing_key)
-    if not signing_key["keyval"].get("private"):
-        raise securesystemslib.exceptions.FormatError(
-            "Signing key needs to be a private key."
-        )
-
-
 def _check_signer(signer):
     if not isinstance(signer, Signer):
         raise ValueError("signer must be a Signer instance")
@@ -555,7 +544,7 @@ def in_toto_run(
         _check_signer(signer)
 
     if signing_key:
-        _check_match_signing_key(signing_key)
+        _check_signing_key(signing_key)
 
     if gpg_keyid:
         securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
@@ -767,7 +756,7 @@ def in_toto_record_start(
         _check_signer(signer)
 
     if signing_key:
-        _check_match_signing_key(signing_key)
+        _check_signing_key(signing_key)
 
     if gpg_keyid:
         securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
@@ -969,7 +958,7 @@ def in_toto_record_stop(
         _check_signer(signer)
 
     if signing_key:
-        _check_match_signing_key(signing_key)
+        _check_signing_key(signing_key)
 
     if gpg_keyid:
         securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -49,6 +49,7 @@ from in_toto.exceptions import (
     SignatureVerificationError,
     ThresholdVerificationError,
 )
+from in_toto.formats import _check_parameter_dict, _check_public_keys
 from in_toto.models.metadata import Metadata
 
 # Inherits from in_toto base logger (c.f. in_toto.log)
@@ -296,9 +297,7 @@ def substitute_parameters(layout, parameter_dictionary):
       The layout object will have any tags replaced with the corresponding
       values defined in the parameter dictionary.
     """
-    in_toto.formats.PARAMETER_DICTIONARY_SCHEMA.check_match(
-        parameter_dictionary
-    )
+    _check_parameter_dict(parameter_dictionary)
 
     for step in layout.steps:
         new_material_rules = []
@@ -377,7 +376,7 @@ def verify_metadata_signatures(metadata, keys_dict):
         if any of the passed verification keys is an expired gpg key
 
     """
-    securesystemslib.formats.VERIFICATION_KEY_DICT_SCHEMA.check_match(keys_dict)
+    _check_public_keys(keys_dict)
 
     # Fail if an empty verification key dictionary was passed
     if len(keys_dict) < 1:

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -361,12 +361,11 @@ def verify_metadata_signatures(metadata, keys_dict):
               verified.
 
       keys_dict:
-              A dictionary of keys to verify the signatures conformant with
-              securesystemslib.formats.VERIFICATION_KEY_DICT_SCHEMA.
+              A dictionary of keys to verify the signatures.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError
-        if the passed key dict does not match VERIFICATION_KEY_DICT_SCHEMA.
+        if the passed key dict is invalid.
 
       SignatureVerificationError
         if an empty verification key dictionary was passed, or

--- a/tests/models/test_layout.py
+++ b/tests/models/test_layout.py
@@ -274,6 +274,21 @@ class TestLayoutValidator(unittest.TestCase):
         with self.assertRaises(securesystemslib.exceptions.FormatError):
             self.layout.validate()
 
+        # ... more invalid keys
+        for invalid_keys in [
+            False,  # must be a dict
+            {1234: {}},  # keyid must be string
+            {"xyz": {}},  # keyid must be hex
+            {"deadbeef": {"missing": "'keyval' field"}},
+        ]:
+            self.layout.keys = invalid_keys
+            with self.assertRaises(securesystemslib.exceptions.FormatError):
+                self.layout._validate_keys()
+
+        self.layout.keys[rsa_key_two["keyid"]] = "kek"
+        with self.assertRaises(securesystemslib.exceptions.FormatError):
+            self.layout.validate()
+
         self.layout.keys = {}
         del rsa_key_one["keyval"]["private"]
         del rsa_key_two["keyval"]["private"]

--- a/tests/models/test_link.py
+++ b/tests/models/test_link.py
@@ -64,6 +64,16 @@ class TestLinkValidator(unittest.TestCase):
         with self.assertRaises(FormatError):
             test_link.validate()
 
+        # Bad hash dicts
+        for bad_hash_dict in [
+            {False: "deadbeef"},  # name must be string
+            {"sha256": False},  # digest must be string
+            {"sha256": "ghijk"},  # digest must be hex
+        ]:
+            test_link.materials = {"foo": bad_hash_dict}
+            with self.assertRaises(FormatError):
+                test_link.validate()
+
     def test_validate_products(self):
         """Test `products` field. Must be a `dict` of HASH_DICTs"""
         test_link = Link()

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -76,6 +76,10 @@ class TestMetablockValidator(unittest.TestCase):
         with self.assertRaises(FormatError):
             metablock._validate_signatures()
 
+        metablock.signatures = [{"missing": "'keyid' and 'sig'"}]
+        with self.assertRaises(FormatError):
+            metablock._validate_signatures()
+
         # Load signed demo link
         demo_link_path = os.path.join(
             os.path.dirname(os.path.realpath(__file__)),

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -27,6 +27,7 @@ import os
 import shutil
 import unittest
 
+from securesystemslib.exceptions import FormatError
 from securesystemslib.interface import (
     import_publickeys_from_file,
     import_rsa_privatekey_from_file,
@@ -113,6 +114,16 @@ class TestSubstituteArtifacts(unittest.TestCase):
         """Raise an error if the parameter is not filled-in"""
         with self.assertRaises(KeyError):
             substitute_parameters(self.layout, {})
+
+    def test_invalid_format(self):
+        for bad_param_dict in [
+            False,  # must be dict
+            {False: "foo"},  # name must be string
+            {"~!#@": "foo"},  # name must not have disallowed characters
+            {"GOOD_NAME": False},  # value must be string
+        ]:
+            with self.assertRaises(FormatError):
+                substitute_parameters(self.layout, bad_param_dict)
 
 
 class TestSubstituteRunField(unittest.TestCase):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -46,6 +46,7 @@ from securesystemslib.signer import CryptoSigner, Signer
 import in_toto.exceptions
 import in_toto.settings
 from in_toto.exceptions import SignatureVerificationError
+from in_toto.formats import _check_hash_dict
 from in_toto.models.link import (
     FILENAME_FORMAT,
     UNFINISHED_FILENAME_FORMAT,
@@ -343,7 +344,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         artifacts_dict = record_artifacts_as_dict(["."])
 
         for val in list(artifacts_dict.values()):
-            securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
+            _check_hash_dict(val)
 
         self.assertListEqual(
             sorted(list(artifacts_dict.keys())),
@@ -495,7 +496,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         artifacts_dict = record_artifacts_as_dict(["foo", "subdir"])
 
         for val in list(artifacts_dict.values()):
-            securesystemslib.formats.HASHDICT_SCHEMA.check_match(val)
+            _check_hash_dict(val)
 
         self.assertListEqual(
             sorted(list(artifacts_dict.keys())),


### PR DESCRIPTION
Adds helper functions to cover all data validation cases in a backwards-compatible manner, where we previously used securesystemslib SCHEMA.

This is part of a series of patches to prepare for removal of legacy securesystemslib interfaces.  (see https://github.com/secure-systems-lab/securesystemslib/issues/183 for specific issues with SCHEMA)

**Details**

Most of the checks are simple type validations, now without the hidden redundancy of SCHEMA. (e.g. `NAME_SCHEMA`, `PATH_SCHEMA`, or `ANY_STRING_SCHEMA` all just checked if the input was a string, now there is only `_check_str`)

A few checks validate more complex data structures, most notably public key dictionaries. While SCHEMA whitelisted allowed fields and their values, we now just try to deserialise using securesystemslib's Signer API, and re-raise a deserialisation error as format error.

This is more Pythonic (if we can parse it as key, it is a key) and scales nicely, because the Signer API allows to [register new public key schemes](https://github.com/secure-systems-lab/securesystemslib/blob/cc0ead6b03ad7e42418a36799daa87a6742e60cf/securesystemslib/signer/__init__.py#L45-L69) in user code.

**Alternative / future work**

This PR is a **hack** with the goal to remove schema in securesystemslibs without breaking the API in in-toto. It also has  the nice side-effect of making validation more explicit and flexible.

A more sustainable solution can be found in the python-tuf Metadata API, where
- most of the data model (including keys and signatures) is represented by classes and validated on deserialization
- API inputs are above all validated to prevent unexpected behavior, or provide better UX
- in many cases, it's okay to just use the exceptions that come from using invalid input data
- type annotations are very useful

However, this would be a more invasive and surely breaking change. So, even though this PR adds a lot of code, I think we should go with it for now, and revise the class model later. 

Reviewing commit by commit should make the review straight-forward.
