### PR TITLE
Enforce ruff/flake8-datetimez rules (DTZ)

### DIFF
--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -171,7 +171,7 @@ class Layout(Signable):
         _check_int(years)
 
         self.expires = (
-            datetime.today()
+            datetime.today()  # noqa: DTZ002
             + relativedelta(days=days, months=months, years=years)
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ extend-select = [
     "B",
     "A",
     "C4",
+    "DTZ",
     "ISC",
     "LOG",
     "G",

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -972,7 +972,7 @@ class TestInTotoVerify(unittest.TestCase, TmpDirMixin):
         # dump expired layout
         layout = copy.deepcopy(layout_template)
         layout.signed.expires = (
-            datetime.today() + relativedelta(months=-1)
+            datetime.today() + relativedelta(months=-1)  # noqa: DTZ002
         ).strftime("%Y-%m-%dT%H:%M:%SZ")
         layout.create_signature(alice)
         layout.dump(cls.layout_expired_path)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

```
DTZ002 `datetime.datetime.today()` used
```

Not sure about the fix: `datetime.today()` → `datetime.now(tz=datetime.timezone.utc)`. Do we want naive "local time"? Should we change to UTC, or perhaps better local time with time zone?

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


