### PR TITLE
Apply remaining ruff/pyupgrade rules (UP)

### DIFF
--- a/in_toto/common_args.py
+++ b/in_toto/common_args.py
@@ -183,9 +183,7 @@ RUN_TIMEOUT_KWARGS = {
     "help": (
         "integer that represents the max timeout in seconds for the "
         "   in-toto-run command."
-        "   Default is '{timeout}' seconds.".format(
-            timeout=LINK_CMD_EXEC_TIMEOUT
-        )
+        f"   Default is '{LINK_CMD_EXEC_TIMEOUT}' seconds."
     ),
 }
 

--- a/in_toto/in_toto_mock.py
+++ b/in_toto/in_toto_mock.py
@@ -63,20 +63,20 @@ quickly generate link metadata, inspect it and sign it retroactively.
 
     parser.usage = "%(prog)s [-h] --name <name> -- <command> [args]"
 
-    parser.epilog = """EXAMPLE USAGE
+    parser.epilog = f"""EXAMPLE USAGE
 
 Generate unsigned link metadata 'foo.link' for the activity of creating file
 'bar', inspect it, and sign it with 'mykey'
 
   # Generate unsigned link
-  {prog} --name foo -- touch bar
+  {parser.prog} --name foo -- touch bar
   # Inspect and/or update unsigned link metadata
   vi foo.link
   # Sign the link, attesting to its validity, and write it to
   # 'foo.<mykey keyid prefix>.link'.
   in-toto-sign -k mykey -f foo.link
 
-""".format(prog=parser.prog)
+"""
 
     named_args = parser.add_argument_group("required named arguments")
 
@@ -111,7 +111,7 @@ Generate unsigned link metadata 'foo.link' for the activity of creating file
     parser.add_argument(
         "--version",
         action="version",
-        version="{} {}".format(parser.prog, __version__),
+        version=f"{parser.prog} {__version__}",
     )
 
     title_case_action_groups(parser)

--- a/in_toto/in_toto_record.py
+++ b/in_toto/in_toto_record.py
@@ -80,31 +80,31 @@ command (for which 'in-toto-run' should be used). It returns a non-zero value
 on failure and zero otherwise.""",
     )
 
-    parser.epilog = """EXAMPLE USAGE
+    parser.epilog = f"""EXAMPLE USAGE
 
 Create link metadata file in two commands, signing it with the private key
 loaded from 'key_file', recording all files in the CWD as materials (on
 start), and as products (on stop).
 
-  {prog} start -n edit-files --signing-key path/to/key_file -m .
-  {prog} stop -n edit-files --signing-key path/to/key_file -p .
+  {parser.prog} start -n edit-files --signing-key path/to/key_file -m .
+  {parser.prog} stop -n edit-files --signing-key path/to/key_file -p .
 
 
 Create link metadata file signed with the default GPG key from the default
 GPG home directory and record a file named 'foo' as material and product.
 
-  {prog} start -n edit-foo --gpg -m path/to/foo
-  {prog} stop -n edit-foo --gpg -p path/to/foo
+  {parser.prog} start -n edit-foo --gpg -m path/to/foo
+  {parser.prog} stop -n edit-foo --gpg -p path/to/foo
 
 
 Create link metadata file signed with the private key loaded from 'key_file',
 record all files in the CWD as material and product, and dump finished link
 file to the target directory (on stop).
 
-  {prog} start -n edit-files --signing-key path/to/key_file -m .
-  {prog} stop -d path/to/target/dir -n edit-files --signing-key path/to/key_file -p .
+  {parser.prog} start -n edit-files --signing-key path/to/key_file -m .
+  {parser.prog} stop -d path/to/target/dir -n edit-files --signing-key path/to/key_file -p .
 
-""".format(prog=parser.prog)
+"""
 
     # The subparsers inherit the arguments from the parent parser
     parent_parser = argparse.ArgumentParser(add_help=False)
@@ -205,7 +205,7 @@ file to the target directory (on stop).
     parser.add_argument(
         "--version",
         action="version",
-        version="{} {}".format(parser.prog, __version__),
+        version=f"{parser.prog} {__version__}",
     )
 
     for parser_, order in [

--- a/in_toto/in_toto_run.py
+++ b/in_toto/in_toto_run.py
@@ -83,24 +83,20 @@ stdout and stderr) to a link metadata file, which is signed with the passed
 key. It returns a non-zero value on failure and zero otherwise.""",
     )
 
