### PR TITLE
bandit → ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     test-and-lint-dependencies:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:
-        - "bandit"
         - "black"
         - "coverage"
         - "pylint"

--- a/doc/source/_ext/argparse_epilog.py
+++ b/doc/source/_ext/argparse_epilog.py
@@ -59,11 +59,13 @@ class ArgparseUsageEpilog(Directive):
 
         # Parse and mark-up epilog
         epilog_lines = parser.epilog.split("\n")
-        assert epilog_lines, "moot '.. argparse-epilog::' with empty 'epilog'"
+        assert (  # noqa: S101
+            epilog_lines
+        ), "moot '.. argparse-epilog::' with empty 'epilog'"
 
         # The first line is expected to be the title
         title = epilog_lines.pop(0)
-        assert title == "EXAMPLE USAGE", "missing 'epilog' title"
+        assert title == "EXAMPLE USAGE", "missing 'epilog' title"  # noqa: S101
         title_node = nodes.title(text=title.title())
 
         # Copy remaining lines (body) as they are and ...

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -31,7 +31,7 @@ import glob
 import io
 import logging
 import os
-import subprocess  # nosec
+import subprocess
 import sys
 import tempfile
 import time
@@ -253,7 +253,7 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
                 streams["err"] += stderr_part
 
             # Start child process, writing its standard streams to temporary files
-            proc = subprocess.Popen(  # pylint: disable=consider-using-with  # nosec
+            proc = subprocess.Popen(  # pylint: disable=consider-using-with  # noqa: S603
                 cmd,
                 stdout=stdout_writer,
                 stderr=stderr_writer,
@@ -332,9 +332,9 @@ def execute_link(link_cmd_args, record_streams, timeout):
         )
 
     else:
-        process = subprocess.run(
+        process = subprocess.run(  # noqa: S603
             link_cmd_args,
-            check=False,  # nosec
+            check=False,
             timeout=timeout,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,11 @@ check-quote-consistency="yes"
 
 [tool.ruff.lint]
 extend-select = [
+    "S",
     "I",
+]
+ignore = [
+    "S101",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,6 @@ include = [
 [tool.black]
 line-length=80
 
-[tool.isort]
-profile="black"
-line_length=80
-known_first_party = ["in_toto"]
-
 # Minimal pylint configuration file for Secure Systems Lab Python Style Guide:
 #     https://github.com/secure-systems-lab/code-style-guidelines
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,3 +138,4 @@ extend-select = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
+"tests/**" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,6 @@ extend-select = [
     "S",
     "I",
 ]
-ignore = [
-    "S101",
-]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -3,6 +3,5 @@
 
 # Test tools for linting and test coverage measurement
 pylint==3.3.4
-bandit==1.8.3
 black==25.1.0
 ruff==0.9.10

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,3 @@ commands =
     ruff check --show-fixes
 
     pylint in_toto tests
-
-    # Run bandit, a security linter from OpenStack Security
-    # Exclude files that need special treatment and are tested below
-    bandit -r in_toto


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Continue moving to ruff by replacing bandit with ruff (`S` rules).

Rules appear in the same order as in the ruff [Rules](https://docs.astral.sh/ruff/rules/) documentation:
```toml
[tool.ruff.lint]
extend-select = [
    "S",
    "I",
]

```
**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature