### PR TITLE
Port securesystemslib.hash file hashing

### DIFF
--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -1,6 +1,7 @@
 """Resolver interface and implementations for files, OSTree, and directory
 artifacts."""
 
+import hashlib
 import locale
 import logging
 import os
@@ -10,7 +11,6 @@ from itertools import combinations
 from os.path import exists, isdir, isfile, join, normpath
 
 from pathspec import GitIgnoreSpec
-from securesystemslib.hash import digest, digest_filename
 
 from in_toto.exceptions import PrefixError
 
@@ -97,12 +97,12 @@ class FileResolver(Resolver):
 
     def _hash(self, path):
         """Helper to generate hash dictionary for path."""
-        digest_obj = digest_filename(
+        hexdigest = _hash_file(
             path,
-            algorithm=_HASH_ALGORITHM,
-            normalize_line_endings=self._normalize_line_endings,
+            _HASH_ALGORITHM,
+            self._normalize_line_endings,
         )
-        return {_HASH_ALGORITHM: digest_obj.hexdigest()}
+        return {_HASH_ALGORITHM: hexdigest}
 
     def _mangle(self, path, existing_paths, scheme_prefix):
         """Helper for path mangling."""
@@ -241,12 +241,9 @@ class OSTreeResolver(Resolver):
             "objects", ref_contents[:2], f"{ref_contents[2:]}.commit"
         )
 
-        digest_obj = digest_filename(
-            object_path,
-            algorithm=self._HASH_ALGORITHM,
-        )
+        hexdigest = _hash_file(object_path, self._HASH_ALGORITHM, False)
 
-        return {self._HASH_ALGORITHM: digest_obj.hexdigest()}
+        return {self._HASH_ALGORITHM: hexdigest}
 
     def hash_artifacts(self, uris):
         hashes = {}
@@ -347,7 +344,7 @@ class DirectoryResolver(Resolver):
             )
             text_repr += "\n"  # trailing new line
 
-        digest_obj = digest(_HASH_ALGORITHM)
+        digest_obj = hashlib.new(_HASH_ALGORITHM)
         digest_obj.update(text_repr.encode("utf-8"))
 
         return {_HASH_ALGORITHM: digest_obj.hexdigest()}
@@ -378,3 +375,36 @@ class DirectoryResolver(Resolver):
             hashes[name] = self._hash(file_hashes)
 
         return hashes
+
+
+def _hash_file(path, algo, normalize_line_endings):
+    """Returns hashed file."""
+
+    digest = hashlib.new(algo)
+    with open(path, "rb") as f:
+        while True:
+            # Chunk size is taken from the previously used and now deprecated
+            # `securesystemslib.hash.digest_fileobject`.
+            data = f.read(4096)
+            if not data:
+                break
+
+            if normalize_line_endings:
+                while data[-1:] == b"\r":
+                    c = f.read(1)
+                    if not c:
+                        break
+
+                    data += c
+
+                data = (
+                    data
+                    # First Windows
+                    .replace(b"\r\n", b"\n")
+                    # Then Mac
+                    .replace(b"\r", b"\n")
+                )
+
+            digest.update(data)
+
+    return digest.hexdigest()

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -41,7 +41,6 @@ from collections import defaultdict
 import securesystemslib._gpg
 import securesystemslib.exceptions
 import securesystemslib.formats
-import securesystemslib.hash
 from securesystemslib.signer import Signer
 
 import in_toto.exceptions

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,10 +1,33 @@
 """Test cases for resolver.py."""
 
+import hashlib
+import os
+import tempfile
 import unittest
 from pathlib import Path
 
 from in_toto.resolver import RESOLVER_FOR_URI_SCHEME, FileResolver, Resolver
+from in_toto.resolver._resolver import _hash_file
 from tests.common import TmpDirMixin
+
+
+class TestResolverHelper(unittest.TestCase):
+    def test_hash_file(self):
+        """Test normalize file endings."""
+        data = b"ab\r\nd\nf\r" * 4096
+        fd, filename = tempfile.mkstemp()
+        try:
+            os.write(fd, data)
+            os.close(fd)
+
+            result = _hash_file(filename, "sha256", True)
+
+            normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+            expected = hashlib.sha256(normalized).hexdigest()
+            self.assertEqual(result, expected)
+
+        finally:
+            os.remove(filename)
 
 
 class TestResolver(unittest.TestCase):


### PR DESCRIPTION
securesystemslib.hash is a small wrapper around hashlib, which serves two main purposes:
* provide helper function to hash a file, while optionally normalizing file endings.
* translate custom hash algorithm name "blake2b-256" to "blake2b" with (digest_size=32).

In preparation for the removal of securesystemslib.hash, this patch ports the former only (file hashing with normalization). The latter was never used in in-toto.


related https://github.com/secure-systems-lab/securesystemslib/issues/943