-    parser.usage = (
-        "%(prog)s <named arguments> [{}] \\\n\t -- <command> [args]".format(
-            OPTS_TITLE.lower()
-        )
-    )
+    parser.usage = f"%(prog)s <named arguments> [{OPTS_TITLE.lower()}] \\\n\t -- <command> [args]"
 
-    parser.epilog = """EXAMPLE USAGE
+    parser.epilog = f"""EXAMPLE USAGE
 
 Tag a git repo, storing files in CWD as products, signing the resulting link
 file with the private key loaded from 'key_file'.
 
-  {prog} -n tag -p . --signing-key key_file -- git tag v1.0
+  {parser.prog} -n tag -p . --signing-key key_file -- git tag v1.0
 
 
 Create a tarball, storing files in 'project' directory as materials and the
 tarball as product, signing the link file with a GPG key '...7E0C8A17'.
 
-  {prog} -n package -m project -p project.tar.gz \\
+  {parser.prog} -n package -m project -p project.tar.gz \\
          -g 8465A1E2E0FB2B40ADB2478E18FB3F537E0C8A17 \\
          -- tar czf project.tar.gz project
 
@@ -110,7 +106,7 @@ still generate signed attestations, e.g. for review work. In that case, files
 may be marked as materials for the manual review process and the command be
 omitted.
 
-  {prog} -n review --signing-key key_file -m document.pdf -x
+  {parser.prog} -n review --signing-key key_file -m document.pdf -x
 
 
 If an artifact that should be recorded is not in the current working directory
@@ -118,7 +114,7 @@ If an artifact that should be recorded is not in the current working directory
 Note that in this example only the relative path, 'document.pdf' is stored
 along with its hash in the resulting link metadata file.
 
-  {prog} -n review --signing-key key_file -m document.pdf \\
+  {parser.prog} -n review --signing-key key_file -m document.pdf \\
          --base-path /my/review/docs/ -x
 
 
@@ -126,12 +122,12 @@ Similarly, it is possible to pass the full path to the artifact that should
 be recorded together with a left-strip path, to only store a relative path,
 e.g. 'document.pdf'.
 
-  {prog} -n review --signing-key key_file \\
+  {parser.prog} -n review --signing-key key_file \\
          -m /tmp/my/review/docs/document.pdf \\
          --lstrip-paths /tmp/my/review/docs/ -x
 
 
-""".format(prog=parser.prog)
+"""
 
     named_args = parser.add_argument_group("required named arguments")
 
@@ -235,7 +231,7 @@ e.g. 'document.pdf'.
     parser.add_argument(
         "--version",
         action="version",
-        version="{} {}".format(parser.prog, __version__),
+        version=f"{parser.prog} {__version__}",
     )
 
     title_case_action_groups(parser)

