### PR TITLE
Enforce ruff flake8-blind-except rules (BLE)

### DIFF
--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -132,7 +132,7 @@ def main():
     try:
         in_toto.runlib.in_toto_mock(args.name, args.link_cmd, args.use_dsse)
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error("(in-toto-mock) %s: %s", type(e).__name__, e)
         sys.exit(1)
 

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -289,7 +289,7 @@ def main():
                 signer=signer,
             )
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error(
             "(in-toto-record %s) %s: %s", args.command, type(e).__name__, e
         )

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -314,7 +314,7 @@ def main():
             signer=signer,
         )
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error("(in-toto-run) %s: %s", type(e).__name__, e)
         sys.exit(1)
 

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -135,7 +135,7 @@ def _sign_and_dump_metadata(metadata, args):
         metadata.dump(out_path)
         sys.exit(0)
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error("The following error occurred while signing: %s", e)
         sys.exit(2)
 
@@ -179,7 +179,7 @@ def _verify_metadata(metadata, args):
         LOG.error("Signature verification failed: %s", e)
         sys.exit(1)
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error(
             "The following error occurred while verifying signatures: %s", e
         )
@@ -205,7 +205,7 @@ def _load_metadata(file_path):
     try:
         return Metadata.load(file_path)
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error(
             "The following error occurred while loading the file '%s': %s",
             file_path,

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -244,7 +244,7 @@ def main():
             inspect_timeout=args.inspect_timeout,
         )
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except Exception as e:  # noqa: BLE001
         LOG.error("(in-toto-verify) %s: %s", type(e).__name__, e)
         sys.exit(1)
 

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -418,7 +418,7 @@ class Layout(Signable):
             parse(self.expires)
             _check_iso8601(self.expires)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             raise securesystemslib.exceptions.FormatError(
                 "Malformed date string in layout. Exception: {}".format(e)
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ line-length = 80
 [tool.ruff.lint]
 extend-select = [
     "S",
+    "BLE",
     "B",
     "A",
     "C4",


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

The error message is:
```
BLE001 Do not catch blind exception: `Exception`
```

Silence by changing `# pylint: disable=broad-exception-caught` into `# noqa: BLE001`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


