### PR TITLE
Apply repo-review rule PP004

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "in-toto"
 description = "A framework to define and secure the integrity of software supply chains"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = "~=3.9"
+requires-python = ">=3.9"
 authors = [
     { name = "New York University: Secure Systems Lab", email = "in-toto-dev@googlegroups.com" },
 ]


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

https://learn.scientific-python.org/development/guides/repo-review/?repo=in-toto%2Fin-toto&ref=develop

Not sure about this one:

> You should never upper cap your Python requirement. This is rarely correct, and tools like pip do not handle this properly even if it is correct. This field is used to back-solve. If you want to specify versions you've tested on, use classifiers. If you want to add a custom error message, add a build-type and/or runtime assert.

I had to read [Version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/) to make sure what `~=` means:
* `~=3.9` means 3.9 or newer, but not 4
* `>=3.9` means 3.9 or newer, including 4

So the idea is you don't need to explicitly exclude Python 4. If there ever was a Python 4, you'd hear about it soon enough to adapt. The classifier `Programming Language :: Python :: 3` is sufficient.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


