### PR TITLE
Constrain sphinx-argparse docs dependency

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,5 +3,6 @@
 
 # sphinx extensions
 sphinx-rtd-theme
-sphinx-argparse
+# TODO: Unpin dependency with sphinx-doc/sphinx-argparse#56
+sphinx-argparse<0.5.0
 recommonmark


### PR DESCRIPTION
Constrains docs dependency to fix failing docs build after recent sphinx-argparse release. see sphinx-doc/sphinx-argparse#56.

(h/t @njzjz for reporting)

The constraint may be removed when the issue is fixed.