--- a/in_toto/in_toto_sign.py
+++ b/in_toto/in_toto_sign.py
@@ -241,35 +241,35 @@ useful to append signatures in case threshold signing of layouts is necessary.
 It returns a non-zero value on failure and zero otherwise.""",
     )
 
-    parser.epilog = """EXAMPLE USAGE
+    parser.epilog = f"""EXAMPLE USAGE
 
 Sign 'unsigned.layout' with two keys and write it to 'root.layout'.
 
-  {prog} -f unsigned.layout -k priv_key1 priv_key2 -o root.layout
+  {parser.prog} -f unsigned.layout -k priv_key1 priv_key2 -o root.layout
 
 
 Replace signature in link file and write to default filename, i.e.
 'package.<priv_key keyid prefix>.link'.
 
-  {prog} -f package.2f89b927.link -k priv_key
+  {parser.prog} -f package.2f89b927.link -k priv_key
 
 
 Verify layout signed with 3 keys.
 
-  {prog} -f root.layout -k pub_key0 pub_key1 pub_key2 --verify
+  {parser.prog} -f root.layout -k pub_key0 pub_key1 pub_key2 --verify
 
 
 Sign layout with default gpg key in default gpg keyring.
 
-  {prog} -f root.layout --gpg
+  {parser.prog} -f root.layout --gpg
 
 
 Verify layout with a gpg key identified by keyid '...439F3C2'.
 
-  {prog} -f root.layout --verify \\
+  {parser.prog} -f root.layout --verify \\
       --gpg 3BF8135765A07E21BD12BF89A5627F6BF439F3C2
 
-""".format(prog=parser.prog)
+"""
 
     named_args = parser.add_argument_group("required named arguments")
 
@@ -354,7 +354,7 @@ Verify layout with a gpg key identified by keyid '...439F3C2'.
     parser.add_argument(
         "--version",
         action="version",
-        version="{} {}".format(parser.prog, __version__),
+        version=f"{parser.prog} {__version__}",
     )
 
     title_case_action_groups(parser)
@@ -417,17 +417,15 @@ def main():
         ):
             parser.print_help()
             parser.error(
-                "too many arguments: {} Hence signing Link metadata"
-                " with multiple keys is not allowed.".format(link_error_message)
+                f"too many arguments: {link_error_message} Hence signing Link metadata"
+                " with multiple keys is not allowed."
             )
 
         if args.append:
             parser.print_help()
             parser.error(
-                "wrong arguments: {}. Hence adding signatures to"
-                " existing signatures on link metadata is not allowed.".format(
-                    link_error_message
-                )
+                f"wrong arguments: {link_error_message}. Hence adding signatures to"
+                " existing signatures on link metadata is not allowed."
             )
 
     if args.verify:

--- a/in_toto/in_toto_verify.py
+++ b/in_toto/in_toto_verify.py
@@ -93,32 +93,32 @@ The command returns 2 if it is called with wrong arguments, 1 if in-toto
 verification fails and 0 if verification passes. """,
     )
 
-    parser.usage = "%(prog)s <named arguments> [{}]".format(OPTS_TITLE.lower())
+    parser.usage = f"%(prog)s <named arguments> [{OPTS_TITLE.lower()}]"
 
-    parser.epilog = """EXAMPLE USAGE
+    parser.epilog = f"""EXAMPLE USAGE
 
 Verify supply chain in 'root.layout', signed with private part of
 'key_file.pub'.
 
-  {prog} --layout root.layout --verification-keys key_file.pub
+  {parser.prog} --layout root.layout --verification-keys key_file.pub
 
 
 Verify supply chain as above but load links corresponding to steps of
 'root.layout' from 'link_dir'.
 
-  {prog} --layout root.layout --verification-keys key_file.pub \\
+  {parser.prog} --layout root.layout --verification-keys key_file.pub \\
       --link-dir link_dir
 
 
 Verify supply chain in 'root.layout', signed with GPG key '...7E0C8A17',
 for which the public part can be found in the GPG keyring at '~/.gnupg'.
 
-  {prog} --layout root.layout \\
+  {parser.prog} --layout root.layout \\
       --gpg 8465A1E2E0FB2B40ADB2478E18FB3F537E0C8A17 \\
       --gpg-home ~/.gnupg
 
 
-""".format(prog=parser.prog)
+"""
 
     named_args = parser.add_argument_group("required named arguments")
 
@@ -184,9 +184,7 @@ for which the public part can be found in the GPG keyring at '~/.gnupg'.
         help=(
             "integer that represents the max timeout in seconds for the "
             "   in-toto-verify command for inspect subprocess."
-            "   Default is '{timeout}' seconds.".format(
-                timeout=LINK_CMD_EXEC_TIMEOUT
-            )
+            f"   Default is '{LINK_CMD_EXEC_TIMEOUT}' seconds."
         ),
     )
 
@@ -197,7 +195,7 @@ for which the public part can be found in the GPG keyring at '~/.gnupg'.
     parser.add_argument(
         "--version",
         action="version",
-        version="{} {}".format(parser.prog, __version__),
+        version=f"{parser.prog} {__version__}",
     )
 
     title_case_action_groups(parser)

--- a/in_toto/models/layout.py
+++ b/in_toto/models/layout.py
@@ -420,16 +420,14 @@ class Layout(Signable):
 
         except Exception as e:  # noqa: BLE001
             raise securesystemslib.exceptions.FormatError(
-                "Malformed date string in layout. Exception: {}".format(e)
+                f"Malformed date string in layout. Exception: {e}"
             )
 
     def _validate_readme(self):
         """Private method to check that the readme field is a string."""
         if not isinstance(self.readme, str):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid readme '{}', value must be a string.".format(
