### PR TITLE
black → ruff format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# Ignore initial black and isort commits
+# Ignore initial black, isort and ruff commits
 #
 # configure globally, e.g. with:
 #    git config blame.ignoreRevsFile .git-blame-ignore-revs
@@ -6,3 +6,4 @@
 # for details see
 #    https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html
 614113e2a3932064b738702a630a5a8587babdc5
+ce2eafd1a8d6e19abb07e913944f5d5472a736f1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     test-and-lint-dependencies:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:
-        - "black"
         - "coverage"
         - "pylint"
         - "ruff"

--- a/in_toto/__init__.py
+++ b/in_toto/__init__.py
@@ -5,6 +5,7 @@
 Configure base logger for in_toto (see in_toto.log for details).
 
 """
+
 import in_toto.log
 
 # in-toto version

--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -28,6 +28,7 @@
   ```
 
 """
+
 import sys
 
 from in_toto.settings import LINK_CMD_EXEC_TIMEOUT
@@ -197,9 +198,7 @@ def title_case_action_groups(parser):
     which title-cases default action groups only.
 
     """
-    for (
-        action_group
-    ) in parser._action_groups:  # pylint: disable=protected-access
+    for action_group in parser._action_groups:  # pylint: disable=protected-access
         action_group.title = action_group.title.title()
 
 
@@ -216,9 +215,7 @@ def sort_action_groups(parser, title_order=None):
         ]
 
     action_group_dict = {}
-    for (
-        action_group
-    ) in parser._action_groups:  # pylint: disable=protected-access
+    for action_group in parser._action_groups:  # pylint: disable=protected-access
         action_group_dict[action_group.title] = action_group
 
     ordered_action_groups = [action_group_dict[title] for title in title_order]

--- a/in_toto/formats.py
+++ b/in_toto/formats.py
@@ -19,6 +19,7 @@
   Helpers to validate API inputs and metadata model objects.
 
 """
+
 from copy import deepcopy
 from re import fullmatch
 

--- a/in_toto/in_toto_match_products.py
+++ b/in_toto/in_toto_match_products.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI to check local artifacts."""
+
 import argparse
 import logging
 import sys

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -25,6 +25,7 @@
   0 if no exception occurred
 
 """
+
 import argparse
 import logging
 import sys
@@ -75,9 +76,7 @@ Generate unsigned link metadata 'foo.link' for the activity of creating file
   # 'foo.<mykey keyid prefix>.link'.
   in-toto-sign -k mykey -f foo.link
 
-""".format(
-        prog=parser.prog
-    )
+""".format(prog=parser.prog)
 
     named_args = parser.add_argument_group("required named arguments")
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -26,6 +26,7 @@
   0 if no exception occurred
 
 """
+
 import argparse
 import logging
 import sys
@@ -103,9 +104,7 @@ file to the target directory (on stop).
   {prog} start -n edit-files --signing-key path/to/key_file -m .
   {prog} stop -d path/to/target/dir -n edit-files --signing-key path/to/key_file -p .
 
-""".format(
-        prog=parser.prog
-    )
+""".format(prog=parser.prog)
 
     # The subparsers inherit the arguments from the parent parser
     parent_parser = argparse.ArgumentParser(add_help=False)

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -131,9 +131,7 @@ e.g. 'document.pdf'.
          --lstrip-paths /tmp/my/review/docs/ -x
 
 
-""".format(
-        prog=parser.prog
-    )
+""".format(prog=parser.prog)
 
     named_args = parser.add_argument_group("required named arguments")
 

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -22,6 +22,7 @@
   or to verify its signatures.
 
 """
+
 import argparse
 import logging
 import sys
@@ -268,9 +269,7 @@ Verify layout with a gpg key identified by keyid '...439F3C2'.
   {prog} -f root.layout --verify \\
       --gpg 3BF8135765A07E21BD12BF89A5627F6BF439F3C2
 
-""".format(
-        prog=parser.prog
-    )
+""".format(prog=parser.prog)
 
     named_args = parser.add_argument_group("required named arguments")
 

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -25,6 +25,7 @@
   0 if no exception occurred (verification passed)
 
 """
+
 import argparse
 import logging
 import sys
@@ -117,9 +118,7 @@ for which the public part can be found in the GPG keyring at '~/.gnupg'.
       --gpg-home ~/.gnupg
 
 
-""".format(
-        prog=parser.prog
-    )
+""".format(prog=parser.prog)
 
     named_args = parser.add_argument_group("required named arguments")
 

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -69,6 +69,7 @@
   ```
 
 """
+
 import logging
 import sys
 
@@ -100,9 +101,7 @@ class InTotoLogger(_LOGGER_CLASS):
         return super().error(msg, *args, exc_info=show_stacktrace)
 
     # Allow non snake_case function name for consistency with logging library
-    def setLevelVerboseOrQuiet(
-        self, verbose, quiet
-    ):  # pylint: disable=invalid-name
+    def setLevelVerboseOrQuiet(self, verbose, quiet):  # pylint: disable=invalid-name
         """Convenience method to set the logger's verbosity level based on the
         passed booleans verbose and quiet (useful for cli tools)."""
         if verbose:

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -32,6 +32,7 @@
   Inspection:
       represents a hook that is run at verification
 """
+
 import json
 import shlex
 from datetime import datetime

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -20,6 +20,7 @@
   syntax.
 
 """
