### PR TITLE
Run CD build despite "with-sslib-main" test error

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,6 +6,7 @@ permissions: {}
 
 jobs:
   test:
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       # Run regular in-toto tests on each OS/Python combination, plus linters
@@ -14,13 +15,16 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
+        experimental: [false]
         include:
           - python-version: '3.8'
             os: ubuntu-latest
             toxenv: lint
+            experimental: false
           - python-version: 3.x
             os: ubuntu-latest
             toxenv: with-sslib-main
+            experimental: true
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The CD build job requires prior test jobs to run successfully. This seems reasonable for all test jobs but "with-sslib-main", which runs against the unreleased main branch of securesystemslib.

This patch changes the test job matrix to allow errors in the "with-sslib-main" job, as described in GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run