-                    self.readme
-                )
+                f"Invalid readme '{self.readme}', value must be a string."
             )
 
     def _validate_keys(self):
@@ -455,8 +453,8 @@ class Layout(Signable):
 
             if step.name in names_seen:
                 raise securesystemslib.exceptions.FormatError(
-                    "There is already a step with name '{}'. Step names must be"
-                    " unique within a layout.".format(step.name)
+                    f"There is already a step with name '{step.name}'. Step names must be"
+                    " unique within a layout."
                 )
             names_seen.add(step.name)
 
@@ -475,8 +473,8 @@ class Layout(Signable):
 
             if inspection.name in names_seen:
                 raise securesystemslib.exceptions.FormatError(
-                    "There is already an inspection with name '{}'. Inspection names"
-                    " must be unique within a layout.".format(inspection.name)
+                    f"There is already an inspection with name '{inspection.name}'. Inspection names"
+                    " must be unique within a layout."
                 )
             names_seen.add(inspection.name)
 
@@ -644,9 +642,7 @@ class Step(SupplyChainItem):
         """Private method to check that the threshold field is set to an int."""
         if not isinstance(self.threshold, int):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid threshold '{}', value must be an int.".format(
-                    self.threshold
-                )
+                f"Invalid threshold '{self.threshold}', value must be an int."
             )
 
     def _validate_pubkeys(self):

--- a/in_toto/models/link.py
+++ b/in_toto/models/link.py
@@ -133,18 +133,14 @@ class Link(Signable):
         """Private method to check that `_type` is set to "link"."""
         if self._type != "link":
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `_type` must be set to 'link', got: {}".format(
-                    self._type
-                )
+                f"Invalid Link: field `_type` must be set to 'link', got: {self._type}"
             )
 
     def _validate_materials(self):
         """Private method to check that `materials` is a `dict` of `HASHDICTs`."""
         if not isinstance(self.materials, dict):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `materials` must be of type dict, got: {}".format(
-                    type(self.materials)
-                )
+                f"Invalid Link: field `materials` must be of type dict, got: {type(self.materials)}"
             )
 
         for material in list(self.materials.values()):
@@ -154,9 +150,7 @@ class Link(Signable):
         """Private method to check that `products` is a `dict` of `HASHDICTs`."""
         if not isinstance(self.products, dict):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `products` must be of type dict, got: {}".format(
-                    type(self.products)
-                )
+                f"Invalid Link: field `products` must be of type dict, got: {type(self.products)}"
             )
 
         for product in list(self.products.values()):
@@ -166,25 +160,19 @@ class Link(Signable):
         """Private method to check that `byproducts` is a `dict`."""
         if not isinstance(self.byproducts, dict):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `byproducts` must be of type dict, got: {}".format(
-                    type(self.byproducts)
-                )
+                f"Invalid Link: field `byproducts` must be of type dict, got: {type(self.byproducts)}"
             )
 
     def _validate_command(self):
         """Private method to check that `command` is a `list`."""
         if not isinstance(self.command, list):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `command` must be of type list, got: {}".format(
-                    type(self.command)
-                )
+                f"Invalid Link: field `command` must be of type list, got: {type(self.command)}"
             )
 
     def _validate_environment(self):
         """Private method to check that `environment` is a `dict`."""
         if not isinstance(self.environment, dict):
             raise securesystemslib.exceptions.FormatError(
-                "Invalid Link: field `environment` must be of type dict, got: {}".format(
-                    type(self.environment)
-                )
+                f"Invalid Link: field `environment` must be of type dict, got: {type(self.environment)}"
             )