+
 import securesystemslib.exceptions
 import securesystemslib.formats
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -27,6 +27,7 @@
     - Return Metadata containing a Link object which can be can be signed
       and stored to disk
 """
+
 import glob
 import io
 import logging

--- a/in_toto/settings.py
+++ b/in_toto/settings.py
@@ -26,6 +26,7 @@
      in_toto.settings.ARTIFACT_BASE_PATH = "/home/user/project"
      ```
 """
+
 # The debug setting is used to set to the in-toto base logger to logging.DEBUG
 DEBUG = False
 

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -955,8 +955,7 @@ def verify_disallow_rule(rule_pattern, artifacts_queue):
 
     if filtered_artifacts:
         raise RuleVerificationError(
-            "'DISALLOW {}' matched the following "
-            "artifacts: {}\n{}".format(
+            "'DISALLOW {}' matched the following artifacts: {}\n{}".format(
                 rule_pattern, filtered_artifacts, _get_artifact_rule_traceback()
             )
         )
@@ -1265,8 +1264,9 @@ def verify_threshold_constraints(layout, chain_link_dict):
         # Should we remove the check?
         if len(key_link_dict) < step.threshold:
             raise ThresholdVerificationError(
-                "Step '{}' not performed"
-                " by enough functionaries!".format(step.name)
+                "Step '{}' not performed by enough functionaries!".format(
+                    step.name
+                )
             )
 
         # Take a reference link (e.g. the first in the step_link_dict)
@@ -1282,8 +1282,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
                 or reference_link.products != link.products
             ):
                 raise ThresholdVerificationError(
-                    "Links '{}' and '{}' have different"
-                    " artifacts!".format(
+                    "Links '{}' and '{}' have different artifacts!".format(
                         in_toto.models.link.FILENAME_FORMAT.format(
                             step_name=step.name, keyid=reference_keyid
                         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ include = [
     "/requirements*.txt",
 ]
 
-[tool.black]
-line-length=80
-
 # Minimal pylint configuration file for Secure Systems Lab Python Style Guide:
 #     https://github.com/secure-systems-lab/code-style-guidelines
 #
@@ -124,6 +121,9 @@ notes="TODO"
 
 [tool.pylint.STRING]
 check-quote-consistency="yes"
+
+[tool.ruff]
+line-length = 80
 
 [tool.ruff.lint]
 extend-select = [

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -3,5 +3,4 @@
 
 # Test tools for linting and test coverage measurement
 pylint==3.3.4
-black==25.1.0
 ruff==0.9.10

--- a/tests/common.py
+++ b/tests/common.py
@@ -26,6 +26,7 @@
   `python tests/runtests.py`.
 
 """
+
 import inspect
 import os
 import shutil

--- a/tests/models/test_inspection.py
+++ b/tests/models/test_inspection.py
@@ -22,7 +22,6 @@
 """
 # pylint: disable=protected-access
 
-
 import unittest
 
 import securesystemslib.exceptions

--- a/tests/models/test_metadata.py
+++ b/tests/models/test_metadata.py
@@ -22,7 +22,6 @@
 """
 # pylint: disable=protected-access
 
-
 import os
 import unittest
 

--- a/tests/models/test_step.py
+++ b/tests/models/test_step.py
@@ -22,7 +22,6 @@
 """
 # pylint: disable=protected-access
 
-
 import unittest
 
 import securesystemslib.exceptions

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -6,7 +6,6 @@
 # Copyright New York University and the in-toto contributors
 # SPDX-License-Identifier: Apache-2.0
 
-
 import os
 import tempfile
 import unittest

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -20,6 +20,7 @@
   Test in_toto_mock command line tool.
 
 """
+
 import logging
 import os
 import unittest

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -18,6 +18,7 @@
   Test in_toto/log.py
 
 """
+
 import logging
 import unittest
 

--- a/tests/test_param_substitution.py
+++ b/tests/test_param_substitution.py
@@ -22,6 +22,7 @@
   layer is to be removed.
 
 """
+
 import unittest
 
 from securesystemslib.exceptions import FormatError

--- a/tests/test_rulelib.py
+++ b/tests/test_rulelib.py
@@ -21,6 +21,7 @@
   Test artifact rule packing and unpacking.
 
 """
+
 import unittest
 
 import securesystemslib.exceptions

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1377,7 +1377,7 @@ class TestInTotoMatchProducts(TmpDirMixin, unittest.TestCase):
                     "lstrip_paths": [
                         # NOTE: normalize lstrip path to match normalized artifact path
                         # (see in-toto/in-toto#565)
-                        f'{Path("baz").absolute().parent}/'.replace("\\", "/")
+                        f"{Path('baz').absolute().parent}/".replace("\\", "/")
                     ],
                 },
                 ({"foo", "bar"}, set(), set()),

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,7 @@
   Test in_toto/settings.py
 
 """
+
 import unittest
 
 import in_toto.settings

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     -rrequirements-lint.txt
 
 commands =
-    black --check --diff .
     ruff check --show-fixes
+    ruff format --diff
 
     pylint in_toto tests


### PR DESCRIPTION
**Fixes issue #**:

Fixes #839.

**Description of the changes being introduced by the pull request**:

Replace black with ruff format. I have not modified the current line length: 80 characters.
```toml
[tool.ruff]
line-length = 80
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature