### PR TITLE
Enforce ruff/Pylint preview warnings (PLW)

### DIFF
--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -234,7 +234,7 @@ class OSTreeResolver(Resolver):
 
         ref_path = os.path.join("refs", "heads", path)
 
-        with open(ref_path) as ref:  # pylint: disable=unspecified-encoding
+        with open(ref_path) as ref:  # noqa: PLW1514, RUF100
             ref_contents = ref.read()
         ref_contents = ref_contents.strip("\n")
 

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -222,13 +222,11 @@ def _subprocess_run_duplicate_streams(cmd, timeout):
     stderr_fd, stderr_name = tempfile.mkstemp()
     try:
         with (
-            open(  # pylint: disable=unspecified-encoding
+            open(  # noqa: PLW1514, RUF100
                 stdout_name
             ) as stdout_reader,
-            os.fdopen(  # pylint: disable=unspecified-encoding
-                stdout_fd, "w"
-            ) as stdout_writer,
-            open(  # pylint: disable=unspecified-encoding
+            os.fdopen(stdout_fd, "w") as stdout_writer,
+            open(  # noqa: PLW1514, RUF100
                 stderr_name
             ) as stderr_reader,
             os.fdopen(stderr_fd, "w") as stderr_writer,

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -640,11 +640,11 @@ class TestSubprocess(unittest.TestCase):
         stdout_fd, stdout_fn = tempfile.mkstemp()
         stderr_fd, stderr_fn = tempfile.mkstemp()
         with (
-            open(  # pylint: disable=unspecified-encoding
+            open(  # noqa: PLW1514, RUF100
                 stdout_fn
             ) as fake_stdout_reader,
             os.fdopen(stdout_fd, "w") as fake_stdout_writer,
-            open(  # pylint: disable=unspecified-encoding
+            open(  # noqa: PLW1514, RUF100
                 stderr_fn
             ) as fake_stderr_reader,
             os.fdopen(stderr_fd, "w") as fake_stderr_writer,


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

This is a preview warning, hence `RUF100` to silence ruff since we are not usinng `--preview`:
```
PLW1514 `open` in text mode without explicit `encoding` argument
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


