### PR TITLE
resolver: restore working directory when hashing fails

### DIFF
--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -140,66 +140,69 @@ class FileResolver(Resolver):
     def hash_artifacts(self, uris):  # noqa: C901
         hashes = {}
 
+        original_cwd = None
         if self._base_path:
             original_cwd = os.getcwd()
             os.chdir(self._base_path)
 
-        for path in uris:
-            # Remove scheme prefix, but preserver to re-add later (see _mangle)
-            path, prefix = self._strip_scheme_prefix(path)  # noqa: PLW2901
+        try:
+            for path in uris:
+                # Remove scheme prefix, but preserver to re-add later (_mangle)
+                path, prefix = self._strip_scheme_prefix(path)  # noqa: PLW2901
 
-            # Normalize URI before filtering and returning them
-            # FIXME: Is this expected behavior? Does this make exclude patterns
-            # with slashes platform-dependent? Check how 'gitwildmatch' treats
-            # dots and slashes!
-            path = normpath(path)  # noqa: PLW2901
+                # Normalize URI before filtering and returning them
+                # FIXME: Is this expected behavior? Does this make exclude
+                # patterns with slashes platform-dependent? Check how
+                # 'gitwildmatch' treats dots and slashes!
+                path = normpath(path)  # noqa: PLW2901
 
-            if self._exclude(path):
-                continue
+                if self._exclude(path):
+                    continue
 
-            if not exists(path):
-                logger.info("path: %s does not exist, skipping..", path)
-                continue
+                if not exists(path):
+                    logger.info("path: %s does not exist, skipping..", path)
+                    continue
 
-            if isfile(path):
-                name = self._mangle(path, hashes, prefix)
-                hashes[name] = self._hash(path)
+                if isfile(path):
+                    name = self._mangle(path, hashes, prefix)
+                    hashes[name] = self._hash(path)
 
-            if isdir(path):
-                for base, dirs, names in os.walk(
-                    path, followlinks=self._follow_symlink_dirs
-                ):
-                    # Filter directories to avoid unnecessary recursion below
-                    # NOTE: Normalize to filter on directory paths without
-                    # their dot-slash prefix, if path was dot.
-                    dirs[:] = [
-                        dirname
-                        for dirname in dirs
-                        if not self._exclude(normpath(join(base, dirname)))
-                    ]
+                if isdir(path):
+                    for base, dirs, names in os.walk(
+                        path, followlinks=self._follow_symlink_dirs
+                    ):
+                        # Filter directories to avoid unnecessary recursion
+                        # NOTE: Normalize to filter on directory paths without
+                        # their dot-slash prefix, if path was dot.
+                        dirs[:] = [
+                            dirname
+                            for dirname in dirs
+                            if not self._exclude(normpath(join(base, dirname)))
+                        ]
 
-                    for filename in names:
-                        # NOTE: Normalize to filter on and return file paths
-                        # without their dot-slash prefix, if path was dot.
-                        filepath = normpath(join(base, filename))
+                        for filename in names:
+                            # NOTE: Normalize to filter on and return file paths
+                            # without their dot-slash prefix, if path was dot.
+                            filepath = normpath(join(base, filename))
 
-                        if self._exclude(filepath):
-                            continue
+                            if self._exclude(filepath):
+                                continue
 
-                        if not isfile(filepath):
-                            logger.info(
-                                "File '%s' appears to be a broken symlink. "
-                                "Skipping...",
-                                filepath,
-                            )
-                            continue
+                            if not isfile(filepath):
+                                logger.info(
+                                    "File '%s' appears to be a broken symlink. "
+                                    "Skipping...",
+                                    filepath,
+                                )
+                                continue
 
-                        name = self._mangle(filepath, hashes, prefix)
-                        hashes[name] = self._hash(filepath)
+                            name = self._mangle(filepath, hashes, prefix)
+                            hashes[name] = self._hash(filepath)
 
-        # Change back to original current working dir
-        if self._base_path:
-            os.chdir(original_cwd)
+        finally:
+            # Change back to original current working dir
+            if original_cwd is not None:
+                os.chdir(original_cwd)
 
         return hashes
 
@@ -246,18 +249,21 @@ class OSTreeResolver(Resolver):
     def hash_artifacts(self, uris):
         hashes = {}
 
+        original_cwd = None
         if self._base_path:
             original_cwd = os.getcwd()
             os.chdir(self._base_path)
 
-        for path in uris:
-            # Remove scheme prefix, but preserver to re-add later
-            path = self._strip_scheme_prefix(path)  # noqa: PLW2901
-            hashes[self._add_scheme_prefix(path)] = self._hash(path)
+        try:
+            for path in uris:
+                # Remove scheme prefix, but preserver to re-add later
+                path = self._strip_scheme_prefix(path)  # noqa: PLW2901
+                hashes[self._add_scheme_prefix(path)] = self._hash(path)
 
-        # Change back to original current working dir
-        if self._base_path:
-            os.chdir(original_cwd)
+        finally:
+            # Change back to original current working dir
+            if original_cwd is not None:
+                os.chdir(original_cwd)
 
         return hashes
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from in_toto.exceptions import PrefixError
 from in_toto.resolver import RESOLVER_FOR_URI_SCHEME, FileResolver, Resolver
 from in_toto.resolver._resolver import _hash_file
 from tests.common import TmpDirMixin
@@ -105,6 +106,16 @@ class TestFileResolver(TmpDirMixin, unittest.TestCase):
             resolver = FileResolver(**kwargs)
             result = resolver.hash_artifacts(uris)
             self.assertEqual(result.keys(), expected_keys)
+
+    def test_hash_artifacts_base_path_cwd_restored_on_error(self):
+        """cwd must be restored even if hashing raises with a base_path set."""
+        # lstrip_paths that map two distinct artifacts to the same name make
+        # _mangle raise PrefixError partway through hashing.
+        resolver = FileResolver(base_path="bar", lstrip_paths=["baz", "foo"])
+        original_cwd = os.getcwd()
+        with self.assertRaises(PrefixError):
+            resolver.hash_artifacts({"baz", "foo"})
+        self.assertEqual(os.getcwd(), original_cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

While reading through the resolver I noticed that `FileResolver.hash_artifacts` and `OSTreeResolver.hash_artifacts` change into `base_path` with `os.chdir` and only change back with the final statement of the method. If anything raises in between, the process is left sitting in `base_path`, and every later relative path the caller resolves then points at the wrong directory. This is reachable from normal use: with a `base_path` set, two `lstrip_paths` that reduce distinct artifacts to the same name make `_mangle` raise `PrefixError` partway through, and an unreadable file would do the same.

This wraps the loop in try/finally so the original working directory is always restored, in both resolvers. I added a regression test that asserts the cwd is unchanged after a `PrefixError`; it fails before the change and passes after. pytest for the resolver and runlib suites stays green.

**Please verify and check that the pull request fulfills the following requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature