### PR TITLE
Pin securesystemslib to current minor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "iso8601",
     "pathspec",
     "python-dateutil",
-    "securesystemslib[crypto]>=0.31.0",
+    "securesystemslib[crypto]~=0.31.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
There are several breaking changes coming up in securesystemslib on its way to 1.0.

To not disrupt in-toto users this patch pins securesystemslib to its current minor version.

This is similar to what python-tuf and tuf-on-ci do:
- https://github.com/theupdateframework/python-tuf/pull/2600
- https://github.com/theupdateframework/tuf-on-ci/pull/243
