### PR TITLE
Enforce ruff/flake8-simplify rules (SIM)

### DIFF
--- a/doc/source/_ext/argparse_epilog.py
+++ b/doc/source/_ext/argparse_epilog.py
@@ -76,12 +76,11 @@ class ArgparseUsageEpilog(Directive):
 
             # ... inject ReST markup for code snippets, if the current line is empty
             # and there is a next line, which starts with two spaces.
-            if line.strip() == "":
-                if epilog_lines_len > idx + 1:
-                    next_line = epilog_lines[idx + 1]
-                    if next_line.startswith("  "):
-                        epilog_lines_dest.append(".. code-block:: sh")
-                        epilog_lines_dest.append("")
+            if line.strip() == "" and epilog_lines_len > idx + 1:
+                next_line = epilog_lines[idx + 1]
+                if next_line.startswith("  "):
+                    epilog_lines_dest.append(".. code-block:: sh")
+                    epilog_lines_dest.append("")
 
         # Parse epilog body as ReST
         text_node = nodes.paragraph()

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -64,9 +64,8 @@ class FileResolver(Resolver):
         if not lstrip_paths:
             lstrip_paths = []
 
-        if base_path is not None:
-            if not isinstance(base_path, str):
-                raise ValueError("'base_path' must be string")
+        if base_path is not None and not isinstance(base_path, str):
+            raise ValueError("'base_path' must be string")
 
         for name, val in [
             ("exclude_patterns", exclude_patterns),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ extend-select = [
     "PYI",
     "Q",
     "SLF",
+    "SIM",
     "SLOT",
     "FLY",
     "I",

--- a/tests/test_in_toto_mock.py
+++ b/tests/test_in_toto_mock.py
@@ -21,6 +21,7 @@
 
 """
 
+import contextlib
 import logging
 import os
 import unittest
@@ -63,10 +64,8 @@ class TestInTotoMockTool(CliTestCase, TmpDirMixin):
         logger.setLevel(cls._base_log_level)
 
     def tearDown(self):
-        try:
+        with contextlib.suppress(OSError):
             os.remove(self.test_link)
-        except OSError:
-            pass
 
     def test_main_required_args(self):
         """Test CLI command with required arguments."""

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -1155,8 +1155,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
         in_toto_record_start(self.step_name, [], signer=self.signer)
         in_toto_record_stop(self.step_name, [], signer=self.signer)
         with self.assertRaises(IOError):
-            # pylint: disable-next=consider-using-with
-            open(self.link_name_unfinished, encoding="utf8")
+            open(self.link_name_unfinished, encoding="utf8")  # noqa: SIM115
         self.assertTrue(os.path.isfile(self.link_name))
         os.remove(self.link_name)
 
@@ -1165,8 +1164,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
         with self.assertRaises(IOError):
             in_toto_record_stop(self.step_name, [], signer=self.signer)
         with self.assertRaises(IOError):
-            # pylint: disable-next=consider-using-with
-            open(self.link_name, encoding="utf8")
+            open(self.link_name, encoding="utf8")  # noqa: SIM115
 
     def test_wrong_signature_in_unfinished_metadata(self):
         """Test record stop exits on wrong signature, no link recorded."""
@@ -1181,8 +1179,7 @@ class TestInTotoRecordStop(unittest.TestCase, TmpDirMixin):
         with self.assertRaises(SignatureVerificationError):
             in_toto_record_stop(self.step_name, [], signer=self.signer2)
         with self.assertRaises(IOError):
-            # pylint: disable-next=consider-using-with
-            open(self.link_name, encoding="utf8")
+            open(self.link_name, encoding="utf8")  # noqa: SIM115
         os.rename(changed_link_name, link_name)
         os.remove(self.link_name_unfinished)
 

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -21,6 +21,7 @@
 
 """
 
+import contextlib
 import os
 import shutil
 import stat
@@ -721,14 +722,12 @@ class TestInTotoRun(unittest.TestCase, TmpDirMixin):
 
     def tearDown(self):
         """Remove link file if it was created."""
-        try:
+        with contextlib.suppress(OSError):
             os.remove(
                 FILENAME_FORMAT.format(
                     step_name=self.step_name, keyid=self.key["keyid"]
                 )
             )
-        except OSError:
-            pass
 
     def test_in_toto_run_verify_signature(self):
         """Successfully run, verify signed metadata."""


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Silence this error message by changing `# pylint: disable-next=consider-using-with` into `# noqa: SIM115`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


