### PR TITLE
Add ArtifactCollisionError for duplicate URI detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* `ArtifactCollisionError` exception for consistent duplicate artifact URI
+  detection across resolver batches and via `lstrip_paths` path manipulation.
+  Replaces `PrefixError` in `FileResolver` and `DirectoryResolver` for URI
+  collision cases (#601)
+
 ## v3.1.0
 
 This release includes version bumpbs, as well as upgraded debian support , and

--- a/in_toto/exceptions.py
+++ b/in_toto/exceptions.py
@@ -39,5 +39,10 @@ class PrefixError(Error):
     """Indicates that there is an error because of the prefixes passed."""
 
 
+class ArtifactCollisionError(Error):
+    """Raised when artifact URIs collide across resolver batches or as a
+    result of path manipulation (e.g. lstrip_paths)."""
+
+
 class InvalidMetadata(Error):  # noqa: N818
     """Indicates that the metadata is not valid."""

--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -12,7 +12,7 @@ from os.path import exists, isdir, isfile, join, normpath
 
 from pathspec import GitIgnoreSpec
 
-from in_toto.exceptions import PrefixError
+from in_toto.exceptions import ArtifactCollisionError, PrefixError
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class FileResolver(Resolver):
 
         # Fail if left-stripping above results in duplicates
         if self._lstrip_paths and path in existing_paths:
-            raise PrefixError(
+            raise ArtifactCollisionError(
                 "Prefix selection has resulted in non unique dictionary key "
                 f"'{path}'"
             )
@@ -321,7 +321,7 @@ class DirectoryResolver(Resolver):
 
         # Fail if left-stripping above results in duplicates
         if self._lstrip_paths and path in existing_paths:
-            raise PrefixError(
+            raise ArtifactCollisionError(
                 "Prefix selection has resulted in non unique dictionary key "
                 f"'{path}'"
             )

--- a/in_toto/runlib.py
+++ b/in_toto/runlib.py
@@ -194,7 +194,13 @@ def record_artifacts_as_dict(  # noqa: PLR0913, PLR0917, RUF100
     # because the left-prefix duplicate check in FileResolver only works for the
     # artifacts hashed in one batch.
     for resolver, uris in resolver_for_uris.items():
-        artifact_hashes.update(resolver.hash_artifacts(uris))
+        batch = resolver.hash_artifacts(uris)
+        duplicates = set(batch.keys()) & set(artifact_hashes.keys())
+        if duplicates:
+            raise in_toto.exceptions.ArtifactCollisionError(
+                f"Artifact URI collision detected across resolvers: {duplicates}"
+            )
+        artifact_hashes.update(batch)
 
     # Clear resolvers to not preserve global state change beyond this function.
     # FIXME: This also clears resolver registered elsewhere. For now we
@@ -496,7 +502,8 @@ def in_toto_run(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915, PLR0917, RUF
 
     securesystemslib.exceptions.StorageError: Cannot hash artifacts.
 
-    PrefixError: Left-stripping artifact paths results in non-unique dict keys.
+    ArtifactCollisionError: Artifact URIs collide, either as a result of
+    left-stripping artifact paths or across resolver batches.
 
     subprocess.TimeoutExpired: Link command times out.
 
@@ -691,7 +698,8 @@ def in_toto_record_start(  # noqa: PLR0913, PLR0917, RUF100
 
     securesystemslib.exceptions.StorageError: Cannot hash artifacts.
 
-    PrefixError: Left-stripping artifact paths results in non-unique dict keys.
+    ArtifactCollisionError: Artifact URIs collide, either as a result of
+    left-stripping artifact paths or across resolver batches.
 
     subprocess.TimeoutExpired: Link command times out.
 
@@ -879,7 +887,8 @@ def in_toto_record_stop(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915, PLR0
 
     securesystemslib.exceptions.StorageError: Cannot hash artifacts.
 
-    PrefixError: Left-stripping artifact paths results in non-unique dict keys.
+    ArtifactCollisionError: Artifact URIs collide, either as a result of
+    left-stripping artifact paths or across resolver batches.
 
     subprocess.TimeoutExpired: Link command times out.
 

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from in_toto.exceptions import PrefixError
+from in_toto.exceptions import ArtifactCollisionError
 from in_toto.resolver import DirectoryResolver
 
 
@@ -80,7 +80,7 @@ class TestDirectoryResolver(unittest.TestCase):
 
         resolver = DirectoryResolver(lstrip_paths=lstrip_paths)
 
-        with self.assertRaises(PrefixError):
+        with self.assertRaises(ArtifactCollisionError):
             resolver.hash_artifacts(uris)
 
     def test_directory_with_exclude(self):

--- a/tests/test_runlib.py
+++ b/tests/test_runlib.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import securesystemslib.exceptions
 import securesystemslib.formats
@@ -42,7 +43,7 @@ from in_toto.models.link import (
     Link,
 )
 from in_toto.models.metadata import Envelope, Metablock
-from in_toto.resolver import FileResolver
+from in_toto.resolver import DirectoryResolver, FileResolver
 from in_toto.runlib import (
     _subprocess_run_duplicate_streams,
     in_toto_match_products,
@@ -236,10 +237,31 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):  # noqa: PLR090
         path = "subdir_new/foosub1"
         shutil.copy("subdir/foosub1", path)
         lstrip_paths = ["subdir/", "subdir_new/"]
-        with self.assertRaises(in_toto.exceptions.PrefixError):
+        with self.assertRaises(in_toto.exceptions.ArtifactCollisionError):
             record_artifacts_as_dict(["."], lstrip_paths=lstrip_paths)
         os.remove(path)
         os.rmdir("subdir_new")
+
+    def test_collision_across_resolvers(self):
+        """Two resolvers returning overlapping URIs raises
+        ArtifactCollisionError."""
+        # The file resolver records "foo" for real; force the directory
+        # resolver to return the same URI to trigger the cross-resolver check.
+        with (
+            mock.patch.object(
+                DirectoryResolver,
+                "hash_artifacts",
+                return_value={"foo": {"sha256": "0" * 64}},
+            ),
+            self.assertRaises(in_toto.exceptions.ArtifactCollisionError),
+        ):
+            record_artifacts_as_dict(["foo", "dir:subdir"])
+
+    def test_non_overlapping_batches(self):
+        """Non-overlapping resolver batches are merged without error."""
+        artifacts_dict = record_artifacts_as_dict(["foo", "dir:subdir"])
+        self.assertIn("foo", artifacts_dict)
+        self.assertIn("dir:subdir", artifacts_dict)
 
     def test_lstrip_paths_invalid_prefix_directory(self):
         lstrip_paths = ["not/a/directory/"]
@@ -271,7 +293,7 @@ class TestRecordArtifactsAsDict(unittest.TestCase, TmpDirMixin):  # noqa: PLR090
         path = "subdir/subsubdir_new/foosubsub"
         shutil.copy("subdir/subsubdir/foosubsub", path)
         lstrip_paths = ["subdir/subsubdir/", "subdir/subsubdir_new/"]
-        with self.assertRaises(in_toto.exceptions.PrefixError):
+        with self.assertRaises(in_toto.exceptions.ArtifactCollisionError):
             record_artifacts_as_dict(
                 [
                     "subdir/subsubdir/foosubsub",


### PR DESCRIPTION
**Fixes issue #**: 601

**Description of the changes being introduced by the pull request**:

`record_artifacts_as_dict` in `runlib.py` aggregates artifact hashes from multiple resolvers using `dict.update()`, which silently overwrites any URI key that appears in more than one resolver batch. This means if two resolvers return the same artifact URI, the second hash silently replaces the first with no error or warning, producing link metadata
that does not accurately reflect what was recorded.

Separately, `FileResolver` and `DirectoryResolver` already raised `PrefixError` when `lstrip_paths` path manipulation caused duplicate keys within a single batch. This is the same category of problem (duplicate URI) but raised a different, semantically unrelated exception.

This PR addresses both issues:

**1. New `ArtifactCollisionError` exception (`exceptions.py`)**

Adds `ArtifactCollisionError(Error)` as a dedicated exception for all artifact URI collision scenarios, covering both cross-resolver batch collisions and `lstrip_paths`-induced duplicates. The docstring describes both causes.

**2. Cross-resolver collision detection (`runlib.py`)**

Replaces the silent `dict.update()` in the per-resolver hashing loop with an explicit duplicate check. If any URI from a new resolver batch already exists in the accumulated results, `ArtifactCollisionError` is raised before the merge. Three docstrings that previously referenced `PrefixError` for lstrip duplicates have been updated to reference `ArtifactCollisionError`.

**3. Consistent exception in resolvers (`resolver/_resolver.py`)**

Replaces `PrefixError` with `ArtifactCollisionError` in both `FileResolver._mangle` and `DirectoryResolver._mangle` for the duplicate-key-after-lstrip case, so all URI collision scenarios raise the same exception type regardless of where the collision is detected. The distinct `PrefixError` in `FileResolver.__init__` for the left-substring lstrip check is left untouched as it covers a separate validation.

**4. Tests**

- `test_runlib.py`: updated `test_lstrip_paths_non_unique_key` and `test_lstrip_paths_non_unique_key_file` to expect `ArtifactCollisionError`. Added `test_collision_across_resolvers` (mocked resolver returning a URI already recorded by `FileResolver` raises `ArtifactCollisionError`) and `test_non_overlapping_batches` (non-overlapping resolver batches merge cleanly).
- `test_directory_resolver.py`: updated `test_colliding_lstrips` to expect `ArtifactCollisionError`.

**5. Changelog**

Added `## Unreleased` section to `CHANGELOG.md` documenting the new exception and behavior change.

**Please verify and check that the pull request fulfills the following
requirements**:
- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new `feature```