### PR TITLE
ci: read release metadata from env in the CD github-script steps

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -61,14 +59,17 @@ jobs:
       - id: gh-release
         name: Publish GitHub release draft
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_NAME: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.ref }}
         with:
           script: |
             fs = require('fs')
             res = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: '${{ github.ref_name }}-rc',
-              tag_name: '${{ github.ref }}',
+              name: process.env.RELEASE_NAME + '-rc',
+              tag_name: process.env.RELEASE_TAG,
               body: 'Release waiting for review...',
             });
 
@@ -105,14 +106,17 @@ jobs:
 
       - name: Finalize GitHub release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_ID: ${{ needs.candidate_release.outputs.release_id }}
+          RELEASE_NAME: ${{ github.ref_name }}
         with:
           script: |
             github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: '${{ needs.candidate_release.outputs.release_id }}',
-              name: '${{ github.ref_name }}',
+              release_id: process.env.RELEASE_ID,
+              name: process.env.RELEASE_NAME,
               body: 'See [CHANGELOG.md](https://github.com/' +
                      context.repo.owner + '/' + context.repo.repo +
-                    '/blob/${{ github.ref_name }}/CHANGELOG.md) for details.'
+                    '/blob/' + process.env.RELEASE_NAME + '/CHANGELOG.md) for details.'
             })


### PR DESCRIPTION
### What

`.github/workflows/cd.yml` interpolates release metadata directly into two `actions/github-script` bodies:

```js
name: '${{ github.ref_name }}-rc',
tag_name: '${{ github.ref }}',
```

and in the finalize step:

```js
name: '${{ github.ref_name }}',
body: '... /blob/${{ github.ref_name }}/CHANGELOG.md ...'
```

The `script:` block is JavaScript source, and `${{ ... }}` is substituted **as text before the script is parsed** — it is not a runtime variable. Git allows a single quote in a tag name (`git check-ref-format` rejects space, `~`, `^`, `:`, `?`, `*`, `[`, `\`, but not `'`), so a tag can close the string literal and have the remainder evaluated as code.

### Why it matters in this file

The finalize step runs in the `release` job, which holds:

```yaml
permissions:
  contents: write
  id-token: write   # Trusted Publisher to pypi.org
```

Code execution in that step is adjacent to the OIDC identity used for PyPI Trusted Publishing.

**On severity — deliberately not overstating it:** the only trigger is `push: tags: [v*]`, so creating a tag requires push access to this repository. This is **defense in depth, not an externally reachable vulnerability.** The reason I think it is still worth fixing here is that it removes a path from "can push a tag" to "can act with the release identity" — the exact insider/compromised-account step that in-toto's own threat model is about.

### The fix

Pass the values through `env:` and read them with `process.env`. An environment variable is only ever data, never source text. Behaviour is unchanged; `release_id` was already a string in the previous code and remains one.

### Second, smaller thing

The build job's checkout carried:

```yaml
with:
  ref: ${{ github.event.workflow_run.head_branch }}
```

`github.event.workflow_run` only exists on a `workflow_run` event, and this workflow triggers solely on `push: tags`. The expression was therefore always empty, and the checkout landed on the right commit only because `actions/checkout` falls back to the triggering ref when `ref` is empty. I removed the line so the default is explicit rather than accidental — happy to make it `ref: ${{ github.ref }}` instead if you prefer it spelled out, and equally happy to split this into its own PR.

### Verification

The workflow parses cleanly and no `${{ }}` expansion remains inside any `script:` body — every value now reaches the script through `env`.

### AI assistance

I used an AI coding agent to sweep release workflows for this pattern and to draft this description. The things I checked myself rather than accepted from a model:

- that `git check-ref-format` rejects space, `~`, `^`, `:`, `?`, `*`, `[` and `\` in a tag name but **does** permit a single quote, which is the whole premise of the string-literal break above;
- that `${{ }}` inside a `script:` body is textual substitution before the JavaScript is parsed, not a runtime binding;
- that `github.event.workflow_run` is always empty under `push: tags`, and that `actions/checkout` falls back to the triggering ref when `ref:` is empty — which is why the dead line never broke anything.

The severity framing is mine. I would rather understate it than have you find I overstated it.
