### PR TITLE
Revert "Constrain sphinx-argparse docs dependency"

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,6 +3,5 @@
 
 # sphinx extensions
 sphinx-rtd-theme
-# TODO: Unpin dependency with sphinx-doc/sphinx-argparse#56
-sphinx-argparse<0.5.0
+sphinx-argparse
 recommonmark


### PR DESCRIPTION
This reverts commit f4631473553aec4e0622a1566968e5b3590f7333.

Upstream released a fix, so we no longer need to constrain the dep.
