### PR TITLE
resolver: Restore working directory if hashing fails

### DIFF
--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -144,62 +144,67 @@ class FileResolver(Resolver):
             original_cwd = os.getcwd()
             os.chdir(self._base_path)
 
-        for path in uris:
-            # Remove scheme prefix, but preserver to re-add later (see _mangle)
-            path, prefix = self._strip_scheme_prefix(path)  # noqa: PLW2901
+        try:
+            for path in uris:
+                # Remove scheme prefix, but preserver to re-add later
+                # (see _mangle)
+                path, prefix = self._strip_scheme_prefix(path)  # noqa: PLW2901
 
-            # Normalize URI before filtering and returning them
-            # FIXME: Is this expected behavior? Does this make exclude patterns
-            # with slashes platform-dependent? Check how 'gitwildmatch' treats
-            # dots and slashes!
-            path = normpath(path)  # noqa: PLW2901
+                # Normalize URI before filtering and returning them
+                # FIXME: Is this expected behavior? Does this make
+                # exclude patterns with slashes platform-dependent? Check
+                # how 'gitwildmatch' treats dots and slashes!
+                path = normpath(path)  # noqa: PLW2901
 
-            if self._exclude(path):
-                continue
+                if self._exclude(path):
+                    continue
 
-            if not exists(path):
-                logger.info("path: %s does not exist, skipping..", path)
-                continue
+                if not exists(path):
+                    logger.info("path: %s does not exist, skipping..", path)
+                    continue
 
-            if isfile(path):
-                name = self._mangle(path, hashes, prefix)
-                hashes[name] = self._hash(path)
+                if isfile(path):
+                    name = self._mangle(path, hashes, prefix)
+                    hashes[name] = self._hash(path)
 
-            if isdir(path):
-                for base, dirs, names in os.walk(
-                    path, followlinks=self._follow_symlink_dirs
-                ):
-                    # Filter directories to avoid unnecessary recursion below
-                    # NOTE: Normalize to filter on directory paths without
-                    # their dot-slash prefix, if path was dot.
-                    dirs[:] = [
-                        dirname
-                        for dirname in dirs
-                        if not self._exclude(normpath(join(base, dirname)))
-                    ]
+                if isdir(path):
+                    for base, dirs, names in os.walk(
+                        path, followlinks=self._follow_symlink_dirs
+                    ):
+                        # Filter directories to avoid unnecessary
+                        # recursion below
+                        # NOTE: Normalize to filter on directory paths without
+                        # their dot-slash prefix, if path was dot.
+                        dirs[:] = [
+                            dirname
+                            for dirname in dirs
+                            if not self._exclude(normpath(join(base, dirname)))
+                        ]
 
-                    for filename in names:
-                        # NOTE: Normalize to filter on and return file paths
-                        # without their dot-slash prefix, if path was dot.
-                        filepath = normpath(join(base, filename))
+                        for filename in names:
+                            # NOTE: Normalize to filter on and return file
+                            # paths without their dot-slash prefix, if path
+                            # was dot.
+                            filepath = normpath(join(base, filename))
 
-                        if self._exclude(filepath):
-                            continue
+                            if self._exclude(filepath):
+                                continue
 
-                        if not isfile(filepath):
-                            logger.info(
-                                "File '%s' appears to be a broken symlink. "
-                                "Skipping...",
-                                filepath,
-                            )
-                            continue
+                            if not isfile(filepath):
+                                logger.info(
+                                    "File '%s' appears to be a broken "
+                                    "symlink. Skipping...",
+                                    filepath,
+                                )
+                                continue
 
-                        name = self._mangle(filepath, hashes, prefix)
-                        hashes[name] = self._hash(filepath)
+                            name = self._mangle(filepath, hashes, prefix)
+                            hashes[name] = self._hash(filepath)
 
-        # Change back to original current working dir
-        if self._base_path:
-            os.chdir(original_cwd)
+        finally:
+            # Change back to original current working dir
+            if self._base_path:
+                os.chdir(original_cwd)
 
         return hashes
 
@@ -250,14 +255,16 @@ class OSTreeResolver(Resolver):
             original_cwd = os.getcwd()
             os.chdir(self._base_path)
 
-        for path in uris:
-            # Remove scheme prefix, but preserver to re-add later
-            path = self._strip_scheme_prefix(path)  # noqa: PLW2901
-            hashes[self._add_scheme_prefix(path)] = self._hash(path)
+        try:
+            for path in uris:
+                # Remove scheme prefix, but preserver to re-add later
+                path = self._strip_scheme_prefix(path)  # noqa: PLW2901
+                hashes[self._add_scheme_prefix(path)] = self._hash(path)
 
-        # Change back to original current working dir
-        if self._base_path:
-            os.chdir(original_cwd)
+        finally:
+            # Change back to original current working dir
+            if self._base_path:
+                os.chdir(original_cwd)
 
         return hashes
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -2,10 +2,12 @@
 
 import hashlib
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
+from in_toto.exceptions import PrefixError
 from in_toto.resolver import RESOLVER_FOR_URI_SCHEME, FileResolver, Resolver
 from in_toto.resolver._resolver import _hash_file
 from tests.common import TmpDirMixin
@@ -105,6 +107,29 @@ class TestFileResolver(TmpDirMixin, unittest.TestCase):
             resolver = FileResolver(**kwargs)
             result = resolver.hash_artifacts(uris)
             self.assertEqual(result.keys(), expected_keys)
+
+    def test_hash_artifacts_error_restores_cwd(self):
+        """Assert that the cwd is restored if hashing below base_path fails."""
+        base_path = tempfile.mkdtemp()
+        try:
+            for name in ["a", "b"]:
+                os.mkdir(os.path.join(base_path, name))
+                Path(base_path, name, "same-name").touch()
+
+            # Stripping the two prefixes makes both files collide on the same
+            # dictionary key, so hash_artifacts raises part-way through.
+            resolver = FileResolver(
+                base_path=base_path, lstrip_paths=["a/", "b/"]
+            )
+            original_cwd = os.getcwd()
+
+            with self.assertRaises(PrefixError):
+                resolver.hash_artifacts(["a", "b"])
+
+            self.assertEqual(os.getcwd(), original_cwd)
+
+        finally:
+            shutil.rmtree(base_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

`FileResolver.hash_artifacts` and `OSTreeResolver.hash_artifacts` chdir into
`base_path` and then chdir back on the last lines of the method. If anything
raises in between, the chdir back is skipped and the process is left sitting in
`base_path`.

A prefix collision is the easiest way to reach it, since `_mangle` raises
`PrefixError` part way through the loop:

```
>>> record_artifacts_as_dict(["a", "b"], base_path=tmp, lstrip_paths=["a/", "b/"])
in_toto.exceptions.PrefixError: Prefix selection has resulted in non unique dictionary key 'same'
>>> os.getcwd()
'/tmp/tmpabf81ddv'
```

For the command line tools this mostly does not matter, since the process is
about to exit anyway. It matters more for `runlib` used as a library: anything
the caller does with relative paths afterwards resolves against the wrong
directory, and a later `in_toto_run(..., record_environment=True)` in the same
process records the stale directory as `environment["workdir"]` in the link.

Both loops now sit in `try`/`finally` so the chdir back always runs. The rest of
the diff is just the reindent that came with it.

The added test fails on develop with the paths differing, and passes with the
change. `tests/runtests.py` is green (253 tests) and `coverage report -m
--fail-under 99` still passes.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
