### PR TITLE
pylint → ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:
         - "coverage"
-        - "pylint"
         - "ruff"
     dependencies:
       # Python (developer) runtime dependencies. Also any new dependencies not

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,8 +14,7 @@ Pull requests must be submitted to the `develop` branch where they undergo
 review and automated testing, including, but not limited to:
 * Unit and build testing via [Tox](https://tox.readthedocs.io/en/latest/) on
   [GitHub Actions](https://github.com/in-toto/in-toto/actions)
-* Static code analysis via [Pylint](https://www.pylint.org/) and
-  [Bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit)
+* Static code analysis via [ruff](https://astral.sh/ruff)
 * Checks for *Signed-off-by* commits via
   [Probot: DCO](https://probot.github.io/apps/dco/)
 * Review by one or more [maintainers](MAINTAINERS.txt)

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -39,5 +39,5 @@ class PrefixError(Error):
     """Indicates that there is an error because of the prefixes passed."""
 
 
-class InvalidMetadata(Error):
+class InvalidMetadata(Error):  # noqa: N818
     """Indicates that the metadata is not valid."""

--- a/in_toto/log.py
+++ b/in_toto/log.py
@@ -101,7 +101,7 @@ class InTotoLogger(_LOGGER_CLASS):
         return super().error(msg, *args, exc_info=show_stacktrace)
 
     # Allow non snake_case function name for consistency with logging library
-    def setLevelVerboseOrQuiet(self, verbose, quiet):  # pylint: disable=invalid-name
+    def setLevelVerboseOrQuiet(self, verbose, quiet):  # noqa: N802
         """Convenience method to set the logger's verbosity level based on the
         passed booleans verbose and quiet (useful for cli tools)."""
         if verbose:

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -83,7 +83,7 @@ class Metadata:
           A Metadata containing a Link or Layout object.
 
         """
-        with open(path, "r", encoding="utf8") as fp:
+        with open(path, encoding="utf8") as fp:
             data = json.load(fp)
 
         return cls.from_dict(data)

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -234,7 +234,7 @@ class OSTreeResolver(Resolver):
 
         ref_path = os.path.join("refs", "heads", path)
 
-        with open(ref_path, "r") as ref:  # pylint: disable=unspecified-encoding
+        with open(ref_path) as ref:  # pylint: disable=unspecified-encoding
             ref_contents = ref.read()
         ref_contents = ref_contents.strip("\n")
 

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -149,13 +149,13 @@ class FileResolver(Resolver):
 
         for path in uris:
             # Remove scheme prefix, but preserver to re-add later (see _mangle)
-            path, prefix = self._strip_scheme_prefix(path)
+            path, prefix = self._strip_scheme_prefix(path)  # noqa: PLW2901
 
             # Normalize URI before filtering and returning them
             # FIXME: Is this expected behavior? Does this make exclude patterns
             # with slashes platform-dependent? Check how 'gitwildmatch' treats
             # dots and slashes!
-            path = normpath(path)
+            path = normpath(path)  # noqa: PLW2901
 
             if self._exclude(path):
                 continue
@@ -258,7 +258,7 @@ class OSTreeResolver(Resolver):
 
         for path in uris:
             # Remove scheme prefix, but preserver to re-add later
-            path = self._strip_scheme_prefix(path)
+            path = self._strip_scheme_prefix(path)  # noqa: PLW2901
             hashes[self._add_scheme_prefix(path)] = self._hash(path)
 
         # Change back to original current working dir
@@ -357,7 +357,7 @@ class DirectoryResolver(Resolver):
         hashes = {}
 
         for path in uris:
-            path = self._strip_scheme_prefix(path)
+            path = self._strip_scheme_prefix(path)  # noqa: PLW2901
 
             if not os.path.isdir(path):
                 raise ValueError(f"path '{path}' is not a directory")

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -223,13 +223,13 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
     try:
         with (
             open(  # pylint: disable=unspecified-encoding
-                stdout_name, "r"
+                stdout_name
             ) as stdout_reader,
             os.fdopen(  # pylint: disable=unspecified-encoding
                 stdout_fd, "w"
             ) as stdout_writer,
             open(  # pylint: disable=unspecified-encoding
-                stderr_name, "r"
+                stderr_name
             ) as stderr_reader,
             os.fdopen(stderr_fd, "w") as stderr_writer,
         ):

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -1042,15 +1042,14 @@ def in_toto_record_stop(
 
     if signer:
         LOG.info(
-            "Updating signature with signer '{:.8}...'...".format(
-                signer.public_key.keyid
-            )
+            "Updating signature with signer '%.8s...'...",
+            signer.public_key.keyid,
         )
 
     else:  # gpg_keyid or gpg_use_default
         # In both cases we use the keyid we got from verifying the preliminary
         # link signature above.
-        LOG.info("Updating signature with gpg key '{:.8}...'...".format(keyid))
+        LOG.info("Updating signature with gpg key '%.8s...'...", keyid)
         signer = GPGSigner(keyid=keyid, homedir=gpg_home)
 
     link_metadata.create_signature(signer)

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -1270,7 +1270,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
             )
 
         # Take a reference link (e.g. the first in the step_link_dict)
-        reference_keyid = list(key_link_dict.keys())[0]
+        reference_keyid = next(iter(key_link_dict.keys()))
         reference_link = key_link_dict[reference_keyid]
 
         # Iterate over all links to compare their properties with a reference_link
@@ -1334,7 +1334,7 @@ def reduce_chain_links(chain_link_dict):
         # Extract the key_link_dict for this step from the passed chain_link_dict
         # take one exemplary link (e.g. the first in the step_link_dict)
         # form the reduced_chain_link_dict to return
-        reduced_chain_link_dict[step_name] = list(key_link_dict.values())[0]
+        reduced_chain_link_dict[step_name] = next(iter(key_link_dict.values()))
 
     return reduced_chain_link_dict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,3 +127,4 @@ ignore = [
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**" = ["S101"]
+"doc/**" = ["A"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ ignore = [
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**" = ["S101", "N"]
-"doc/**" = ["A"]
+"doc/**" = ["A", "RUF012"]
 
 [tool.ruff.lint.flake8-comprehensions]
 allow-dict-calls-with-keyword-arguments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,63 +72,55 @@ include = [
     "/requirements*.txt",
 ]
 
-# Minimal pylint configuration file for Secure Systems Lab Python Style Guide:
-#     https://github.com/secure-systems-lab/code-style-guidelines
-#
-# Based on Google Python Style Guide pylintrc and pylint defaults:
-#     https://google.github.io/styleguide/pylintrc
-#     http://pylint.pycqa.org/en/latest/technical_reference/features.html
-#
-[tool.pylint.message_control]
-# Disable the message, report, category or checker with the given id(s).
-# NOTE: To keep this config as short as possible we only disable checks that
-# are currently in conflict with our code. If new code displeases the linter
-# (for good reasons) consider updating this config file, or disable checks with.
-disable=[
-  "fixme",
-  "too-few-public-methods",
-  "too-many-arguments",
-  "too-many-positional-arguments",
-  "format",
-  "duplicate-code",
-  "consider-using-f-string"
-]
-
-[tool.pylint.basic]
-good-names = ["i","j","k","v","e","f","fn","fp","_type","_"]
-# Regexes for allowed names are copied from the Google pylintrc
-# NOTE: Pylint captures regex name groups such as 'snake_case' or 'camel_case'.
-# If there are multiple groups it enforces the prevalent naming style inside
-# each modules. Names in the exempt capturing group are ignored.
-function-rgx="^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$"
-method-rgx="(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$"
-argument-rgx="^[a-z][a-z0-9_]*$"
-attr-rgx="^_{0,2}[a-z][a-z0-9_]*$"
-class-attribute-rgx="^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$"
-class-rgx="^_?[A-Z][a-zA-Z0-9]*$"
-const-rgx="^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$"
-inlinevar-rgx="^[a-z][a-z0-9_]*$"
-module-rgx="^(_?[a-z][a-z0-9_]*|__init__)$"
-no-docstring-rgx="(__.*__|main|test.*|.*test|.*Test)$"
-variable-rgx="^[a-z][a-z0-9_]*$"
-docstring-min-length=10
-
-[tool.pylint.logging]
-logging-format-style="old"
-
-[tool.pylint.miscellaneous]
-notes="TODO"
-
-[tool.pylint.STRING]
-check-quote-consistency="yes"
-
 [tool.ruff]
 line-length = 80
 
 [tool.ruff.lint]
 extend-select = [
     "S",
+    "B",
+    "A",
+    "C4",
+    "ISC",
+    "LOG",
+    "G",
+    "PIE",
+    "PYI",
+    "Q",
+    "SLOT",
+    "FLY",
     "I",
+    "N",
+    "PERF",
+    "PGH",
+    "PLE",
+    "PLR",
+    "PLW",
+    "UP",
+    "FURB",
+    "RUF",
+]
+ignore = [
+    "PLR0912",  # too-many-branches
+    "PLR0913",  # too-many-arguments
+    "PLR0915",  # too-many-statements
+    "PLR0917",  # too-many-positional-arguments
+    "PLR2004",  # magic-value-comparison
+    "UP032",    # f-string
+    "UP038",    # https://github.com/astral-sh/ruff/issues/7871
+    # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ extend-select = [
     "RUF",
 ]
 ignore = [
+    "B904",     # raise-without-from-inside-except
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR0915",  # too-many-statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ignore = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
-"tests/**" = ["S101"]
+"tests/**" = ["S101", "N"]
 "doc/**" = ["A"]
 
 [tool.ruff.lint.flake8-comprehensions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,6 @@ ignore = [
 "__init__.py" = ["F401"]
 "tests/**" = ["S101"]
 "doc/**" = ["A"]
+
+[tool.ruff.lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ extend-select = [
 ]
 ignore = [
     "B904",     # raise-without-from-inside-except
+    "PERF203",  # try-except-in-loop
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR0915",  # too-many-statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ ignore = [
     "PLR2004",  # magic-value-comparison
     "UP032",    # f-string
     "UP038",    # https://github.com/astral-sh/ruff/issues/7871
+    "RUF005",   # collection-literal-concatenation
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",
     "E111",

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -2,5 +2,4 @@
 -r requirements-pinned.txt
 
 # Test tools for linting and test coverage measurement
-pylint==3.3.4
 ruff==0.9.10

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -641,11 +641,11 @@ class TestSubprocess(unittest.TestCase):
         stderr_fd, stderr_fn = tempfile.mkstemp()
         with (
             open(  # pylint: disable=unspecified-encoding
-                stdout_fn, "r"
+                stdout_fn
             ) as fake_stdout_reader,
             os.fdopen(stdout_fd, "w") as fake_stdout_writer,
             open(  # pylint: disable=unspecified-encoding
-                stderr_fn, "r"
+                stderr_fn
             ) as fake_stderr_reader,
             os.fdopen(stderr_fd, "w") as fake_stderr_writer,
         ):
@@ -1157,7 +1157,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
         in_toto_record_stop(self.step_name, [], signer=self.signer)
         with self.assertRaises(IOError):
             # pylint: disable-next=consider-using-with
-            open(self.link_name_unfinished, "r", encoding="utf8")
+            open(self.link_name_unfinished, encoding="utf8")
         self.assertTrue(os.path.isfile(self.link_name))
         os.remove(self.link_name)
 
@@ -1167,7 +1167,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
             in_toto_record_stop(self.step_name, [], signer=self.signer)
         with self.assertRaises(IOError):
             # pylint: disable-next=consider-using-with
-            open(self.link_name, "r", encoding="utf8")
+            open(self.link_name, encoding="utf8")
 
     def test_wrong_signature_in_unfinished_metadata(self):
         """Test record stop exits on wrong signature, no link recorded."""
@@ -1183,7 +1183,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
             in_toto_record_stop(self.step_name, [], signer=self.signer2)
         with self.assertRaises(IOError):
             # pylint: disable-next=consider-using-with
-            open(self.link_name, "r", encoding="utf8")
+            open(self.link_name, encoding="utf8")
         os.rename(changed_link_name, link_name)
         os.remove(self.link_name_unfinished)
 

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -435,7 +435,6 @@ class TestVerifyRule(unittest.TestCase):
             # A pattern is passed, which should be interpreted *literally*
             ["*", {"*"}, False],
             ["*", {"foo"}, True],
-            #
         ]
 
         for i, test_data in enumerate(test_cases):

--- a/tox.ini
+++ b/tox.ini
@@ -40,5 +40,3 @@ deps =
 commands =
     ruff check --show-fixes
     ruff format --diff
-
-    pylint in_toto tests


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Replace Pylint with ruff.

Note that I have **not** enabled all rules yet. The ruff rules equivalent to some Pylint rules are obviously missing, as can be seen by the remaining occurrences of `# pylint: disable`. I'm leaving these `# pylint: disable` comments for now, they will help identify the missing ruff rules and enable them later.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature