### PR TITLE
Adopt mandatory Signer.public_key property

### DIFF
--- a/in_toto/models/_signer.py
+++ b/in_toto/models/_signer.py
@@ -137,6 +137,10 @@ class GPGSigner(Signer):
         self.keyid = keyid
         self.homedir = homedir
 
+    @property
+    def public_key(self) -> Key:
+        raise NotImplementedError  # pragma: no cover
+
     @classmethod
     def from_priv_key_uri(
         cls,

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -41,7 +41,7 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.gpg
 import securesystemslib.hash
-from securesystemslib.signer import Key, Signature, Signer, SSlibSigner
+from securesystemslib.signer import Signature, Signer, SSlibSigner
 
 import in_toto.exceptions
 import in_toto.settings
@@ -398,13 +398,6 @@ def in_toto_mock(name, link_cmd_args, use_dsse=False):
 def _check_signer(signer):
     if not isinstance(signer, Signer):
         raise ValueError("signer must be a Signer instance")
-
-    if not (
-        hasattr(signer, "public_key") and isinstance(signer.public_key, Key)
-    ):
-        # TODO: add `public_key` to `Signer` interface upstream
-        # see secure-systems-lab/securesystemslib#605
-        raise ValueError("only Signer instances with public key supported")
 
 
 def _require_signing_arg(signer, signing_key, gpg_keyid, gpg_use_default):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -41,7 +41,7 @@ from securesystemslib.interface import (
     import_rsa_privatekey_from_file,
     import_rsa_publickey_from_file,
 )
-from securesystemslib.signer import CryptoSigner, Signer
+from securesystemslib.signer import CryptoSigner
 
 import in_toto.exceptions
 import in_toto.settings
@@ -1435,39 +1435,6 @@ class TestSigner(unittest.TestCase, TmpDirMixin):
 
         with self.assertRaises(ValueError):
             link = in_toto_run("foo", [], [], [], signer=NoSigner())
-
-        # Fail with incompatible signers
-        class BadSigner(Signer):
-            """Signer implementation w/o public_key attribute.
-            secure-systems-lab/securesystemslib#605
-            """
-
-            @classmethod
-            def from_priv_key_uri(
-                cls,
-                priv_key_uri,
-                public_key,
-                secrets_handler=None,
-            ):
-                pass
-
-            def sign(self, payload):
-                pass
-
-        # Fail with missing public_key attribute.
-        bad_signer = BadSigner()
-        with self.assertRaises(ValueError):
-            link = in_toto_run("foo", [], [], [], signer=bad_signer)
-
-        class NoKey:
-            pass
-
-        # Fail with wrong tpe on public_key attribute
-        bad_signer.public_key = (  # pylint: disable=attribute-defined-outside-init
-            NoKey()
-        )
-        with self.assertRaises(ValueError):
-            link = in_toto_run("foo", [], [], [], signer=bad_signer)
 
     def test_record(self):
         # Successfully create, sign and verify link


### PR DESCRIPTION
secure-systems-lab/securesystemslib#756 added a `public_key` property to the Signer interface.

This PR updates in-toto accordingly:

* Add dummy public_key property to GPG pseudo-signer GPGSigner only implements parts of the Signer interface for compatibility-reasons. This is okay, because it is only used internally.

* Remove obsolete public_key property check and related test in runlib.
