### PR TITLE
resolver: Restore locale after hashing a directory

### DIFF
--- a/in_toto/resolver/_resolver.py
+++ b/in_toto/resolver/_resolver.py
@@ -334,8 +334,15 @@ class DirectoryResolver(Resolver):
         text_repr = ""
         keys = list(file_hashes.keys())
         if keys:
-            locale.setlocale(locale.LC_ALL, "C")
-            keys.sort(key=cmp_to_key(locale.strcoll))
+            # Sort under the C locale to match the documented shell
+            # equivalent, then put the caller's locale back: setlocale is
+            # process wide and in-toto is also used as a library.
+            previous_locale = locale.setlocale(locale.LC_ALL)
+            try:
+                locale.setlocale(locale.LC_ALL, "C")
+                keys.sort(key=cmp_to_key(locale.strcoll))
+            finally:
+                locale.setlocale(locale.LC_ALL, previous_locale)
 
             text_repr = "\n".join(
                 [f"{file_hashes[k][_HASH_ALGORITHM]}  {k}" for k in keys]

--- a/tests/test_directory_resolver.py
+++ b/tests/test_directory_resolver.py
@@ -3,6 +3,7 @@
 
 """Test cases for DirectoryResolver."""
 
+import locale
 import os
 import tempfile
 import unittest
@@ -35,6 +36,24 @@ class TestDirectoryResolver(unittest.TestCase):
 
         artifact_dict = resolver.hash_artifacts([uri])
         self.assertEqual(artifact_dict, expected_artifact_dict)
+
+    def test_hashing_preserves_locale(self):
+        """Hashing a directory must not leave the process locale changed."""
+        path = str(Path(__file__).parent / "resolver" / "dir_resolver")
+
+        original = locale.setlocale(locale.LC_ALL)
+        try:
+            try:
+                locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+            except locale.Error:
+                self.skipTest("en_US.UTF-8 not available on this system")
+
+            before = locale.setlocale(locale.LC_ALL)
+            DirectoryResolver().hash_artifacts([f"dir:{path}"])
+            self.assertEqual(locale.setlocale(locale.LC_ALL), before)
+
+        finally:
+            locale.setlocale(locale.LC_ALL, original)
 
     def test_regular_directory_with_lstrip(self):
         lstrip_path = (


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

`DirectoryResolver._hash` calls `locale.setlocale(locale.LC_ALL, "C")` to get the same
collation as the `LC_ALL=C sort` in the documented shell equivalent, but never puts the
previous locale back. `setlocale` is process wide, so hashing a directory permanently
resets the locale of whatever is calling in:

```
>>> locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
'en_US.UTF-8'
>>> record_artifacts_as_dict(["dir:payload"])
{'dir:payload': {'sha256': '...'}}
>>> locale.setlocale(locale.LC_ALL)
'C'
```

It is `LC_ALL`, so it is not only collation: a caller that had set a locale for number or
date formatting silently loses it too. For the CLIs this does not really matter, but
`runlib` is a library entry point.

Now saved and restored around the sort. The recorded hash is unchanged, which was the part
I most wanted to be sure of: for a directory containing `a.txt`, `B.txt`, `b.txt`, `café`,
`Ωmega`, `zz` and `_x` the digest is
`43b8084ca1f99bffc05c8791c154db1b5f731ecffaef8d3ab46e0edbb4c06466` both before and after
the change.

While checking that, plain `keys.sort()` turned out to give the same order as
`cmp_to_key(locale.strcoll)` under C for every name I tried, including the non-ASCII ones,
which makes sense since UTF-8 byte order matches code point order. Dropping the
`setlocale` dance entirely would be simpler and would also sidestep the fact that
`setlocale` is not thread safe. I did not do it here because it changes how the ordering is
derived and this value ends up in signed link metadata, so it felt like your call rather
than mine. Happy to switch if you prefer that.

The added test skips where `en_US.UTF-8` is not available, and restores whatever locale it
found on the way out. `tests/runtests.py` is green at 253 tests, `coverage report -m
--fail-under 99` passes, and ruff check and format are clean.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
