### PR TITLE
Dependabot: use groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,7 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
+
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,31 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-
+  groups:
+    build-and-release-dependencies:
+      # Python dependencies known to be critical to our build/release security
+      patterns:
+        - "build"
+        - "hatchling"
+    test-and-lint-dependencies:
+      # Python dependencies that are only pinned to ensure test reproducibility
+      patterns:
+        - "bandit"
+        - "black"
+        - "coverage"
+        - "isort"
+        - "pylint"
+    dependencies:
+      # Python (developer) runtime dependencies. Also any new dependencies not
+      # caught by earlier groups
+      patterns:
+        - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    action-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
Group weekly dependency updates to reduce maintenance burden.

Groups are:
  * critical python build/release deps
  * python test and lint deps (only pinned for test repro)
  * all other python dependencies
  * all github action dependencies

This was shamelessly copied from @jku's
https://github.com/theupdateframework/python-tuf/pull/2530. Cheers!