### PR TITLE
Get rid of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-# This file exists to keep dependabot happy:
-# https://github.com/dependabot/dependabot-core/issues/4483
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

This issue has been fixed, Dependabot shouldn't need `setup.py` any more to identify dependecies:
	https://github.com/dependabot/dependabot-core/issues/4483

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature