### PR TITLE
Apply assorted ruff rules

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -221,9 +221,7 @@ def sort_action_groups(parser, title_order=None):
     ) in parser._action_groups:  # pylint: disable=protected-access
         action_group_dict[action_group.title] = action_group
 
-    ordered_action_groups = []
-    for title in title_order:
-        ordered_action_groups.append(action_group_dict[title])
+    ordered_action_groups = [action_group_dict[title] for title in title_order]
 
     parser._action_groups = (  # pylint: disable=protected-access
         ordered_action_groups

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -127,7 +127,7 @@ def _sign_and_dump_metadata(metadata, args):
             out_path = args.file
 
         else:  # pragma: no cover
-            raise ValueError("invalid type {_type}")  # unreachable
+            raise ValueError(f"invalid type {_type}")  # unreachable
 
         LOG.info("Dumping %s to '%s'...", _type, out_path)
 

--- a/in_toto/models/_signer.py
+++ b/in_toto/models/_signer.py
@@ -52,7 +52,7 @@ def load_crypto_signer_from_pkcs8_file(
     return signer
 
 
-def load_public_key_from_file(path: str) -> Dict[str, Any]:
+def load_public_key_from_file(path: str) -> dict[str, Any]:
     """Internal helper to load key from SubjectPublicKeyInfo/PEM file."""
     with open(path, "rb") as f:
         data = f.read()
@@ -90,7 +90,7 @@ class GPGSignature(Signature):
         self.other_headers = other_headers
 
     @classmethod
-    def from_dict(cls, signature_dict: Dict) -> "GPGSignature":
+    def from_dict(cls, signature_dict: dict) -> "GPGSignature":
         """Creates a ``GPGSignature`` object from its JSON/dict
         representation.
 
@@ -110,7 +110,7 @@ class GPGSignature(Signature):
             signature_dict["other_headers"],
         )
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Returns the JSON-serializable dictionary representation of self."""
         return {
             "keyid": self.keyid,
@@ -203,15 +203,15 @@ class GPGKey(Key):
 
     type: str
     method: str
-    hashes: List[str]
-    keyval: Dict[str, str]
+    hashes: list[str]
+    keyval: dict[str, str]
     keyid: str
     creation_time: Optional[int] = None
     validity_period: Optional[int] = None
-    subkeys: Optional[Dict[str, "GPGKey"]] = None
+    subkeys: Optional[dict[str, "GPGKey"]] = None
 
     @classmethod
-    def from_dict(cls, keyid: str, key_dict: Dict[str, Any]):
+    def from_dict(cls, keyid: str, key_dict: dict[str, Any]):
         """Creates ``GPGKey`` object from its json/dict representation.
         Raises:
           KeyError, TypeError: Invalid arguments.
@@ -237,7 +237,7 @@ class GPGKey(Key):
         )
 
     @classmethod
-    def from_legacy_dict(cls, key_dict: Dict[str, Any]):
+    def from_legacy_dict(cls, key_dict: dict[str, Any]):
         """Create GPGKey from legacy dictionary representation."""
 
         keyid = key_dict["keyid"]

--- a/in_toto/models/_signer.py
+++ b/in_toto/models/_signer.py
@@ -20,7 +20,7 @@
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import securesystemslib._gpg.exceptions as gpg_exceptions
 import securesystemslib._gpg.functions as gpg

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -139,15 +139,14 @@ class Layout(Signable):
           The created Layout object.
 
         """
-        steps = []
 
-        for step_data in data.get("steps"):
-            steps.append(Step.read(step_data))
+        steps = [Step.read(step_data) for step_data in data.get("steps")]
         data["steps"] = steps
 
-        inspections = []
-        for inspect_data in data.get("inspect"):
-            inspections.append(Inspection.read(inspect_data))
+        inspections = [
+            Inspection.read(inspect_data)
+            for inspect_data in data.get("inspect")
+        ]
         data["inspect"] = inspections
 
         return Layout(**data)
@@ -182,9 +181,7 @@ class Layout(Signable):
           A list of step names.
 
         """
-        step_names = []
-        for step in self.steps:
-            step_names.append(step.name)
+        step_names = [step.name for step in self.steps]
 
         return step_names
 
@@ -235,9 +232,7 @@ class Layout(Signable):
           A list of inspection names.
 
         """
-        inspection_names = []
-        for inspection in self.inspect:
-            inspection_names.append(inspection.name)
+        inspection_names = [inspection.name for inspection in self.inspect]
 
         return inspection_names
 

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -226,9 +226,7 @@ class Layout(Signable):
         """
         _check_str(step_name)
 
-        for step in self.steps:
-            if step.name == step_name:
-                self.steps.remove(step)
+        self.steps[:] = [x for x in self.steps if x.name != step_name]
 
     def get_inspection_name_list(self):
         """Returns ordered list of inspection names as they appear in the layout.
@@ -281,9 +279,7 @@ class Layout(Signable):
         """
         _check_str(inspection_name)
 
-        for inspection in self.inspect:
-            if inspection.name == inspection_name:
-                self.inspect.remove(inspection)
+        self.inspect[:] = [x for x in self.inspect if x.name != inspection_name]
 
     def get_functionary_key_id_list(self):
         """Returns list of functionary keyids from the layout.

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -4,7 +4,7 @@ artifacts."""
 import locale
 import logging
 import os
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from functools import cmp_to_key
 from itertools import combinations
 from os.path import exists, isdir, isfile, join, normpath
@@ -21,7 +21,7 @@ _HASH_ALGORITHM = "sha256"
 RESOLVER_FOR_URI_SCHEME = {}
 
 
-class Resolver(metaclass=ABCMeta):
+class Resolver(ABC):
     """Resolver interface and factory."""
 
     @classmethod

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -96,9 +96,9 @@ def unpack_rule(rule):
     if rule_len < 2 or rule_lower[0] not in ALL_RULES:
         raise securesystemslib.exceptions.FormatError(
             "Wrong rule format,"
-            " rules must start with one of '{0}' and specify a 'pattern' as"
+            " rules must start with one of '{}' and specify a 'pattern' as"
             " second element.\n"
-            "Got: \n\t'{1}'".format(", ".join(ALL_RULES), rule)
+            "Got: \n\t'{}'".format(", ".join(ALL_RULES), rule)
         )
 
     rule_type = rule_lower[0]
@@ -266,8 +266,8 @@ def pack_rule(
 
     if rule_type.lower() not in ALL_RULES:
         raise securesystemslib.exceptions.FormatError(
-            "'{0}' is not a valid "
-            "'type'.  Rule type must be one of:  {1} (case insensitive).".format(
+            "'{}' is not a valid "
+            "'type'.  Rule type must be one of:  {} (case insensitive).".format(
                 rule_type, ", ".join(ALL_RULES)
             )
         )

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -89,9 +89,7 @@ def unpack_rule(rule):
     # Create all lower rule copy to case insensitively parse out tokens whose
     # position we don't know yet
     # We keep the original rule to retain the non-token elements' case
-    rule_lower = []
-    for rule_elem in rule:
-        rule_lower.append(rule_elem.lower())
+    rule_lower = [rule_elem.lower() for rule_elem in rule]
 
     rule_len = len(rule)
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -221,13 +221,13 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
     stderr_fd, stderr_name = tempfile.mkstemp()
     try:
         with (
-            io.open(  # pylint: disable=unspecified-encoding
+            open(  # pylint: disable=unspecified-encoding
                 stdout_name, "r"
             ) as stdout_reader,
             os.fdopen(  # pylint: disable=unspecified-encoding
                 stdout_fd, "w"
             ) as stdout_writer,
-            io.open(  # pylint: disable=unspecified-encoding
+            open(  # pylint: disable=unspecified-encoding
                 stderr_name, "r"
             ) as stderr_reader,
             os.fdopen(stderr_fd, "w") as stderr_writer,

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -489,9 +489,8 @@ def verify_link_signature_thresholds(layout, steps_metadata):
                     break
 
                 # ... or the signing key is a subkey of an authorized key
-                if (
-                    authorized_key
-                    and link_keyid in authorized_key.get("subkeys", {}).keys()
+                if authorized_key and link_keyid in authorized_key.get(
+                    "subkeys", {}
                 ):
                     verification_key = authorized_key
                     break

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -314,9 +314,9 @@ def substitute_parameters(layout, parameter_dictionary):
     for step in layout.steps:
         new_material_rules = []
         for rule in step.expected_materials:
-            new_rule = []
-            for stanza in rule:
-                new_rule.append(stanza.format(**parameter_dictionary))
+            new_rule = [
+                stanza.format(**parameter_dictionary) for stanza in rule
+            ]
             new_material_rules.append(new_rule)
 
         new_product_rules = []
@@ -326,9 +326,10 @@ def substitute_parameters(layout, parameter_dictionary):
                 new_rule.append(stanza.format(**parameter_dictionary))
             new_product_rules.append(new_rule)
 
-        new_expected_command = []
-        for argv in step.expected_command:
-            new_expected_command.append(argv.format(**parameter_dictionary))
+        new_expected_command = [
+            argv.format(**parameter_dictionary)
+            for argv in step.expected_command
+        ]
 
         step.expected_command = new_expected_command
         step.expected_materials = new_material_rules
@@ -349,9 +350,9 @@ def substitute_parameters(layout, parameter_dictionary):
                 new_rule.append(stanza.format(**parameter_dictionary))
             new_product_rules.append(new_rule)
 
-        new_run = []
-        for argv in inspection.run:
-            new_run.append(argv.format(**parameter_dictionary))
+        new_run = [
+            argv.format(**parameter_dictionary) for argv in inspection.run
+        ]
 
         inspection.run = new_run
         inspection.expected_materials = new_material_rules
@@ -704,17 +705,16 @@ def verify_match_rule(rule_data, artifacts_queue, source_artifacts, links):
     # prefix before filtering with rule pattern (see filter part 2) to prevent
     # globbing in the prefix.
     if rule_data["source_prefix"]:
-        filtered_source_paths = []
         # Add trailing slash to source prefix if it does not exist
         normalized_source_prefix = os.path.join(
             rule_data["source_prefix"], ""
         ).replace("\\", "/")
 
-        for artifact_path in artifacts_queue:
-            if artifact_path.startswith(normalized_source_prefix):
-                filtered_source_paths.append(
-                    artifact_path[len(normalized_source_prefix) :]
-                )
+        filtered_source_paths = [
+            artifact_path[len(normalized_source_prefix) :]
+            for artifact_path in artifacts_queue
+            if artifact_path.startswith(normalized_source_prefix)
+        ]
 
     else:
         filtered_source_paths = artifacts_queue

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -396,7 +396,7 @@ def verify_metadata_signatures(metadata, keys_dict):
         )
 
     # Fail if any of the passed keys can't verify a signature on the Layout
-    for _, verify_key in keys_dict.items():
+    for verify_key in keys_dict.values():
         metadata.verify_signature(verify_key)
 
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -158,7 +158,7 @@ def load_links_for_layout(layout, link_dir_path):
                     metadata = Metadata.load(filepath)
                     links_per_step[keyid] = metadata
 
-                except IOError:
+                except OSError:
                     pass
 
         # This is only a preliminary threshold check, based on (authorized)

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -83,9 +83,9 @@ def _raise_on_bad_retval(return_value, command=None):
 
     msg = "Got non-{what} " + "return value '{}'".format(return_value)
     if command:
-        msg = "{0} from command '{1}'.".format(msg, command)
+        msg = "{} from command '{}'.".format(msg, command)
     else:
-        msg = "{0}.".format(msg)
+        msg = "{}.".format(msg)
 
     if not isinstance(return_value, int):
         raise BadReturnValueError(msg.format(what="int"))
@@ -166,8 +166,8 @@ def load_links_for_layout(layout, link_dir_path):
         # check is indispensable.
         if len(links_per_step) < step.threshold:
             raise in_toto.exceptions.LinkNotFoundError(
-                "Step '{0}' requires '{1}'"
-                " link metadata file(s), found '{2}'.".format(
+                "Step '{}' requires '{}'"
+                " link metadata file(s), found '{}'.".format(
                     step.name, step.threshold, len(links_per_step)
                 )
             )
@@ -1004,7 +1004,7 @@ def _get_artifact_rule_traceback():
     error message for RuleVerificationError.
 
     """
-    traceback_str = "Full trace for 'expected_{0}' of item '{1}':\n".format(
+    traceback_str = "Full trace for 'expected_{}' of item '{}':\n".format(
         RULE_TRACE["source_type"], RULE_TRACE["source_name"]
     )
 
@@ -1018,7 +1018,7 @@ def _get_artifact_rule_traceback():
         )
 
     for trace_entry in RULE_TRACE["trace"]:
-        traceback_str += "Queue after '{0}':\n".format(
+        traceback_str += "Queue after '{}':\n".format(
             " ".join(trace_entry["rule"])
         )
         traceback_str += "{}\n".format(trace_entry["queue"])
@@ -1265,7 +1265,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
         # Should we remove the check?
         if len(key_link_dict) < step.threshold:
             raise ThresholdVerificationError(
-                "Step '{0}' not performed"
+                "Step '{}' not performed"
                 " by enough functionaries!".format(step.name)
             )
 
@@ -1282,7 +1282,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
                 or reference_link.products != link.products
             ):
                 raise ThresholdVerificationError(
-                    "Links '{0}' and '{1}' have different"
+                    "Links '{}' and '{}' have different"
                     " artifacts!".format(
                         in_toto.models.link.FILENAME_FORMAT.format(
                             step_name=step.name, keyid=reference_keyid

--- a/tests/common.py
+++ b/tests/common.py
@@ -33,7 +33,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import patch
 
 from securesystemslib.signer import CryptoSigner

--- a/tests/common.py
+++ b/tests/common.py
@@ -50,13 +50,13 @@ class SignerStore:
     """CryptoSigner and public key (dict) store for sign/verify tests."""
 
     rsa: CryptoSigner = load_signer(PEMS / "rsa_private_unencrypted.pem")
-    rsa_pub: Dict[str, Any] = load_pubkey(PEMS / "rsa_public.pem")
+    rsa_pub: dict[str, Any] = load_pubkey(PEMS / "rsa_public.pem")
     ecdsa: CryptoSigner = load_signer(PEMS / "ecdsa_private_unencrypted.pem")
-    ecdsa_pub: Dict[str, Any] = load_pubkey(PEMS / "ecdsa_public.pem")
+    ecdsa_pub: dict[str, Any] = load_pubkey(PEMS / "ecdsa_public.pem")
     ed25519: CryptoSigner = load_signer(
         PEMS / "ed25519_private_unencrypted.pem"
     )
-    ed25519_pub: Dict[str, Any] = load_pubkey(PEMS / "ed25519_public.pem")
+    ed25519_pub: dict[str, Any] = load_pubkey(PEMS / "ed25519_public.pem")
 
 
 class TmpDirMixin:

--- a/tests/test_ostree_resolver.py
+++ b/tests/test_ostree_resolver.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding=utf-8
 
 # Copyright New York University and the in-toto contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -547,7 +547,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
                 ["foo", "bar", "#esc!", "subdir/foosub1", "subdir/foosub2"],
             ),
             (
-                ["\#esc*"],  # pylint: disable=W1401
+                ["\\#esc*"],
                 [
                     "foo",
                     "bar",
@@ -557,7 +557,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
                 ],
             ),
             (
-                ["*esc\!"],  # pylint: disable=W1401
+                ["*esc\\!"],
                 [
                     "foo",
                     "bar",

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding=utf-8
 
 # Copyright New York University and the in-toto contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -333,7 +333,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         """If the platform is Windows, raises an error that asks the user if
         developer mode is activated."""
         if os.name == "nt":
-            raise IOError(
+            raise OSError(
                 "Developer mode is required to work with symlinks on "
                 "Windows. Is it enabled?"
             )
@@ -357,7 +357,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
             # level as the link (target)
             try:
                 os.symlink(os.path.basename(pair[0]), pair[1])
-            except IOError:
+            except OSError:
                 TestRecordArtifactsAsDict._raise_win_dev_mode_error()
                 raise
 
@@ -403,7 +403,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         for link in links:
             try:
                 os.symlink("does/not/exist", link)
-            except IOError:
+            except OSError:
                 TestRecordArtifactsAsDict._raise_win_dev_mode_error()
                 raise
 
@@ -433,7 +433,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         try:
             # Link to subdir
             os.symlink("subdir", "subdir_link")
-        except IOError:
+        except OSError:
             TestRecordArtifactsAsDict._raise_win_dev_mode_error()
             raise
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -190,15 +190,11 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
 
         in_toto.settings.ARTIFACT_BASE_PATH = base_path
         artifacts_dict = record_artifacts_as_dict(["."])
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
         in_toto.settings.ARTIFACT_BASE_PATH = None
 
         artifacts_dict = record_artifacts_as_dict(["."], base_path=base_path)
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
 
     def test_base_path_is_parent_dir(self):
         """Test path of recorded artifacts and cd back with parent as base."""
@@ -210,15 +206,11 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
 
         in_toto.settings.ARTIFACT_BASE_PATH = base_path
         artifacts_dict = record_artifacts_as_dict(["."])
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
         in_toto.settings.ARTIFACT_BASE_PATH = None
 
         artifacts_dict = record_artifacts_as_dict(["."], base_path=base_path)
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
 
         os.chdir(self.test_dir)
 
@@ -237,9 +229,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         artifacts_dict = record_artifacts_as_dict(
             ["."], lstrip_paths=lstrip_paths
         )
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
 
     def test_lstrip_paths_substring_prefix_directory(self):
         lstrip_paths = ["subdir/subsubdir/", "subdir/"]
@@ -271,9 +261,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         artifacts_dict = record_artifacts_as_dict(
             ["."], lstrip_paths=lstrip_paths
         )
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
 
     def test_lstrip_paths_valid_prefix_file(self):
         lstrip_paths = ["subdir/subsubdir/"]
@@ -281,9 +269,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         artifacts_dict = record_artifacts_as_dict(
             ["./subdir/subsubdir/foosubsub"], lstrip_paths=lstrip_paths
         )
-        self.assertListEqual(
-            sorted(list(artifacts_dict.keys())), expected_artifacts
-        )
+        self.assertListEqual(sorted(artifacts_dict.keys()), expected_artifacts)
 
     def test_lstrip_paths_non_unique_key_file(self):
         os.mkdir("subdir/subsubdir_new")
@@ -315,7 +301,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
                 ["./ಠ/"], lstrip_paths=lstrip_paths
             )
             self.assertListEqual(
-                sorted(list(artifacts_dict.keys())), expected_artifacts
+                sorted(artifacts_dict.keys()), expected_artifacts
             )
             os.remove(path)
             os.rmdir("ಠ")
@@ -339,7 +325,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
             _check_hash_dict(val)
 
         self.assertListEqual(
-            sorted(list(artifacts_dict.keys())),
+            sorted(artifacts_dict.keys()),
             sorted(self.full_file_path_list),
         )
 
@@ -385,7 +371,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
 
             # Test that everything was recorded ...
             self.assertListEqual(
-                sorted(list(artifacts_dict.keys())),
+                sorted(artifacts_dict.keys()),
                 sorted(
                     self.full_file_path_list + [pair[1] for pair in link_pairs]
                 ),
@@ -431,7 +417,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
 
             # Test only the files were recorded ...
             self.assertListEqual(
-                sorted(list(artifacts_dict.keys())),
+                sorted(artifacts_dict.keys()),
                 sorted(self.full_file_path_list),
             )
 
@@ -464,7 +450,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         )
         # Test that all files were recorded including files in linked subdir ...
         self.assertListEqual(
-            sorted(list(artifacts_dict.keys())),
+            sorted(artifacts_dict.keys()),
             sorted(self.full_file_path_list + [pair[1] for pair in link_pairs]),
         )
 
@@ -477,7 +463,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
         # Record with follow_symlink_dirs FALSE (default)
         artifacts_dict = record_artifacts_as_dict(["."])
         self.assertListEqual(
-            sorted(list(artifacts_dict.keys())),
+            sorted(artifacts_dict.keys()),
             sorted(self.full_file_path_list),
         )
 
@@ -491,7 +477,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
             _check_hash_dict(val)
 
         self.assertListEqual(
-            sorted(list(artifacts_dict.keys())),
+            sorted(artifacts_dict.keys()),
             sorted(
                 [
                     "foo",
@@ -605,8 +591,8 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):
             )
 
             self.assertTrue(
-                sorted(list(artifacts1))
-                == sorted(list(artifacts2))
+                sorted(artifacts1)
+                == sorted(artifacts2)
                 == sorted(expected_results)
             )
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -156,7 +156,7 @@ class TestRunAllInspections(unittest.TestCase, TmpDirMixin):
         link = Metablock.load("touch-bar.link")
         self.assertListEqual(list(link.signed.materials.keys()), ["foo"])
         self.assertListEqual(
-            sorted(list(link.signed.products.keys())), sorted(["foo", "bar"])
+            sorted(link.signed.products.keys()), sorted(["foo", "bar"])
         )
 
         in_toto.settings.ARTIFACT_BASE_PATH = None


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Apply ruff rules that seem to improve readability or maintainability. That's debatable of course, which is why I have pushed a commit per rule, so that rules can be disabled.

I did not try to enforce ruff rules, since pylint is currently the linter of choice.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature