### PR TITLE
isort → ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,8 @@ updates:
         - "bandit"
         - "black"
         - "coverage"
-        - "isort"
         - "pylint"
+        - "ruff"
     dependencies:
       # Python (developer) runtime dependencies. Also any new dependencies not
       # caught by earlier groups

--- a/doc/source/_ext/argparse_epilog.py
+++ b/doc/source/_ext/argparse_epilog.py
@@ -5,8 +5,6 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
 from docutils.statemachine import StringList
 
-from in_toto import in_toto_run
-
 
 class ArgparseUsageEpilog(Directive):
     """Sphinx directive to modify argparse epilog to render nicely.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-import sphinx_rtd_theme
+import sphinx_rtd_theme  # noqa: F401
 
 # sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,6 @@ check-quote-consistency="yes"
 extend-select = [
     "I",
 ]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,8 @@ notes="TODO"
 
 [tool.pylint.STRING]
 check-quote-consistency="yes"
+
+[tool.ruff.lint]
+extend-select = [
+    "I",
+]

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -5,4 +5,4 @@
 pylint==3.3.4
 bandit==1.8.3
 black==25.1.0
-isort==6.0.1
+ruff==0.9.10

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
 
 commands =
     black --check --diff .
-    isort --check --diff .
+    ruff check --show-fixes
 
     pylint in_toto tests
 


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Start moving to ruff by replacing isort with ruff (`I` rules).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature