### PR TITLE
remove extraneous python3-six dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Build-Depends:
  python3-hatchling,
  python3-attr,
  python3-dateutil,
- python3-six,
  python3-iso8601,
  python3-pathspec,
  python3-cryptography,


### PR DESCRIPTION
https://wiki.debian.org/Python3-six-removal

