### PR TITLE
Adopt upstream DSSE model change

### DIFF
--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -72,7 +72,7 @@ def _sign_and_dump_metadata(metadata, args):
 
     try:
         if not args.append:
-            metadata.signatures = []
+            metadata.signatures.clear()
 
         signature = None
         # If the cli tool was called with `--gpg [KEYID ...]` `args.gpg` is

--- a/in_toto/models/_signer.py
+++ b/in_toto/models/_signer.py
@@ -137,6 +137,10 @@ class GPGSigner(Signer):
         self.keyid = keyid
         self.homedir = homedir
 
+    @property
+    def public_key(self) -> Key:
+        raise NotImplementedError  # pragma: no cover
+
     @classmethod
     def from_priv_key_uri(
         cls,

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -160,7 +160,7 @@ class Envelope(SSlibEnvelope, Metadata):
         return cls(
             payload=json_bytes,
             payload_type=ENVELOPE_PAYLOAD_TYPE,
-            signatures=[],
+            signatures={},
         )
 
     def create_signature(self, signer: Signer) -> Signature:

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -41,7 +41,7 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.gpg
 import securesystemslib.hash
-from securesystemslib.signer import Key, Signature, Signer, SSlibSigner
+from securesystemslib.signer import Signature, Signer, SSlibSigner
 
 import in_toto.exceptions
 import in_toto.settings
@@ -398,13 +398,6 @@ def in_toto_mock(name, link_cmd_args, use_dsse=False):
 def _check_signer(signer):
     if not isinstance(signer, Signer):
         raise ValueError("signer must be a Signer instance")
-
-    if not (
-        hasattr(signer, "public_key") and isinstance(signer.public_key, Key)
-    ):
-        # TODO: add `public_key` to `Signer` interface upstream
-        # see secure-systems-lab/securesystemslib#605
-        raise ValueError("only Signer instances with public key supported")
 
 
 def _require_signing_arg(signer, signing_key, gpg_keyid, gpg_use_default):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -41,7 +41,7 @@ import securesystemslib.exceptions
 import securesystemslib.formats
 import securesystemslib.gpg
 import securesystemslib.hash
-from securesystemslib.signer import Signature, Signer, SSlibSigner
+from securesystemslib.signer import Signer, SSlibSigner
 
 import in_toto.exceptions
 import in_toto.settings
@@ -1040,12 +1040,16 @@ def in_toto_record_stop(
         LOG.info(
             "Verifying preliminary link signature using default gpg key..."
         )
-        # signatures are objects in DSSE.
-        sig = link_metadata.signatures[0]
-        if isinstance(sig, Signature):
-            keyid = sig.keyid
+
+        # The `signatures` field is not part of the common Envelope/Metablock
+        # interface, so we need to case handle. Note that we shouldn't be
+        # accessing `signatures` here in the first place (see FIXME above).
+        if isinstance(link_metadata, Envelope):
+            keyid = link_metadata.signatures.values()[0].keyid
+
         else:
-            keyid = sig["keyid"]
+            keyid = link_metadata.signatures[0]["keyid"]
+
         gpg_pubkey = securesystemslib.gpg.functions.export_pubkey(
             keyid, gpg_home
         )

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -41,7 +41,7 @@ from securesystemslib.interface import (
     import_rsa_privatekey_from_file,
     import_rsa_publickey_from_file,
 )
-from securesystemslib.signer import CryptoSigner, Signer
+from securesystemslib.signer import CryptoSigner
 
 import in_toto.exceptions
 import in_toto.settings
@@ -1435,39 +1435,6 @@ class TestSigner(unittest.TestCase, TmpDirMixin):
 
         with self.assertRaises(ValueError):
             link = in_toto_run("foo", [], [], [], signer=NoSigner())
-
-        # Fail with incompatible signers
-        class BadSigner(Signer):
-            """Signer implementation w/o public_key attribute.
-            secure-systems-lab/securesystemslib#605
-            """
-
-            @classmethod
-            def from_priv_key_uri(
-                cls,
-                priv_key_uri,
-                public_key,
-                secrets_handler=None,
-            ):
-                pass
-
-            def sign(self, payload):
-                pass
-
-        # Fail with missing public_key attribute.
-        bad_signer = BadSigner()
-        with self.assertRaises(ValueError):
-            link = in_toto_run("foo", [], [], [], signer=bad_signer)
-
-        class NoKey:
-            pass
-
-        # Fail with wrong tpe on public_key attribute
-        bad_signer.public_key = (  # pylint: disable=attribute-defined-outside-init
-            NoKey()
-        )
-        with self.assertRaises(ValueError):
-            link = in_toto_run("foo", [], [], [], signer=bad_signer)
 
     def test_record(self):
         # Successfully create, sign and verify link


### PR DESCRIPTION
* includes #728 (to unbreak with-sslib-main tests)
* blocks on next securesystemslib release

---

Adopt `securesystemslib.dsse.Envelope.signatures` type change from list to dict (https://github.com/secure-systems-lab/securesystemslib/pull/743) in `in_toto.models.metadata.Envelope` subclass.