--- a/in_toto/models/metadata.py
+++ b/in_toto/models/metadata.py
@@ -266,7 +266,7 @@ class Metablock(Metadata, ValidationMixin):
 
         """
         with open(path, "wb") as fp:
-            fp.write("{}".format(self).encode("utf-8"))
+            fp.write(f"{self}".encode())
 
     @classmethod
     def from_dict(cls, data):
@@ -385,7 +385,7 @@ class Metablock(Metadata, ValidationMixin):
 
         else:
             raise SignatureVerificationError(
-                "No signature found for key '{}'".format(verification_keyid)
+                f"No signature found for key '{verification_keyid}'"
             )
 
         valid = False
@@ -413,7 +413,7 @@ class Metablock(Metadata, ValidationMixin):
 
         if not valid:
             raise SignatureVerificationError(
-                "Invalid signature for keyid '{}'".format(verification_keyid)
+                f"Invalid signature for keyid '{verification_keyid}'"
             )
 
     def _validate_signed(self):

--- a/in_toto/rulelib.py
+++ b/in_toto/rulelib.py
@@ -117,7 +117,7 @@ def unpack_rule(rule):
                 "ALLOW <pattern>\n\t"
                 "DISALLOW <pattern>\n"
                 "REQUIRE <file>\n"
-                "Got:\n\t{}".format(rule)
+                f"Got:\n\t{rule}"
             )
         return {
             "rule_type": rule_type,
@@ -181,7 +181,7 @@ def unpack_rule(rule):
                 " match rules must have the format:\n\t"
                 " MATCH <pattern> [IN <source-path-prefix>] WITH"
                 " (MATERIALS|PRODUCTS) [IN <destination-path-prefix>] FROM <step>.\n"
-                "Got: \n\t{}".format(rule)
+                f"Got: \n\t{rule}"
             )
 
         if dest_type not in {"materials", "products"}:
@@ -189,7 +189,7 @@ def unpack_rule(rule):
                 "Wrong rule format,"
                 " match rules must have either MATERIALS or PRODUCTS (case"
                 " insensitive) as destination.\n"
-                "Got: \n\t{}".format(rule)
+                f"Got: \n\t{rule}"
             )
 
         return {
@@ -278,18 +278,16 @@ def pack_rule(  # noqa: PLR0913, PLR0917, RUF100
             dest_type.lower() == "materials" or dest_type.lower() == "products"
         ):
             raise securesystemslib.exceptions.FormatError(
-                "'{}' is not a valid"
+                f"'{dest_type}' is not a valid"
                 " 'dest_type'. Rules of type 'MATCH' require a destination type of"
-                " either 'MATERIALS' or 'PRODUCTS' (case insensitive).".format(
-                    dest_type
-                )
+                " either 'MATERIALS' or 'PRODUCTS' (case insensitive)."
             )
 
         if not (isinstance(dest_name, str) and dest_name):
             raise securesystemslib.exceptions.FormatError(
-                "'{}' is not a valid"
+                f"'{dest_name}' is not a valid"
                 " 'dest_name'. Rules of type 'MATCH' require a step name as a"
-                " destination name.".format(dest_name)
+                " destination name."
             )
 
         # Construct rule

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -941,9 +941,7 @@ def in_toto_record_stop(  # noqa: PLR0912, PLR0913, PLR0914, PLR0915, PLR0917, R
         if not unfinished_fn_list:
             raise in_toto.exceptions.LinkNotFoundError(
                 "Could not find a preliminary"
-                " link for step '{}' in the current working directory.".format(
-                    step_name
-                )
+                f" link for step '{step_name}' in the current working directory."
             )
 
         if len(unfinished_fn_list) > 1:

--- a/in_toto/verifylib.py
+++ b/in_toto/verifylib.py
@@ -81,11 +81,11 @@ def _raise_on_bad_retval(return_value, command=None):
       None.
     """
 
-    msg = "Got non-{what} " + "return value '{}'".format(return_value)
-    if command:
-        msg = "{} from command '{}'.".format(msg, command)
+    msg = "Got non-{what} " + f"return value '{return_value}'"
+    if command:  # noqa: SIM108
+        msg = f"{msg} from command '{command}'."
     else:
-        msg = "{}.".format(msg)
+        msg = f"{msg}."
 
     if not isinstance(return_value, int):
         raise BadReturnValueError(msg.format(what="int"))
@@ -166,10 +166,8 @@ def load_links_for_layout(layout, link_dir_path):
         # check is indispensable.
         if len(links_per_step) < step.threshold:
             raise in_toto.exceptions.LinkNotFoundError(
-                "Step '{}' requires '{}'"
-                " link metadata file(s), found '{}'.".format(
-                    step.name, step.threshold, len(links_per_step)
-                )
+                f"Step '{step.name}' requires '{step.threshold}'"
+                f" link metadata file(s), found '{len(links_per_step)}'."
             )
 
         steps_metadata[step.name] = links_per_step
@@ -547,11 +545,9 @@ def verify_link_signature_thresholds(layout, steps_metadata):  # noqa: PLR0912
         # Maybe we should add such a check to the layout validation? Or here?
         if valid_authorized_links_cnt < step.threshold:
             raise ThresholdVerificationError(
-                "Step '{}' requires at least '{}' links"
+                f"Step '{step.name}' requires at least '{step.threshold}' links"
                 " validly signed by different authorized functionaries. Only"
-                " found '{}'".format(
-                    step.name, step.threshold, valid_authorized_links_cnt
-                )
+                f" found '{valid_authorized_links_cnt}'"
             )
 
         # Add all good links of this step to the dictionary of links of all steps
@@ -955,9 +951,7 @@ def verify_disallow_rule(rule_pattern, artifacts_queue):
 
     if filtered_artifacts:
         raise RuleVerificationError(
-            "'DISALLOW {}' matched the following artifacts: {}\n{}".format(
-                rule_pattern, filtered_artifacts, _get_artifact_rule_traceback()
-            )
+            f"'DISALLOW {rule_pattern}' matched the following artifacts: {filtered_artifacts}\n{_get_artifact_rule_traceback()}"
         )
 
 
@@ -989,12 +983,8 @@ def verify_require_rule(filename, artifacts_queue):
     """
     if filename not in artifacts_queue:
         raise RuleVerificationError(
-            "'REQUIRE {filename}' did not find {filename} "
-            "in: {queue}\n{traceback}".format(
-                filename=filename,
-                queue=artifacts_queue,
-                traceback=_get_artifact_rule_traceback(),
-            )
+            f"'REQUIRE {filename}' did not find {filename} "
+            f"in: {artifacts_queue}\n{_get_artifact_rule_traceback()}"
         )
 
 
@@ -1084,7 +1074,7 @@ def verify_item_rules(source_name, source_type, rules, links):
     if source_type not in {"materials", "products"}:
         raise securesystemslib.exceptions.FormatError(
             "Argument 'source_type' of function 'verify_item_rules' has to be "
-            "one of 'materials' or 'products'. Got: '{}'".format(source_type)
+            f"one of 'materials' or 'products'. Got: '{source_type}'"
         )
 
     # Create shortcuts to item's materials and products (including hashes),
@@ -1156,7 +1146,7 @@ def verify_item_rules(source_name, source_type, rules, links):
 
         else:  # pragma: no cover (unreachable)
             raise securesystemslib.exceptions.FormatError(
-                "Invaldid rule type '{}'.".format(_type)
+                f"Invaldid rule type '{_type}'."
             )
 
         artifacts_queue -= consumed
@@ -1264,9 +1254,7 @@ def verify_threshold_constraints(layout, chain_link_dict):
         # Should we remove the check?
         if len(key_link_dict) < step.threshold:
             raise ThresholdVerificationError(
-                "Step '{}' not performed by enough functionaries!".format(
-                    step.name
-                )
+                f"Step '{step.name}' not performed by enough functionaries!"
             )
 
         # Take a reference link (e.g. the first in the step_link_dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,6 @@ ignore = [
     "B904",     # raise-without-from-inside-except
     "PERF203",  # try-except-in-loop
     "PLR2004",  # magic-value-comparison
-    "UP038",    # https://github.com/astral-sh/ruff/issues/7871
     "RUF005",   # collection-literal-concatenation
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,6 @@ ignore = [
     "B904",     # raise-without-from-inside-except
     "PERF203",  # try-except-in-loop
     "PLR2004",  # magic-value-comparison
-    "UP032",    # f-string
     "UP038",    # https://github.com/astral-sh/ruff/issues/7871
     "RUF005",   # collection-literal-concatenation
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules

--- a/tests/test_common_args.py
+++ b/tests/test_common_args.py
@@ -51,7 +51,7 @@ class TestCommonArgs(unittest.TestCase):
 
         for idx, (params, expected) in enumerate(tests):
             result = parse_password_and_prompt_args(parser.parse_args(params))
-            self.assertTupleEqual(result, expected, "(row {})".format(idx))
+            self.assertTupleEqual(result, expected, f"(row {idx})")
 
 
 class TestArgparseActionGroupHelpers(unittest.TestCase):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -761,9 +761,7 @@ class TestInTotoRun(unittest.TestCase, TmpDirMixin):
         stdout_contents = link.signed.byproducts.get("stdout")
         self.assertTrue(
             "Python" in stderr_contents or "Python" in stdout_contents,
-            msg="\nSTDERR:\n{}\nSTDOUT:\n{}".format(
-                stderr_contents, stdout_contents
-            ),
+            msg=f"\nSTDERR:\n{stderr_contents}\nSTDOUT:\n{stdout_contents}",
         )
 
     def test_in_toto_run_without_byproduct(self):

--- a/tests/test_verifylib.py
+++ b/tests/test_verifylib.py
@@ -260,7 +260,7 @@ class TestVerifyRule(unittest.TestCase):
             self.assertSetEqual(
                 result,
                 expected,
-                "test {}: {}".format(i, dict(zip(test_data_keys, test_data))),
+                f"test {i}: {dict(zip(test_data_keys, test_data))}",
             )
 
     def test_verify_create_rule(self):
@@ -294,7 +294,7 @@ class TestVerifyRule(unittest.TestCase):
             self.assertSetEqual(
                 result,
                 expected,
-                "test {}: {}".format(i, dict(zip(test_data_keys, test_data))),
+                f"test {i}: {dict(zip(test_data_keys, test_data))}",
             )
 
     def test_verify_modify_rule(self):
@@ -365,7 +365,7 @@ class TestVerifyRule(unittest.TestCase):
             self.assertSetEqual(
                 result,
                 expected,
-                "test {}: {}".format(i, dict(zip(test_data_keys, test_data))),
+                f"test {i}: {dict(zip(test_data_keys, test_data))}",
             )
 
     def test_verify_allow_rule(self):
@@ -389,7 +389,7 @@ class TestVerifyRule(unittest.TestCase):
             self.assertSetEqual(
                 result,
                 expected,
-                "test {}: {}".format(i, dict(zip(test_data_keys, test_data))),
+                f"test {i}: {dict(zip(test_data_keys, test_data))}",
             )
 
     def test_verify_disallow_rule(self):
@@ -409,7 +409,7 @@ class TestVerifyRule(unittest.TestCase):
         for i, test_data in enumerate(test_cases):
             pattern, queue, should_raise = test_data
 
-            msg = "test {}: {}".format(i, dict(zip(test_data_keys, test_data)))
+            msg = f"test {i}: {dict(zip(test_data_keys, test_data))}"
             exception = None
 
             try:
@@ -418,10 +418,10 @@ class TestVerifyRule(unittest.TestCase):
                 exception = e
 
             if should_raise and not exception:
-                self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
+                self.fail(f"Expected 'RuleVerificationError'\n{msg}")
 
             if exception and not should_raise:
-                self.fail("Unexpected {}\n{}".format(exception, msg))
+                self.fail(f"Unexpected {exception}\n{msg}")
 
     def test_verify_require_rule(self):
         """Test verifylib.verify_require_rule."""
@@ -439,7 +439,7 @@ class TestVerifyRule(unittest.TestCase):
         for i, test_data in enumerate(test_cases):
             pattern, queue, should_raise = test_data
 
-            msg = "test {}: {}".format(i, dict(zip(test_data_keys, test_data)))
+            msg = f"test {i}: {dict(zip(test_data_keys, test_data))}"
             exception = None
 
             try:
@@ -448,10 +448,10 @@ class TestVerifyRule(unittest.TestCase):
                 exception = e
 
             if should_raise and not exception:
-                self.fail("Expected 'RuleVerificationError'\n{}".format(msg))
+                self.fail(f"Expected 'RuleVerificationError'\n{msg}")
 
             if exception and not should_raise:
-                self.fail("Unexpected {}\n{}".format(exception, msg))
+                self.fail(f"Unexpected {exception}\n{msg}")
 
 
 class TestVerifyMatchRule(unittest.TestCase):
@@ -703,9 +703,7 @@ class TestVerifyMatchRule(unittest.TestCase):
             self.assertSetEqual(
                 result,
                 expected,
-                "'result': {}\n test {}: {}, 'links':{}".format(
-                    result, i, dict(zip(test_data_keys, test_data)), self.links
-                ),
+                f"'result': {result}\n test {i}: {dict(zip(test_data_keys, test_data))}, 'links':{self.links}",
             )
 
 


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Apply UP032.

Get rid of UP038, deprecated by ruff 0.10.0.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature